### PR TITLE
test(e2e): fix Template Gallery assertions by targeting /features

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,7 +12,13 @@ permissions:
   issues: write
 
 env:
-  BASE_URL: https://uvai.io
+  # Defaults to production. Override with the `E2E_BASE_URL` repository
+  # variable to point at another deployment (e.g. a Vercel preview). Note:
+  # Vercel preview deployments are protected (HTTP 401) and require a
+  # "Protection Bypass for Automation" token forwarded as a request header
+  # before they can be exercised here — until that is wired up, the E2E
+  # gate validates production rather than the PR's own preview build.
+  BASE_URL: ${{ vars.E2E_BASE_URL || 'https://uvai.io' }}
   TEST_YOUTUBE_URL: https://www.youtube.com/watch?v=auJzb1D-fag
 
 jobs:

--- a/tests/e2e/pipeline.test.ts
+++ b/tests/e2e/pipeline.test.ts
@@ -2,7 +2,7 @@
  * EventRelay E2E Test Suite
  *
  * Tests the live deployment at BASE_URL (default: https://uvai.io) for:
- *   1. Homepage / Template Gallery rendering
+ *   1. Homepage smoke check + Template Gallery (/features) rendering
  *   2. SSE pipeline stream — full end-to-end with a real YouTube URL
  *   3. SSE stream closes properly (no 95% hang regression)
  *   4. CloudEvent schema compliance in SSE events
@@ -93,9 +93,16 @@ describe('EventRelay E2E — Live Deployment', () => {
     }
   });
 
-  // ── 1. Template Gallery Homepage ──────────────────────────────────
+  // ── 1. Template Gallery / Feature Showcase ────────────────────────
+  // The homepage (BASE_URL) is the interactive Video Workflow Studio and
+  // intentionally does NOT render the template gallery. The workflow /
+  // template content lives on the /features page, so the content
+  // assertions below target /features (the homepage keeps a generic
+  // 200/HTML smoke check).
 
   describe('Template Gallery', () => {
+    const FEATURES_URL = `${BASE_URL}/features`;
+
     it('homepage returns 200 with HTML', async () => {
       const res = await fetchWithTimeout(BASE_URL);
       expect(res.status).toBe(200);
@@ -103,10 +110,11 @@ describe('EventRelay E2E — Live Deployment', () => {
       expect(ct).toContain('text/html');
     });
 
-    it('homepage contains template gallery markup', async () => {
-      const res = await fetchWithTimeout(BASE_URL);
+    it('features page contains template/workflow markup', async () => {
+      const res = await fetchWithTimeout(FEATURES_URL);
+      expect(res.status).toBe(200);
       const html = await res.text();
-      // The template gallery should have at least some of these workflow names
+      // The features page should reference at least some of these workflow names
       const expectedTemplates = [
         'Tutorial',
         'Conference',
@@ -121,12 +129,12 @@ describe('EventRelay E2E — Live Deployment', () => {
       expect(found.length).toBeGreaterThanOrEqual(3);
     });
 
-    it('homepage contains at least 5 template cards', async () => {
-      const res = await fetchWithTimeout(BASE_URL);
+    it('features page surfaces at least 5 workflow/template indicators', async () => {
+      const res = await fetchWithTimeout(FEATURES_URL);
+      expect(res.status).toBe(200);
       const html = await res.text();
-      // Count template card patterns — look for the workflow template structure
-      // Each template card has a "Run" or "Launch" or similar CTA
-      // We check for multiple distinct template-related content blocks
+      // Count distinct template-related content blocks across the feature
+      // sections and the shared footer use-case list.
       const templateIndicators = [
         'youtube',
         'tutorial',


### PR DESCRIPTION
## Problem

The **E2E Pipeline Tests** check failed on its two **Template Gallery** content assertions for every PR — including against production — independent of the branch's changes.

**Root cause:** those assertions fetched the **homepage** (`BASE_URL`) and checked for template keywords (`Tutorial`, `Conference`, `Podcast`, `Meeting`, `demo`, …). But the homepage now renders the interactive **Video Workflow Studio** (`apps/web/src/components/VideoWorkflowStudio.tsx`), which only contains ~2 of those keywords (`youtube`, `research`). The template/workflow content moved to **`/features`**. `TemplatesSection.tsx` — which holds the named template cards — is orphaned (nothing imports it), so it never reaches any rendered page.

Verified against production:

| Page | Assertion 1 (need ≥3) | Assertion 2 (need ≥5) |
|------|----------------------|----------------------|
| `/` (studio homepage) | **1** ❌ | **2** ❌ |
| `/features` | **4** ✅ | **6** ✅ |
| `/dashboard` | 0 ❌ | 1 ❌ |

## Fix

Retarget the two content assertions to **`/features`**, where the content actually lives. The homepage was intentionally changed to the studio (recent `feat(web): launch UVAI video workflow studio`), so re-rendering the gallery there would undo a product decision; `/features` is the correct, content-faithful target.

- The homepage keeps a generic **200 / HTML** smoke check.
- **Keyword lists and thresholds are unchanged** — the test's strictness is preserved; only the URL it fetches changed.
- Coverage on `/features` is robust, not borderline: the shared `Footer.tsx` `USE_CASES` (`Meeting Notes`, `Conference Talks`, `Tutorials`, `Product Demos`, `Podcasts`) provides a durable backbone of 5 keywords, plus `youtube` from the page body. The Footer is imported by `/features` but **not** by the studio homepage — which is exactly why the homepage lacked the keywords.

### Verification

Ran the exact failing gate against production:

```
✓ Template Gallery > homepage returns 200 with HTML
✓ Template Gallery > features page contains template/workflow markup
✓ Template Gallery > features page surfaces at least 5 workflow/template indicators

Test Files  1 passed (1)
      Tests  3 passed | 14 skipped (17)
```

## Workflow note (secondary)

`.github/workflows/e2e-tests.yml` hardcoded `BASE_URL: https://uvai.io`, so the E2E always validates production rather than the PR's own preview build. This PR makes `BASE_URL` configurable via the `E2E_BASE_URL` repository variable (defaulting to production, so it's a no-op unless set).

**Not yet wired up:** actually testing the PR's Vercel **preview** deployment requires a *Protection Bypass for Automation* token forwarded as a request header (previews return HTTP 401). That needs the token stored as a secret and threaded through the test's `fetch` calls — left as a documented follow-up (noted in a comment in the workflow) rather than referencing a secret that doesn't exist yet.

## Files

- `tests/e2e/pipeline.test.ts` — retarget the two Template Gallery content assertions to `/features`; add per-fetch `200` checks.
- `.github/workflows/e2e-tests.yml` — make `BASE_URL` overridable; document the preview-bypass requirement.

https://claude.ai/code/session_01KTd1FKQ814af5V1ct3icQN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTd1FKQ814af5V1ct3icQN)_