### PR TITLE
feat: BuildPlan schema (Stage 2) + OpenAPI generator (Stainless prep)

### DIFF
--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Generate OpenAPI spec from EventRelay's FastAPI backend.
+
+FastAPI auto-generates OpenAPI schemas. This script extracts it
+and saves it for Stainless SDK generation.
+
+Usage:
+    python scripts/generate_openapi.py > openapi.json
+
+Then feed openapi.json to Stainless:
+    npx stainless init --input openapi.json
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# Add project root
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+def main():
+    """Extract OpenAPI spec from the FastAPI app."""
+    try:
+        # Import the FastAPI app
+        from youtube_extension.backend.api import app
+        
+        # FastAPI provides .openapi() method
+        openapi_schema = app.openapi()
+        
+        # Add Stainless-compatible extensions
+        openapi_schema["info"]["x-stainless-config"] = {
+            "package-name": {
+                "python": "uvai",
+                "typescript": "@uvai/sdk"
+            },
+            "api-url": "https://api.uvai.io",
+            "topics": {
+                "videos": "Video processing and analysis",
+                "projects": "Code generation and deployment",
+                "agents": "AI agent orchestration"
+            }
+        }
+        
+        print(json.dumps(openapi_schema, indent=2))
+        
+    except ImportError as e:
+        print(f"Error: Could not import FastAPI app: {e}", file=sys.stderr)
+        print("Make sure you're running from the EventRelay root with dependencies installed.", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/src/youtube_extension/backend/models/build_plan.py
+++ b/src/youtube_extension/backend/models/build_plan.py
@@ -1,0 +1,74 @@
+"""
+BuildPlan — Structured instruction extraction for Stage 2 parsing.
+
+Replaces loose text extraction with a deterministic, structured output
+that Stage 3 (code generation) can consume directly.
+
+Usage:
+    from youtube_extension.backend.models.build_plan import BuildPlan, BuildStep
+
+    # Gemini returns JSON matching this schema
+    plan = BuildPlan.model_validate(gemini_response)
+    for step in plan.steps:
+        print(f"{step.action} → {step.target_file}")
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class StepAction(str, Enum):
+    """Action types a build step can perform."""
+    CREATE_FILE = "create_file"
+    MODIFY_FILE = "modify_file"
+    INSTALL_DEPENDENCY = "install_dependency"
+    RUN_COMMAND = "run_command"
+    CONFIGURE = "configure"
+    DEPLOY = "deploy"
+
+
+class BuildStep(BaseModel):
+    """A single, atomic build step extracted from video analysis."""
+
+    order: int = Field(..., description="1-based step order")
+    action: StepAction = Field(..., description="What this step does")
+    description: str = Field(..., description="Human-readable description of what happens")
+    target_file: Optional[str] = Field(None, description="File path this step creates/modifies")
+    code_content: Optional[str] = Field(None, description="Code snippet shown in the video (if visible)")
+    dependencies: list[str] = Field(default_factory=list, description="Packages/tools this step requires")
+    prerequisites: list[int] = Field(default_factory=list, description="Step order numbers that must complete first")
+
+
+class BuildPlan(BaseModel):
+    """
+    Structured build plan extracted from video analysis (Stage 2 output).
+
+    This is the contract between Stage 2 (parsing) and Stage 3 (code generation).
+    Gemini's structured output mode should return JSON matching this schema.
+    """
+
+    video_id: str = Field(..., description="YouTube video ID")
+    video_title: str = Field(..., description="Video title")
+    project_type: str = Field(default="web", description="web | api | mobile | cli")
+    framework: Optional[str] = Field(None, description="Primary framework (react, vue, fastapi, etc.)")
+    technologies: list[str] = Field(default_factory=list, description="All technologies mentioned")
+    steps: list[BuildStep] = Field(default_factory=list, description="Ordered build steps")
+    summary: str = Field(default="", description="One-paragraph summary of what the video teaches")
+
+    @property
+    def file_steps(self) -> list[BuildStep]:
+        """Steps that create or modify files."""
+        return [s for s in self.steps if s.action in (StepAction.CREATE_FILE, StepAction.MODIFY_FILE)]
+
+    @property
+    def dependency_steps(self) -> list[BuildStep]:
+        """Steps that install dependencies."""
+        return [s for s in self.steps if s.action == StepAction.INSTALL_DEPENDENCY]
+
+    def gemini_schema(self) -> dict:
+        """Return the JSON Schema dict for Gemini structured output."""
+        return self.model_json_schema()


### PR DESCRIPTION
Part of #81 and #85

### BuildPlan Schema (`src/youtube_extension/backend/models/build_plan.py`)
Structured output schema for Stage 2 parsing. Defines the contract between video analysis and code generation:

```python
class BuildStep(BaseModel):
    order: int           # 1-based step order
    action: StepAction   # create_file, modify_file, install_dependency, ...
    target_file: str     # e.g., 'src/App.js'
    code_content: str    # Code snippet from the video
    dependencies: list   # Required packages
    prerequisites: list  # Steps that must complete first

class BuildPlan(BaseModel):
    video_id: str
    video_title: str
    project_type: str    # web, api, mobile, cli
    framework: str       # react, vue, fastapi, etc.
    steps: list[BuildStep]
```

### OpenAPI Generator (`scripts/generate_openapi.py`)
Extracts FastAPI's auto-generated OpenAPI spec with Stainless-compatible extensions for SDK generation.

### What's Next
- Wire BuildPlan into Gemini's structured output mode (`response_mime_type='application/json'`)
- Update code_generator to consume BuildPlan steps sequentially
- Generate Python (`uvai`) and TypeScript (`@uvai/sdk`) clients via Stainless