### PR TITLE
feat: update hero messaging to video-to-action positioning

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -10,11 +10,11 @@ import './globals.css';
 
 export const metadata: Metadata = {
   title: {
-    default: 'UVAI — Video to Structured Intelligence',
+    default: 'UVAI — The Action Layer for Video',
     template: '%s | UVAI',
   },
-  description: 'UVAI turns YouTube videos into transcripts, typed events, action items, and AI-driven analysis using Gemini and OpenAI. Open source via the EventRelay project.',
-  keywords: ['UVAI', 'video intelligence', 'YouTube transcript', 'structured events', 'Gemini', 'OpenAI', 'EventRelay', 'agentic video'],
+  description: 'UVAI takes what is inside a YouTube video and builds from it — transcripts, typed events, action items, and agentic execution powered by Gemini and OpenAI. Open source via EventRelay.',
+  keywords: ['UVAI', 'video to action', 'YouTube build', 'video intelligence', 'structured events', 'Gemini', 'OpenAI', 'EventRelay', 'agentic video execution'],
   authors: [{ name: 'UVAI' }],
   creator: 'UVAI',
   publisher: 'UVAI',
@@ -24,21 +24,21 @@ export const metadata: Metadata = {
     locale: 'en_US',
     url: 'https://v0-uvai.vercel.app',
     siteName: 'UVAI',
-    title: 'UVAI — Video to Structured Intelligence',
-    description: 'Paste a YouTube URL. Get transcripts, typed events, action items, and multi-agent analysis from an open-source video intelligence platform.',
+    title: 'UVAI — The Action Layer for Video',
+    description: 'Paste a YouTube URL. UVAI takes what is inside the video and builds from it — transcripts, typed events, action items, and agentic execution.',
     images: [
       {
         url: '/og-image.png',
         width: 1200,
         height: 630,
-        alt: 'UVAI — Agentic Video Execution Platform',
+        alt: 'UVAI — The Action Layer for Video',
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'UVAI — Video to Structured Intelligence',
-    description: 'Paste a YouTube URL. Get transcripts, typed events, action items, and multi-agent analysis from an open-source video intelligence platform.',
+    title: 'UVAI — The Action Layer for Video',
+    description: 'Paste a YouTube URL. UVAI takes what is inside the video and builds from it — transcripts, typed events, action items, and agentic execution.',
     images: ['/og-image.png'],
     creator: '@groupthinking',
   },

--- a/apps/web/src/components/landing/HeroSection.tsx
+++ b/apps/web/src/components/landing/HeroSection.tsx
@@ -85,13 +85,13 @@ export default function HeroSection() {
               style={{ background: '#6af2de' }}
               aria-hidden
             />
-            Agentic video execution platform
+            The action layer for video
           </span>
         </div>
 
         {/* Hero headline — display scale */}
         <h1 className="font-heading text-center text-[clamp(3rem,8vw,8rem)] font-black leading-[0.9] tracking-tighter mb-8 text-ink">
-          Turn video into{' '}
+          Paste a video.{' '}
           <span
             style={{
               WebkitBackgroundClip: 'text',
@@ -99,14 +99,14 @@ export default function HeroSection() {
               backgroundImage: 'linear-gradient(135deg, #6af2de 0%, #38fbf7 50%, #14b8a6 100%)',
             }}
           >
-            intelligence.
+            Build from it.
           </span>
         </h1>
 
         {/* Sub-headline */}
         <p className="text-center text-[clamp(1rem,2vw,1.25rem)] leading-relaxed max-w-2xl mx-auto mb-12 text-ink/55">
-          Paste a YouTube URL. UVAI returns a verbatim transcript, typed events, action items,
-          and multi-agent analysis — powered by Gemini and OpenAI.
+          Paste a YouTube URL. UVAI takes what is inside the video — transcript, typed events, action items,
+          and AI-driven execution — and builds from it. YouTube tells you what&apos;s there. UVAI acts on it.
         </p>
 
         {/* CTAs */}


### PR DESCRIPTION
## Toolbar note changes — /page hero messaging

Targeted, minimal edits to `HeroSection.tsx` and `layout.tsx` to apply the 3 unresolved toolbar notes.

### Changes

**`apps/web/src/components/landing/HeroSection.tsx`**
- Eyebrow: `Agentic video execution platform` → `The action layer for video`
- H1: `Turn video into intelligence.` → `Paste a video. Build from it.`
- Sub-headline: rewritten to make the action/execution positioning explicit — "YouTube tells you what's there. UVAI acts on it."

**`apps/web/src/app/layout.tsx`**
- Page title: `UVAI — Video to Structured Intelligence` → `UVAI — The Action Layer for Video`
- OG/Twitter title and description updated to match

### Toolbar threads addressed
- `MhPCqou9KnZw` — producer.ai reference, app-like positioning
- `FKkdzKPzXD36` — WWDC Foundation Models links + image note: UVAI fills the gap YouTube native doesn't (action/execution)
- `2qpZ7PrcO1cm` — Google Doc strategy copy for H1