### PR TITLE
feat(web): add privacy/terms/api-docs/app/login routes; noindex prototype

### DIFF
--- a/apps/web/src/app/api/docs/page.tsx
+++ b/apps/web/src/app/api/docs/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Nav from '@/components/Nav';
+import Footer from '@/components/Footer';
+
+export const metadata: Metadata = {
+  title: 'API Reference',
+  description:
+    'HTTP reference for the UVAI / EventRelay public API: transcription, event extraction, agent pipelines, and video metadata.',
+  alternates: { canonical: '/api/docs' },
+  robots: { index: true, follow: true },
+};
+
+type Endpoint = {
+  method: 'GET' | 'POST';
+  path: string;
+  summary: string;
+  body?: string;
+};
+
+const ENDPOINTS: Endpoint[] = [
+  { method: 'GET', path: '/api', summary: 'Service descriptor (name, version, status).' },
+  { method: 'POST', path: '/api/transcribe', summary: 'Fetch a transcript for a YouTube URL.', body: '{ "url": "https://youtu.be/..." }' },
+  { method: 'POST', path: '/api/extract-events', summary: 'Extract typed events from a transcript.' },
+  { method: 'GET', path: '/api/pipeline', summary: 'Inspect available pipeline stages.' },
+  { method: 'POST', path: '/api/pipeline', summary: 'Run the full intake → events → agents pipeline.' },
+  { method: 'POST', path: '/api/pipeline/stream', summary: 'Streaming variant of /api/pipeline (SSE).' },
+  { method: 'POST', path: '/api/chat', summary: 'Conversational query over an analyzed video.' },
+  { method: 'GET', path: '/api/video', summary: 'List recently analyzed videos.' },
+  { method: 'POST', path: '/api/video', summary: 'Register a new video for analysis.' },
+  { method: 'GET', path: '/api/video/search', summary: 'Semantic search across stored videos.' },
+  { method: 'GET', path: '/api/dashboard', summary: 'Dashboard aggregates and recent runs.' },
+  { method: 'POST', path: '/api/dashboard', summary: 'Mutate dashboard state (pin, archive, etc.).' },
+  { method: 'GET', path: '/api/training/status', summary: 'Current status of training/embedding jobs.' },
+  { method: 'POST', path: '/api/training/trigger', summary: 'Trigger a training/embedding job.' },
+];
+
+const METHOD_COLOR: Record<Endpoint['method'], string> = {
+  GET: 'bg-teal-500/10 border-teal-500/30 text-teal-300',
+  POST: 'bg-amber-500/10 border-amber-500/30 text-amber-300',
+};
+
+export default function ApiDocsPage() {
+  return (
+    <div className="min-h-screen bg-void text-ink">
+      <Nav />
+      <main className="mx-auto max-w-4xl px-6 py-20">
+        <header className="mb-12">
+          <p className="text-xs uppercase tracking-[0.2em] text-ink/40">Reference</p>
+          <h1 className="mt-2 font-heading text-4xl font-black">API Reference</h1>
+          <p className="mt-3 max-w-2xl text-ink/60">
+            UVAI exposes a small, REST-style surface for transcription, event
+            extraction, pipeline execution, and search. All endpoints accept
+            and return JSON unless noted. Streaming endpoints use Server-Sent
+            Events.
+          </p>
+        </header>
+
+        <section className="mb-10 rounded-xl border border-white/5 bg-white/[0.02] p-6">
+          <h2 className="font-heading text-lg font-bold text-ink">Base URL</h2>
+          <code className="mt-2 block text-sm text-teal-300">https://uvai.io</code>
+          <p className="mt-3 text-sm text-ink/60">
+            Want to run it yourself? UVAI is MIT-licensed.{' '}
+            <a
+              href="https://github.com/groupthinking/EventRelay"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-teal-400 hover:underline"
+            >
+              See the EventRelay repo
+            </a>{' '}
+            for self-hosting.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="font-heading text-2xl font-bold text-ink">Endpoints</h2>
+          <ul className="divide-y divide-white/5 rounded-xl border border-white/5">
+            {ENDPOINTS.map((e) => (
+              <li key={`${e.method}-${e.path}`} className="flex flex-col gap-2 p-4 sm:flex-row sm:items-start sm:gap-4">
+                <span
+                  className={`inline-flex h-6 shrink-0 items-center justify-center rounded-md border px-2 font-mono text-xs font-bold ${METHOD_COLOR[e.method]}`}
+                >
+                  {e.method}
+                </span>
+                <div className="flex-1">
+                  <code className="font-mono text-sm text-ink">{e.path}</code>
+                  <p className="mt-1 text-sm text-ink/60">{e.summary}</p>
+                  {e.body ? (
+                    <pre className="mt-2 overflow-x-auto rounded-md border border-white/5 bg-black/40 p-3 text-xs text-ink/70">
+                      <code>{e.body}</code>
+                    </pre>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="mt-12">
+          <h2 className="font-heading text-2xl font-bold text-ink">Try it</h2>
+          <p className="mt-2 text-ink/60">
+            The{' '}
+            <Link href="/playground" className="text-teal-400 hover:underline">
+              playground
+            </Link>{' '}
+            exercises these endpoints end-to-end against a real YouTube URL.
+          </p>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/src/app/app/page.tsx
+++ b/apps/web/src/app/app/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+
+export const metadata: Metadata = {
+  title: 'App',
+  description: 'Redirect to the UVAI dashboard.',
+  alternates: { canonical: '/dashboard' },
+  robots: { index: false, follow: true },
+};
+
+export default function AppRedirect() {
+  redirect('/dashboard');
+}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+
+export const metadata: Metadata = {
+  title: 'Sign in',
+  description:
+    'UVAI is currently open for use without an account — you go straight to the dashboard.',
+  alternates: { canonical: '/dashboard' },
+  robots: { index: false, follow: true },
+};
+
+export default function LoginRedirect() {
+  redirect('/dashboard');
+}

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Nav from '@/components/Nav';
+import Footer from '@/components/Footer';
+import { CONTACT_EMAIL } from '@/lib/constants';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy',
+  description:
+    'How UVAI (EventRelay) collects, processes, and protects data when you analyze YouTube videos and use our AI pipelines.',
+  alternates: { canonical: '/privacy' },
+  robots: { index: true, follow: true },
+};
+
+const LAST_UPDATED = 'May 25, 2026';
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-void text-ink">
+      <Nav />
+      <main className="mx-auto max-w-3xl px-6 py-20">
+        <header className="mb-12">
+          <p className="text-xs uppercase tracking-[0.2em] text-ink/40">Legal</p>
+          <h1 className="mt-2 font-heading text-4xl font-black">Privacy Policy</h1>
+          <p className="mt-3 text-sm text-ink/50">Last updated: {LAST_UPDATED}</p>
+        </header>
+
+        <div className="prose prose-invert space-y-8 text-ink/80">
+          <section>
+            <p>
+              UVAI is an open-source video intelligence product operated by the
+              EventRelay project. This page describes, in plain language, what
+              data we touch when you use the hosted UVAI product. It is not
+              legal advice, and it will be replaced with a formal policy before
+              we collect data from organizations under contract.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-2xl font-bold text-ink">What we process</h2>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>
+                <strong>YouTube URLs you submit.</strong> We resolve metadata
+                and transcripts via the public YouTube APIs and our
+                transcription pipeline.
+              </li>
+              <li>
+                <strong>Derived artifacts.</strong> Transcripts, extracted
+                events, embeddings, and agent traces produced while running
+                your request.
+              </li>
+              <li>
+                <strong>Operational telemetry.</strong> Anonymous performance
+                and error data via Vercel Analytics and Speed Insights. We do
+                not sell this data.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-2xl font-bold text-ink">What we do not do</h2>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>We do not sell personal data.</li>
+              <li>We do not train foundation models on your inputs.</li>
+              <li>
+                We do not store credentials for third-party services in our
+                browser bundles.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-2xl font-bold text-ink">Third-party processors</h2>
+            <p>
+              UVAI routes inference through Gemini, OpenAI, Anthropic, or Grok
+              depending on the task. Your input may be transmitted to one of
+              these providers under their respective terms. Hosting is on
+              Vercel.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-2xl font-bold text-ink">Your rights</h2>
+            <p>
+              You can request deletion of artifacts associated with your
+              account by emailing{' '}
+              <a className="text-teal-400 hover:underline" href={`mailto:${CONTACT_EMAIL}`}>
+                {CONTACT_EMAIL}
+              </a>
+              . Because UVAI is open source under MIT, you can also self-host
+              and retain full control.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-2xl font-bold text-ink">Contact</h2>
+            <p>
+              Questions about this policy:{' '}
+              <a className="text-teal-400 hover:underline" href={`mailto:${CONTACT_EMAIL}`}>
+                {CONTACT_EMAIL}
+              </a>
+              . See also our{' '}
+              <Link className="text-teal-400 hover:underline" href="/terms">
+                Terms of Service
+              </Link>
+              .
+            </p>
+          </section>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/src/app/prototype/layout.tsx
+++ b/apps/web/src/app/prototype/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Prototype spec',
+  description:
+    'Internal prototype spec for the UVAI build flow. Not indexed.',
+  robots: { index: false, follow: false, nocache: true },
+};
+
+export default function PrototypeLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -1,0 +1,100 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Nav from '@/components/Nav';
+import Footer from '@/components/Footer';
+import { CONTACT_EMAIL } from '@/lib/constants';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service',
+  description:
+    'Terms governing use of the UVAI hosted product. EventRelay is MIT-licensed and may be self-hosted at any time.',
+  alternates: { canonical: '/terms' },
+  robots: { index: true, follow: true },
+};
+
+const LAST_UPDATED = 'May 25, 2026';
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-void text-ink">
+      <Nav />
+      <main className="mx-auto max-w-3xl px-6 py-20">
+        <header className="mb-12">
+          <p className="text-xs uppercase tracking-[0.2em] text-ink/40">Legal</p>
+          <h1 className="mt-2 font-heading text-4xl font-black">Terms of Service</h1>
+          <p className="mt-3 text-sm text-ink/50">Last updated: {LAST_UPDATED}</p>
+        </header>
+
+        <div className="prose prose-invert space-y-8 text-ink/80">
+          <section>
+            <p>
+              By using the hosted UVAI product you agree to these terms. The
+              underlying EventRelay code is open source under the MIT license;
+              these terms apply specifically to the hosted product served from
+              this domain.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-2xl font-bold text-ink">Acceptable use</h2>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>Only submit YouTube content you have the right to analyze.</li>
+              <li>
+                Do not attempt to exfiltrate the model, abuse the platform with
+                automated scraping, or use UVAI to generate content that
+                violates applicable law.
+              </li>
+              <li>
+                Do not use UVAI to make consequential decisions about
+                individuals without human review.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-2xl font-bold text-ink">No warranty</h2>
+            <p>
+              UVAI is provided &ldquo;as is&rdquo; without warranty of any
+              kind. AI outputs may be incorrect, incomplete, or biased — treat
+              them as drafts requiring review. We are not liable for
+              decisions made on the basis of automated output.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-2xl font-bold text-ink">Your content</h2>
+            <p>
+              You retain ownership of any content you submit. By submitting,
+              you grant UVAI a limited license to process that content solely
+              for the purpose of fulfilling your request.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-2xl font-bold text-ink">Changes</h2>
+            <p>
+              These terms may evolve as the product matures. Material changes
+              will be flagged on this page with an updated revision date.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-2xl font-bold text-ink">Contact</h2>
+            <p>
+              Questions:{' '}
+              <a className="text-teal-400 hover:underline" href={`mailto:${CONTACT_EMAIL}`}>
+                {CONTACT_EMAIL}
+              </a>
+              . See also our{' '}
+              <Link className="text-teal-400 hover:underline" href="/privacy">
+                Privacy Policy
+              </Link>
+              .
+            </p>
+          </section>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/src/components/landing/LandingFooter.tsx
+++ b/apps/web/src/components/landing/LandingFooter.tsx
@@ -52,6 +52,12 @@ export default function LandingFooter() {
           >
             Contact
           </a>
+          <Link href="/privacy" className="text-sm text-ink/35 hover:text-ink/70 transition-colors">
+            Privacy
+          </Link>
+          <Link href="/terms" className="text-sm text-ink/35 hover:text-ink/70 transition-colors">
+            Terms
+          </Link>
         </nav>
 
         <p className="text-xs text-ink/20">© 2026 UVAI. MIT licensed.</p>


### PR DESCRIPTION
## Summary

Second, scoped, low-risk PR for the route-coverage gaps that **PR #202** does not address. PR #202 covers assets, robots, sitemap, canonical, JSON-LD, and a11y; this PR closes the remaining 404s on the public surface.

Verified gaps on `uvai.io` (live monitor):
- `/privacy`, `/terms` — 404
- `/api/docs` — 404 (and `/api` JSON points to it)
- `/app`, `/login` — 404 (no auth gate exists today)
- `/prototype` — 200 but is an internal spec; should be `noindex`

## Changes

| Path | Type | Notes |
| --- | --- | --- |
| `apps/web/src/app/privacy/page.tsx` | new | Startup-friendly placeholder legal copy + metadata + canonical |
| `apps/web/src/app/terms/page.tsx` | new | Same shape as `/privacy` |
| `apps/web/src/app/api/docs/page.tsx` | new | Human-readable reference for the 14 real `/api/*` routes; resolves the `documentation` link in the `/api` JSON descriptor |
| `apps/web/src/app/app/page.tsx` | new | Server redirect → `/dashboard`, `robots: noindex` |
| `apps/web/src/app/login/page.tsx` | new | Server redirect → `/dashboard`, `robots: noindex` (no auth gate today) |
| `apps/web/src/app/prototype/layout.tsx` | new | Adds `robots: { index: false, follow: false }` to the existing client page without touching it |
| `apps/web/src/components/landing/LandingFooter.tsx` | mod | Adds Privacy + Terms links now that the pages exist |

## Architecture delta

- No backend / Python changes. Frontend-only.
- Branch is based on `main` (not stacked on PR #202). The two PRs do not touch the same files; PR #202's `sitemap.ts` will need a follow-up to include the new public routes (`/privacy`, `/terms`, `/api/docs`) — flagged here intentionally rather than duplicating PR #202's diff.
- No `CHANGELOG.md` entry: that file is introduced by PR #202 and does not yet exist on `main`. Once PR #202 lands, this can be amended or noted in a follow-up.

## Scope discipline

Deliberately not in scope:
- Backend API repairs (`/api` runtime errors, etc.) — out of scope, separate effort.
- Auth implementation — no auth system exists today; redirects match real product behavior.
- Replacing PR #202's assets/sitemap/robots/JSON-LD work.

## Testing

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on the changed files — clean
- [x] `npx next build` — succeeds; 25 routes registered including the 6 new ones (`/privacy`, `/terms`, `/api/docs`, `/app`, `/login`, plus `/prototype` now noindexed)
- [ ] Live E2E deferred — preview environment will exercise routes; no production deploy touched in this PR

## Risk

Low. New routes are additive; the only modification to existing code is two `<Link>` entries in `LandingFooter`. Redirects use Next's server `redirect()`, so they're 307s without client hydration cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)