### PR TITLE
fix: update hero overline to 'Video Intelligence Engine'

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -202,7 +202,7 @@ export default function Home() {
           <div className="max-w-[1200px] mx-auto grid lg:grid-cols-2 gap-12 items-start">
             <div>
               <p className="text-xs tracking-[0.3em] uppercase mb-5" style={{ color: TEAL }}>
-                Agentic video execution platform
+                Video Intelligence Engine
               </p>
               <h1
                 className="font-heading text-4xl md:text-6xl font-bold tracking-tighter mb-6 leading-[1.05]"


### PR DESCRIPTION
## Summary

Updates the hero section overline from `"Agentic video execution platform"` to **"Video Intelligence Engine"**.

### Change
- `apps/web/src/app/page.tsx` — hero overline `<p>` text updated

### Why
"Video Intelligence Engine" is more precise, more memorable, and directly names what the system does: it turns video into structured intelligence. The previous label was accurate but generic and lacked the sharpness of the product's actual identity.

---
*Co-authored-by: v0[bot] <v0[bot]@users.noreply.github.com>*