### PR TITLE
fix(security): SECRET_KEY, CORS wildcard, SQL injection, command injection (#193 #195 #196 #197 #200)

### DIFF
--- a/src/youtube_extension/backend/code_generator.py
+++ b/src/youtube_extension/backend/code_generator.py
@@ -1006,12 +1006,14 @@ body {{
 
         if "authentication" in features:
             auth_imports = '''
+import os
+import secrets
 from datetime import datetime, timedelta
 from jose import JWTError, jwt
 from passlib.context import CryptContext'''
             auth_code = '''
 # Authentication setup
-SECRET_KEY = "your-secret-key-here"
+SECRET_KEY = os.getenv("SECRET_KEY", secrets.token_urlsafe(32))
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 
@@ -1044,7 +1046,7 @@ app = FastAPI(
 # CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=["http://localhost:3000", "http://localhost:8000", "http://localhost:5173"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/src/youtube_extension/backend/deployment_manager.py
+++ b/src/youtube_extension/backend/deployment_manager.py
@@ -108,7 +108,18 @@ class DeploymentManager:
         }
 
         project_dir = Path(project_path)
-        package_json = project_dir / "package.json"
+
+        # Security: validate and resolve path to prevent traversal
+        try:
+            resolved_path = project_dir.resolve()
+            if not resolved_path.is_dir():
+                result["summary"] = "Invalid project path: not a directory"
+                return result
+        except Exception as e:
+            result["summary"] = f"Invalid project path: {e}"
+            return result
+
+        package_json = resolved_path / "package.json"
 
         # Check if package.json exists
         if not package_json.exists():
@@ -122,8 +133,8 @@ class DeploymentManager:
             logger.info("📦 Running npm install...")
             npm_path = "/usr/local/bin/npm" if os.path.exists("/usr/local/bin/npm") else "npm"
             install_result = subprocess.run(
-                [npm_path, "install", "--legacy-peer-deps"],
-                cwd=project_path,
+                [npm_path, "install", "--legacy-peer-deps", "--ignore-scripts"],
+                cwd=str(resolved_path),
                 capture_output=True,
                 text=True,
                 timeout=180  # 3 minutes for npm install
@@ -145,7 +156,7 @@ class DeploymentManager:
             logger.info("🔨 Running npm run build...")
             build_result = subprocess.run(
                 [npm_path, "run", "build"],
-                cwd=project_path,
+                cwd=str(resolved_path),
                 capture_output=True,
                 text=True,
                 timeout=180
@@ -200,7 +211,7 @@ class DeploymentManager:
                 npx_path = "/usr/local/bin/npx" if os.path.exists("/usr/local/bin/npx") else "npx"
                 tsc_result = subprocess.run(
                     [npx_path, "tsc", "--noEmit"],
-                    cwd=project_path,
+                    cwd=str(resolved_path),
                     capture_output=True,
                     text=True,
                     timeout=60

--- a/src/youtube_extension/backend/real_api_endpoints.py
+++ b/src/youtube_extension/backend/real_api_endpoints.py
@@ -452,10 +452,17 @@ if __name__ == "__main__":
         version="2.0.0"
     )
 
+    # Get allowed origins from environment or use secure defaults
+    import os
+    allowed_origins = os.getenv(
+        "ALLOWED_ORIGINS",
+        "http://localhost:3000,http://localhost:5173,http://localhost:8080,http://localhost:3001"
+    ).split(",")
+
     # CORS middleware
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=allowed_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/src/youtube_extension/backend/services/database_cleanup_service.py
+++ b/src/youtube_extension/backend/services/database_cleanup_service.py
@@ -16,6 +16,7 @@ Features:
 
 import asyncio
 import json
+import re
 import logging
 import os
 import sqlite3
@@ -201,6 +202,21 @@ class DatabaseCleanupService:
         records_deleted = 0
         initial_size = self.get_database_size_mb(db_path)
 
+        # Validate table name to prevent SQL injection
+        if not re.match(r"^[a-zA-Z0-9_]+$", policy.table_name):
+            return CleanupResult(
+                database_path=db_path,
+                table_name=policy.table_name,
+                records_deleted=0,
+                space_freed_mb=0.0,
+                execution_time_ms=0.0,
+                timestamp=datetime.now(timezone.utc),
+                success=False,
+                error_message=f"Invalid table name format: {policy.table_name}"
+            )
+
+        safe_table_name = f'"{policy.table_name}"'
+
         try:
             if not os.path.exists(db_path):
                 return CleanupResult(
@@ -236,7 +252,7 @@ class DatabaseCleanupService:
                 cutoff_date = datetime.now(timezone.utc) - timedelta(days=policy.retention_days)
 
                 # Determine a valid timestamp column for retention checks
-                cursor.execute(f"PRAGMA table_info({policy.table_name})")
+                cursor.execute(f"PRAGMA table_info({safe_table_name})")
                 columns = [row[1] for row in cursor.fetchall()]
                 time_col = None
                 for candidate in ("timestamp", "created_at", "createdAt", "ts"):
@@ -264,9 +280,9 @@ class DatabaseCleanupService:
                 while True:
                     cursor.execute(
                         f"""
-                        DELETE FROM {policy.table_name}
+                        DELETE FROM {safe_table_name}
                         WHERE rowid IN (
-                            SELECT rowid FROM {policy.table_name}
+                            SELECT rowid FROM {safe_table_name}
                             WHERE {time_col} < ?
                             LIMIT ?
                         )

--- a/tests/unit/test_database_cleanup_security.py
+++ b/tests/unit/test_database_cleanup_security.py
@@ -1,0 +1,73 @@
+import os
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from youtube_extension.backend.services.database_cleanup_service import (
+    CleanupResult,
+    DatabaseCleanupService,
+    RetentionPolicy,
+)
+
+
+@pytest.fixture
+def temp_db():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    conn = sqlite3.connect(path)
+    cursor = conn.cursor()
+    cursor.execute(
+        "CREATE TABLE my_table (id INTEGER PRIMARY KEY, timestamp TEXT, data TEXT)"
+    )
+    old_date = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+    cursor.execute(
+        "INSERT INTO my_table (timestamp, data) VALUES (?, ?)", (old_date, "old data")
+    )
+    new_date = datetime.now(timezone.utc).isoformat()
+    cursor.execute(
+        "INSERT INTO my_table (timestamp, data) VALUES (?, ?)", (new_date, "new data")
+    )
+    conn.commit()
+    conn.close()
+
+    yield path
+
+    os.unlink(path)
+
+
+def test_valid_table_name_cleans_up(temp_db):
+    service = DatabaseCleanupService()
+    policy = RetentionPolicy(table_name="my_table", retention_days=5)
+    result = service.cleanup_table(temp_db, policy)
+    assert result.success is True
+    assert result.records_deleted == 1
+
+
+def test_sql_injection_table_name_rejected(temp_db):
+    service = DatabaseCleanupService()
+    policy = RetentionPolicy(
+        table_name="my_table; DROP TABLE my_table;",
+        retention_days=5,
+    )
+    result = service.cleanup_table(temp_db, policy)
+    assert result.success is False
+    assert "Invalid table name format" in result.error_message
+
+
+def test_table_intact_after_rejected_injection(temp_db):
+    service = DatabaseCleanupService()
+    malicious = RetentionPolicy(
+        table_name="my_table; DROP TABLE my_table;",
+        retention_days=5,
+    )
+    service.cleanup_table(temp_db, malicious)
+
+    conn = sqlite3.connect(temp_db)
+    cursor = conn.cursor()
+    cursor.execute("SELECT COUNT(*) FROM my_table")
+    count = cursor.fetchone()[0]
+    conn.close()
+    assert count == 2


### PR DESCRIPTION
Applies five security fixes from PRs that had merge conflicts with #206. The conflicting hunks were all in `tests/e2e/pipeline.test.ts` which was already fixed better in #206; only the security-relevant changes are applied here.

## Changes

| File | Fix | Source PR |
|------|-----|-----------|
| `code_generator.py` | Replace hardcoded `SECRET_KEY = \"your-secret-key-here\"` with `os.getenv(\"SECRET_KEY\", secrets.token_urlsafe(32))` | #193 |
| `code_generator.py` | Restrict CORS `allow_origins` from `[\"*\"]` to explicit localhost origins | #195 |
| `real_api_endpoints.py` | Read `ALLOWED_ORIGINS` from env var; default to localhost origins instead of `[\"*\"]` | #196 |
| `database_cleanup_service.py` | Validate table name with `^[a-zA-Z0-9_]+$` regex before SQL use; quote with double quotes for PRAGMA/DELETE | #197 |
| `deployment_manager.py` | Path traversal guard (resolve + is_dir check); add `--ignore-scripts` to npm install; use `resolved_path` for all `cwd` args | #200 |
| `tests/unit/test_database_cleanup_security.py` | New unit tests for SQL injection prevention | #197 |

## Closes
Closes #193, #195, #196, #197, #200

https://claude.ai/code/session_01AgA9F82EwazbdB5R2f9nsd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgA9F82EwazbdB5R2f9nsd)_