### PR TITLE
feat(web): render the workflow template gallery on /features

### DIFF
--- a/apps/web/src/app/features/page.tsx
+++ b/apps/web/src/app/features/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { clsx } from 'clsx';
 import LandingNav from '@/components/landing/LandingNav';
+import TemplatesSection from '@/components/landing/TemplatesSection';
 import Footer from '@/components/Footer';
 
 // ─── Visual Mockup Components ──────────────────────────────────────────────────
@@ -758,6 +759,9 @@ export default function FeaturesPage() {
           ))}
         </div>
       </section>
+
+      {/* ── Template gallery ────────────────────────────────────────────────── */}
+      <TemplatesSection />
 
       {/* ── Comparison table ─────────────────────────────────────────────────── */}
       <section className="max-w-5xl mx-auto px-6 mb-24">


### PR DESCRIPTION
## Why

Follow-up to the audit on #235. The E2E "Template Gallery" assertions were green only because `/features` *incidentally* mentioned template keywords (mostly the shared `Footer` use-case list) — while `TemplatesSection.tsx`, the actual template gallery component, was **orphaned**: defined but imported nowhere, rendering on no page. The homepage became the Video Workflow Studio, which left the gallery without a home.

So the test guarded content that didn't really exist as a gallery, and a polished component was dead code.

## What

Render `<TemplatesSection />` on the `/features` showcase, between the stats strip and the comparison table. One import + one element (4 lines).

This:
- **Removes the dead component** — it now renders on a real page.
- **Gives the E2E gate something real to guard** — "Tutorial → project plan", "Conference talk → action items", "Podcast → blog post", "Lecture → study notes" now appear as actual gallery cards, backed by a stable component rather than incidental footer copy (so the keyword coverage no longer silently depends on marketing prose).

## Verification

Production build (`turbo run build`) succeeds and `/features` prerenders as **static content**. Inspected the prerendered server HTML (`.next/server/app/features.html`):

```
✓ Workflow starting points
✓ Tutorial → project plan
✓ Conference talk → action items
✓ Podcast → blog post
✓ Lecture → study notes
✓ See all 9 templates
```

E2E keyword assertions against the new HTML: **assertion 1 = 4 (need ≥3), assertion 2 = 6 (need ≥5)** — both pass, now backed by a genuine gallery.

Theme compatibility confirmed: `TemplatesSection`'s tokens (`text-ink` → `--color-ink: 248 245 253`, `surface` scale, `font-heading`) are all defined and render correctly on the dark `/features` page.

## Notes

- The E2E gate still runs against **production**, so this gallery won't be exercised by CI until it deploys — but the existing `/features` assertions already pass against prod, so nothing regresses meanwhile. (Wiring the gate to test the Vercel preview is tracked separately and needs a Protection-Bypass token.)
- `git grep TemplatesSection` previously returned only its own definition; this PR adds the single import site.

https://claude.ai/code/session_01KTd1FKQ814af5V1ct3icQN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTd1FKQ814af5V1ct3icQN)_