### PR TITLE
fix(sdk): align TranscriptAction and HealthResponse types with API contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ dashboard_test.html
 *.cert
 *.code-workspace
 *.coverage
+coverage.xml
 *.crt
 *.egg-info/
 *.db

--- a/sdk/python/eventrelay_sdk/resources/transcript.py
+++ b/sdk/python/eventrelay_sdk/resources/transcript.py
@@ -34,7 +34,8 @@ class TranscriptResource:
             :class:`TranscriptActionResponse` with transcript and actions.
         """
         payload = TranscriptActionRequest(
-            video_url=video_url, action=action, options=options or {}
+            video_url=video_url,
+            video_options=options or None,
         )
         response = self._client._post(
             "/api/v1/transcript-action",
@@ -58,7 +59,8 @@ class AsyncTranscriptResource:
     ) -> TranscriptActionResponse:
         """Async version of :meth:`TranscriptResource.action`."""
         payload = TranscriptActionRequest(
-            video_url=video_url, action=action, options=options or {}
+            video_url=video_url,
+            video_options=options or None,
         )
         response = await self._client._post(
             "/api/v1/transcript-action",

--- a/sdk/python/eventrelay_sdk/types.py
+++ b/sdk/python/eventrelay_sdk/types.py
@@ -176,14 +176,18 @@ class TranscriptActionRequest(BaseModel):
 class TranscriptActionResponse(BaseModel):
     """Response body from the /api/v1/transcript-action endpoint."""
 
-    status: str
-    video_url: Optional[str] = None
-    transcript: Optional[dict[str, Any]] = None
-    actions: Optional[list[Any]] = None
-    outputs: Optional[list[dict[str, Any]]] = None
-    metadata: Optional[dict[str, Any]] = None
-    errors: Optional[list[str]] = None
-    orchestration_meta: Optional[dict[str, Any]] = None
+    success: bool
+    video_url: str
+    metadata: dict[str, Any]
+    transcript: dict[str, Any]
+    outputs: dict[str, Any]
+    errors: list[str] = Field(default_factory=list)
+    orchestration_meta: dict[str, Any]
+    async_processing: bool = False
+    job_id: Optional[str] = None
+    job_status: Optional[str] = None
+    status_url: Optional[str] = None
+    processing_transport: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -220,7 +224,7 @@ class HealthResponse(BaseModel):
     """Health check response."""
 
     status: str
-    timestamp: Optional[datetime] = None
+    timestamp: datetime
     version: Optional[str] = None
     components: Optional[dict[str, Any]] = None
 

--- a/sdk/python/eventrelay_sdk/types.py
+++ b/sdk/python/eventrelay_sdk/types.py
@@ -158,6 +158,7 @@ class AgentStatusResponse(BaseModel):
 class TranscriptActionRequest(BaseModel):
     """Request body for the /api/v1/transcript-action endpoint."""
 
+    video_url: str = Field(..., description="YouTube video URL to process")
     language: Optional[str] = Field(
         None,
         description="Optional language code for transcript processing",
@@ -175,10 +176,12 @@ class TranscriptActionRequest(BaseModel):
 class TranscriptActionResponse(BaseModel):
     """Response body from the /api/v1/transcript-action endpoint."""
 
-    success: bool
-    metadata: Optional[dict[str, Any]] = None
+    status: str
+    video_url: Optional[str] = None
     transcript: Optional[dict[str, Any]] = None
+    actions: Optional[list[Any]] = None
     outputs: Optional[list[dict[str, Any]]] = None
+    metadata: Optional[dict[str, Any]] = None
     errors: Optional[list[str]] = None
     orchestration_meta: Optional[dict[str, Any]] = None
 
@@ -217,7 +220,7 @@ class HealthResponse(BaseModel):
     """Health check response."""
 
     status: str
-    timestamp: datetime
+    timestamp: Optional[datetime] = None
     version: Optional[str] = None
     components: Optional[dict[str, Any]] = None
 

--- a/sdk/python/eventrelay_sdk/types.py
+++ b/sdk/python/eventrelay_sdk/types.py
@@ -185,7 +185,7 @@ class TranscriptActionResponse(BaseModel):
     orchestration_meta: dict[str, Any]
     async_processing: bool = False
     job_id: Optional[str] = None
-    job_status: Optional[str] = None
+    job_status: Optional[JobStatus] = None
     status_url: Optional[str] = None
     processing_transport: Optional[str] = None
 

--- a/tests/test_sdk_python.py
+++ b/tests/test_sdk_python.py
@@ -192,13 +192,15 @@ class TestTranscriptModels:
 
     def test_transcript_action_response_parse(self) -> None:
         data = {
+            "success": True,
             "video_url": TEST_VIDEO_URL,
+            "metadata": {},
             "transcript": {"text": "Hello world"},
-            "actions": [],
-            "status": "success",
+            "outputs": {},
+            "orchestration_meta": {},
         }
         resp = TranscriptActionResponse.model_validate(data)
-        assert resp.status == "success"
+        assert resp.success is True
 
 
 # ---------------------------------------------------------------------------
@@ -336,7 +338,7 @@ class TestEventRelayClient:
         assert result.components is not None
 
     def test_client_context_manager(self) -> None:
-        routes = {("GET", "/api/v1/health"): {"status": "healthy"}}
+        routes = {("GET", "/api/v1/health"): {"status": "healthy", "timestamp": "2024-01-01T00:00:00"}}
         with self._make_client(routes) as client:
             result = client.health.check()
         assert result.status == "healthy"
@@ -350,7 +352,7 @@ class TestEventRelayClient:
             call_count += 1
             if call_count < 2:
                 return httpx.Response(500)
-            return httpx.Response(200, json={"status": "healthy"})
+            return httpx.Response(200, json={"status": "healthy", "timestamp": "2024-01-01T00:00:00"})
 
         transport = httpx.MockTransport(handler)
         http = httpx.Client(transport=transport)
@@ -394,7 +396,7 @@ class TestAsyncEventRelayClient:
 
     @pytest.mark.asyncio
     async def test_async_health_check(self) -> None:
-        routes = {("GET", "/api/v1/health"): {"status": "healthy"}}
+        routes = {("GET", "/api/v1/health"): {"status": "healthy", "timestamp": "2024-01-01T00:00:00"}}
         client = self._make_client(routes)
         result = await client.health.check()
         assert result.status == "healthy"
@@ -414,7 +416,7 @@ class TestAsyncEventRelayClient:
 
     @pytest.mark.asyncio
     async def test_async_context_manager(self) -> None:
-        routes = {("GET", "/api/v1/health"): {"status": "healthy"}}
+        routes = {("GET", "/api/v1/health"): {"status": "healthy", "timestamp": "2024-01-01T00:00:00"}}
         async with self._make_client(routes) as client:
             result = await client.health.check()
         assert result.status == "healthy"


### PR DESCRIPTION
## Summary

Fixes 6 failing tests in `tests/test_sdk_python.py` — all 34 SDK tests and 226 total tests now pass.

Four SDK type mismatches between the SDK and the actual API contract in `src/youtube_extension/backend/api/v1/models.py`:

- **`TranscriptActionRequest`**: added required `video_url: str` field that the constructor expected but the model lacked
- **`TranscriptActionResponse`**: fully aligned with backend contract — `success: bool`, `video_url: str`, `metadata`, `transcript`, `outputs`, `orchestration_meta` as required fields; `job_status` typed as `Optional[JobStatus]` (not `Optional[str]`) for proper enum validation
- **`TranscriptResource.action()`**: fixed invalid constructor kwargs (`action`, `options`) that caused `ValidationError` at runtime; mapped `options` to `video_options`
- **`HealthResponse.timestamp`**: kept as required `datetime` field (matching backend); fixed test mocks to include the timestamp instead of weakening the type

## Test plan

- [x] `pytest tests/test_sdk_python.py -v` — all 34 tests pass
- [x] `pytest tests/ --ignore=tests/unit/test_transcript_action_workflow.py` — all 226 tests pass

https://claude.ai/code/session_01AgA9F82EwazbdB5R2f9nsd