### PR TITLE
test(e2e): forward Vercel protection-bypass header for preview testing

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,14 +12,22 @@ permissions:
   issues: write
 
 env:
-  # Defaults to production. Override with the `E2E_BASE_URL` repository
-  # variable to point at another deployment (e.g. a Vercel preview). Note:
-  # Vercel preview deployments are protected (HTTP 401) and require a
-  # "Protection Bypass for Automation" token forwarded as a request header
-  # before they can be exercised here — until that is wired up, the E2E
-  # gate validates production rather than the PR's own preview build.
+  # By default the E2E suite runs against production. To validate a PR's own
+  # Vercel preview instead, two things are needed:
+  #   1. Point BASE_URL at the preview — set the `E2E_BASE_URL` repository
+  #      variable, or compute the per-PR preview URL in a prior step and export
+  #      it to $GITHUB_ENV as E2E_BASE_URL.
+  #   2. Provide `VERCEL_AUTOMATION_BYPASS_SECRET` as a repository secret.
+  #      Vercel previews return HTTP 401 to anonymous traffic; the test harness
+  #      forwards this value as the `x-vercel-protection-bypass` header on every
+  #      request (see tests/e2e/pipeline.test.ts). Generate it under Vercel →
+  #      Project → Settings → Deployment Protection → Protection Bypass for
+  #      Automation.
+  # When the variable/secret are unset (the default), BASE_URL falls back to
+  # production and no bypass header is sent — behaviour is unchanged.
   BASE_URL: ${{ vars.E2E_BASE_URL || 'https://uvai.io' }}
   TEST_YOUTUBE_URL: https://www.youtube.com/watch?v=auJzb1D-fag
+  VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
 jobs:
   e2e:

--- a/tests/e2e/pipeline.test.ts
+++ b/tests/e2e/pipeline.test.ts
@@ -27,7 +27,27 @@ const TEST_YOUTUBE_URL =
   process.env.TEST_YOUTUBE_URL ||
   'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
 
+// To exercise a protected deployment (e.g. a Vercel preview, which returns 401
+// to anonymous requests), set VERCEL_AUTOMATION_BYPASS_SECRET to the project's
+// "Protection Bypass for Automation" secret. It is attached as a header on
+// every request so the preview is reachable. Unset (the default — e.g. when
+// BASE_URL is production) → no header is added and behaviour is unchanged.
+const VERCEL_BYPASS_SECRET = process.env.VERCEL_AUTOMATION_BYPASS_SECRET || '';
+
 // ─── Helpers ────────────────────────────────────────────────────────
+
+/** Merge the Vercel protection-bypass header into a request init, when configured. */
+function withBypass(init?: RequestInit): RequestInit {
+  if (!VERCEL_BYPASS_SECRET) return init ?? {};
+  return {
+    ...init,
+    headers: {
+      ...(init?.headers as Record<string, string> | undefined),
+      'x-vercel-protection-bypass': VERCEL_BYPASS_SECRET,
+      'x-vercel-set-bypass-cookie': 'true',
+    },
+  };
+}
 
 /** Fetch with a hard timeout and automatic retry for transient network errors. */
 async function fetchWithTimeout(
@@ -41,7 +61,7 @@ async function fetchWithTimeout(
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const res = await fetch(url, { ...init, signal: controller.signal });
+      const res = await fetch(url, { ...withBypass(init), signal: controller.signal });
       clearTimeout(timer);
       return res;
     } catch (err) {


### PR DESCRIPTION
## Why

Follow-up to the audit on #235 (finding **F2**): the E2E gate runs against **production**, so it can't catch a regression a PR introduces — and the failure mode is self-perpetuating (a PR breaks `/features`, merges green against the still-good prod, then every later PR's E2E goes red once it deploys). The root reason it can't test the PR's own Vercel preview is that previews return **HTTP 401** to anonymous traffic.

This PR adds the **harness half** of preview testing: the plumbing to authenticate against a protected preview. It's **inert by default** — nothing changes until a maintainer provisions the token.

## What

- **`tests/e2e/pipeline.test.ts`** — when `VERCEL_AUTOMATION_BYPASS_SECRET` is set, `fetchWithTimeout` attaches the `x-vercel-protection-bypass` header to every request (all requests already funnel through this one helper). Unset → returns the init untouched, so the path is byte-identical to today.
- **`.github/workflows/e2e-tests.yml`** — forwards `secrets.VERCEL_AUTOMATION_BYPASS_SECRET` into the job env, and documents the activation steps.

## Activation (for whoever has Vercel admin)

1. Generate the secret: **Vercel → Project → Settings → Deployment Protection → Protection Bypass for Automation**.
2. Add it as the `VERCEL_AUTOMATION_BYPASS_SECRET` GitHub **repo secret**.
3. Point `BASE_URL` at the preview — set the `E2E_BASE_URL` repo **variable**, or compute the per-PR preview URL in a prior step and export it to `$GITHUB_ENV`.

## Deliberately *not* included

**Dynamic per-PR preview-URL discovery.** Wiring the workflow to resolve each PR's unique preview URL (e.g. trigger on `deployment_status` and read `environment_url`, or query the Vercel API) is a design decision with several valid approaches, and it can't be verified without the token — so I left it as a documented step (3 above) rather than ship an unverifiable CI change that could break the gate. Happy to implement it once the token exists and the team picks an approach.

## Verification

Ran the **full suite against production with the bypass header active on every request** (`VERCEL_AUTOMATION_BYPASS_SECRET=dummy…`; prod harmlessly ignores the unknown header). This proves the header merge is correct for both **GET** (Template Gallery) and **header-setting POST** (SSE `Content-Type`) requests — all green. The unset/default path is byte-identical to current `main`. Workflow YAML validated.

https://claude.ai/code/session_01KTd1FKQ814af5V1ct3icQN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTd1FKQ814af5V1ct3icQN)_