### PR TITLE
fix: validate BACKEND_URL before using it

### DIFF
--- a/apps/web/src/app/api/transcribe/route.ts
+++ b/apps/web/src/app/api/transcribe/route.ts
@@ -14,7 +14,10 @@ function getGemini() {
   return _gemini;
 }
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+// Backend URL with validation - skip if not a valid URL
+const rawBackendUrl = process.env.BACKEND_URL || '';
+const BACKEND_URL = rawBackendUrl.startsWith('http') ? rawBackendUrl : 'http://localhost:8000';
+const BACKEND_AVAILABLE = rawBackendUrl.startsWith('http');
 
 /**
  * POST /api/transcribe
@@ -37,7 +40,7 @@ export async function POST(request: Request) {
     }
 
     // Strategy 1: Try YouTube transcript API via backend (fast + free)
-    if (url && !audioUrl) {
+    if (url && !audioUrl && BACKEND_AVAILABLE) {
       try {
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 8_000);

--- a/apps/web/src/app/api/video/route.ts
+++ b/apps/web/src/app/api/video/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server';
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+// Backend URL with validation - skip if not a valid URL
+const rawBackendUrl = process.env.BACKEND_URL || '';
+const BACKEND_URL = rawBackendUrl.startsWith('http') ? rawBackendUrl : 'http://localhost:8000';
+const BACKEND_AVAILABLE = rawBackendUrl.startsWith('http');
 
 /**
  * POST /api/video
@@ -19,12 +22,13 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Video URL is required' }, { status: 400 });
     }
 
-    // ── Strategy 1: Full backend pipeline ──
-    try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 15_000);
+    // ── Strategy 1: Full backend pipeline (skip if no backend configured) ──
+    if (BACKEND_AVAILABLE) {
+      try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 15_000);
 
-      const response = await fetch(`${BACKEND_URL}/api/v1/transcript-action`, {
+        const response = await fetch(`${BACKEND_URL}/api/v1/transcript-action`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ video_url: url, language: 'en' }),
@@ -82,9 +86,10 @@ export async function POST(request: Request) {
           },
         });
       }
-      console.warn(`Backend returned ${response.status}, falling back to frontend-only pipeline`);
-    } catch {
-      console.log('Backend unavailable — using frontend-only pipeline');
+        console.warn(`Backend returned ${response.status}, falling back to frontend-only pipeline`);
+      } catch {
+        console.log('Backend unavailable — using frontend-only pipeline');
+      }
     }
 
     // ── Strategy 2: Frontend-only pipeline ──
@@ -165,29 +170,35 @@ export async function POST(request: Request) {
 }
 
 export async function GET() {
-  try {
-    const response = await fetch(`${BACKEND_URL}/api/v1/health`);
-    const health = await response.json();
+  // If backend URL is configured and valid, check its health
+  if (BACKEND_AVAILABLE) {
+    try {
+      const response = await fetch(`${BACKEND_URL}/api/v1/health`);
+      const health = await response.json();
 
-    return NextResponse.json({
-      name: 'UVAI Video Analysis API',
-      version: '2.0.0',
-      backend_status: health.status,
-      backend_components: health.components,
-      endpoints: {
-        analyze: 'POST /api/video - Analyze a video URL',
-        health: 'GET /api/video - Check API status',
-      },
-    });
-  } catch {
-    return NextResponse.json({
-      name: 'UVAI Video Analysis API',
-      version: '2.0.0',
-      backend_status: 'unavailable',
-      frontend_pipeline: 'active',
-      endpoints: {
-        analyze: 'POST /api/video - Analyze a video URL',
-      },
-    });
+      return NextResponse.json({
+        name: 'UVAI Video Analysis API',
+        version: '2.0.0',
+        backend_status: health.status,
+        backend_components: health.components,
+        endpoints: {
+          analyze: 'POST /api/video - Analyze a video URL',
+          health: 'GET /api/video - Check API status',
+        },
+      });
+    } catch {
+      // Backend configured but unreachable
+    }
   }
+
+  // Frontend-only mode
+  return NextResponse.json({
+    name: 'UVAI Video Analysis API',
+    version: '2.0.0',
+    backend_status: 'not-configured',
+    frontend_pipeline: 'active',
+    endpoints: {
+      analyze: 'POST /api/video - Analyze a video URL',
+    },
+  });
 }


### PR DESCRIPTION
Skip backend calls entirely when BACKEND_URL is not configured or contains an invalid value (like a literal ${...} template string). This prevents URL parse errors on Vercel where the env var may not be set.

https://claude.ai/code/session_015Pd3a6hinTenCNrPRGiZqE