### PR TITLE
Fix dependency review workflow and update .gitignore

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,26 +21,4 @@ jobs:
         with:
           fail-on-severity: moderate
           allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, Python-2.0
-          deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0
           comment-summary-in-pr: always
-          comment-summary-in-pr-title: "Dependency Review Summary"
-          comment-summary-in-pr-body: |
-            ## 📦 Dependency Review Results
-            
-            **Summary**: {{ summary }}
-            
-            **Vulnerabilities**: {{ vulnerabilities }}
-            **Licenses**: {{ licenses }}
-            **Dependencies**: {{ dependencies }}
-            
-            {% if vulnerabilities > 0 %}
-            ⚠️ **Security vulnerabilities detected!** Please review and update dependencies.
-            {% endif %}
-            
-            {% if licenses > 0 %}
-            ⚠️ **License issues detected!** Please review license compatibility.
-            {% endif %}
-            
-            {% if vulnerabilities == 0 and licenses == 0 %}
-            ✅ **All dependencies are secure and properly licensed!**
-            {% endif %}

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ notebooklm_chrome_profile/
 src/utils/notebooklm_profile/
 src/utils/notebooklm_profile_v2/
 .gstack/
+
+# Claude agent worktrees (auto-generated, never commit)
+.claude/worktrees/


### PR DESCRIPTION
This pull request makes a minor update to the dependency review workflow configuration. The main change is the removal of custom PR comment summary fields and license denial settings.

Workflow configuration updates:

* Removed the `deny-licenses` field and custom PR comment summary options (`comment-summary-in-pr-title` and `comment-summary-in-pr-body`) from the dependency review workflow in `.github/workflows/dependency-review.yml`.

Other changes:

* Removed a subproject commit reference from `.claude/worktrees/beautiful-margulis`.