### PR TITLE
fix(deps): reduce launch audit findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "@google/generative-ai": "^0.24.1",
         "@stripe/stripe-js": "^2.0.0",
         "@supabase/supabase-js": "^2.39.0",
-        "@upstash/redis": "^1.28.0",
+        "@upstash/redis": "^1.38.0",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "class-variance-authority": "^0.7.0",
@@ -581,100 +581,6 @@
       "peerDependencies": {
         "@tanstack-query-firebase/react": "^2.0.0",
         "firebase": "^11.3.0 || ^12.0.0"
-      }
-    },
-    "node_modules/@ai-sdk/anthropic": {
-      "version": "2.0.57",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.57.tgz",
-      "integrity": "sha512-DREpYqW2pylgaj69gZ+K8u92bo9DaMgFdictYnY+IwYeY3bawQ4zI7l/o1VkDsBDljAx8iYz5lPURwVZNu+Xpg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.1",
-        "@ai-sdk/provider-utils": "3.0.20"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/gateway": {
-      "version": "2.0.29",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.29.tgz",
-      "integrity": "sha512-1b7E9F/B5gex/1uCkhs+sGIbH0KsZOItHnNz3iY5ir+nc4ZUA6WOU5Cu2w1USlc+3UVbhf+H+iNLlxVjLe4VvQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.1",
-        "@ai-sdk/provider-utils": "3.0.20",
-        "@vercel/oidc": "3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/google": {
-      "version": "2.0.52",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.52.tgz",
-      "integrity": "sha512-2XUnGi3f7TV4ujoAhA+Fg3idUoG/+Y2xjCRg70a1/m0DH1KSQqYaCboJ1C19y6ZHGdf5KNT20eJdswP6TvrY2g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.1",
-        "@ai-sdk/provider-utils": "3.0.20"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/openai": {
-      "version": "2.0.89",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.89.tgz",
-      "integrity": "sha512-4+qWkBCbL9HPKbgrUO/F2uXZ8GqrYxHa8SWEYIzxEJ9zvWw3ISr3t1/27O1i8MGSym+PzEyHBT48EV4LAwWaEw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.1",
-        "@ai-sdk/provider-utils": "3.0.20"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/provider": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
-      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.20.tgz",
-      "integrity": "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.1",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4034,9 +3940,9 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
-      "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -8052,21 +7958,12 @@
       }
     },
     "node_modules/@upstash/redis": {
-      "version": "1.36.1",
-      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.36.1.tgz",
-      "integrity": "sha512-N6SjDcgXdOcTAF+7uNoY69o7hCspe9BcA7YjQdxVu5d25avljTwyLaHBW3krWjrP0FfocgMk94qyVtQbeDp39A==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
       "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
-      }
-    },
-    "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/@vitest/expect": {
@@ -8425,33 +8322,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/ai": {
-      "version": "5.0.123",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.123.tgz",
-      "integrity": "sha512-V3Imb0tg0pHCa6a/VsoW/FZpT07mwUw/4Hj6nexJC1Nvf1eyKQJyaYVkl+YTLnA8cKQSUkoarKhXWbFy4CSgjw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/gateway": "2.0.29",
-        "@ai-sdk/provider": "2.0.1",
-        "@ai-sdk/provider-utils": "3.0.20",
-        "@opentelemetry/api": "1.9.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/ai/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -11013,9 +10883,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -18669,16 +18539,16 @@
       "name": "@repo/ai-gateway",
       "version": "0.0.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "^2.0.53",
-        "@ai-sdk/google": "^2.0.44",
-        "@ai-sdk/openai": "^2.0.76",
+        "@ai-sdk/anthropic": "^3.0.82",
+        "@ai-sdk/google": "^3.0.80",
+        "@ai-sdk/openai": "^3.0.69",
         "@dataconnect/generated": "file:src/dataconnect-generated",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@temporalio/activity": "^1.15.0",
         "@temporalio/client": "^1.15.0",
         "@temporalio/worker": "^1.15.0",
         "@temporalio/workflow": "^1.15.0",
-        "ai": "^5.0.106",
+        "ai": "^6.0.200",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -18686,6 +18556,100 @@
         "eslint": "^8",
         "jest": "^29",
         "typescript": "^5"
+      }
+    },
+    "packages/ai-gateway/node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.82",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.82.tgz",
+      "integrity": "sha512-WKKou2wbhGGYV8PSALAPyV2YY4nfCqCPkyBzYtJtDA9yCcIFwsbtkTNgg7bqtLCVzeEsY7wwxRoCWy+EMfrw/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "packages/ai-gateway/node_modules/@ai-sdk/gateway": {
+      "version": "3.0.127",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.127.tgz",
+      "integrity": "sha512-Obmw5hmE5x+ccRrMp/Djx5r0rpFVX87YqE6OY06g5fwYlRI30dA84ARfTzX45ivCvkW4eCnBpOVXVWQ/pjH85w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "packages/ai-gateway/node_modules/@ai-sdk/google": {
+      "version": "3.0.80",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.80.tgz",
+      "integrity": "sha512-5ORbm/yFUPO0MEvZsxBMN0cdKw2+lwU/wVn5KN3KF8Dmk1LughuDuUohMh/7iU/XFTiyB0OvmTW/tdV/J7O9zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "packages/ai-gateway/node_modules/@ai-sdk/openai": {
+      "version": "3.0.69",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.69.tgz",
+      "integrity": "sha512-T/J3ED6ERDsine+crkXHfraisSG20k6BkBdgjvXCvySYnnJ19IaLIOsQPYfvXdOsKrl0LVNghooTV/nKCA7SmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "packages/ai-gateway/node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ai-gateway/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "packages/ai-gateway/node_modules/@dataconnect/generated": {
@@ -18740,6 +18704,33 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "packages/ai-gateway/node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "packages/ai-gateway/node_modules/ai": {
+      "version": "6.0.200",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.200.tgz",
+      "integrity": "sha512-kme8AWPy7om8s5Isj/uIE0T3hVf8d5QEIpd2WJ/RiAansglud92fIEurCaz/ZYgjW5abcxuyhv55soQnLIWYEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.127",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "packages/ai-gateway/src/dataconnect-generated": {
@@ -18872,10 +18863,7 @@
       "name": "@repo/eslint-config",
       "version": "0.0.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "2.0.53",
-        "@ai-sdk/openai": "2.0.76",
         "@dataconnect/generated": "file:src/dataconnect-generated",
-        "ai": "6.0.5",
         "next": "^16.2.6"
       },
       "devDependencies": {
@@ -18884,173 +18872,9 @@
         "eslint-config-prettier": "^9.0.0"
       }
     },
-    "packages/eslint-config/node_modules/@ai-sdk/anthropic": {
-      "version": "2.0.53",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.53.tgz",
-      "integrity": "sha512-ih7NV+OFSNWZCF+tYYD7ovvvM+gv7TRKQblpVohg2ipIwC9Y0TirzocJVREzZa/v9luxUwFbsPji++DUDWWxsg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.18"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/eslint-config/node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
-      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/eslint-config/node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.18.tgz",
-      "integrity": "sha512-ypv1xXMsgGcNKUP+hglKqtdDuMg68nWHucPPAhIENrbFAI+xCHiqPVN8Zllxyv1TNZwGWUghPxJXU+Mqps0YRQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/eslint-config/node_modules/@ai-sdk/gateway": {
-      "version": "3.0.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.1",
-        "@ai-sdk/provider-utils": "4.0.2",
-        "@vercel/oidc": "3.0.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/eslint-config/node_modules/@ai-sdk/openai": {
-      "version": "2.0.76",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.76.tgz",
-      "integrity": "sha512-ryUkhTDVxe3D1GSAGc94vPZsJlSY8ZuBDLkpf4L81Dm7Ik5AgLfhQrZa8+0hD4kp0dxdVaIoxhpa3QOt1CmncA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.18"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/eslint-config/node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
-      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/eslint-config/node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.18.tgz",
-      "integrity": "sha512-ypv1xXMsgGcNKUP+hglKqtdDuMg68nWHucPPAhIENrbFAI+xCHiqPVN8Zllxyv1TNZwGWUghPxJXU+Mqps0YRQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/eslint-config/node_modules/@ai-sdk/provider": {
-      "version": "3.0.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/eslint-config/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.1",
-        "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
     "packages/eslint-config/node_modules/@dataconnect/generated": {
       "resolved": "packages/eslint-config/src/dataconnect-generated",
       "link": true
-    },
-    "packages/eslint-config/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/eslint-config/node_modules/@vercel/oidc": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.5.tgz",
-      "integrity": "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "packages/eslint-config/node_modules/ai": {
-      "version": "6.0.5",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/gateway": "3.0.4",
-        "@ai-sdk/provider": "3.0.1",
-        "@ai-sdk/provider-utils": "4.0.2",
-        "@opentelemetry/api": "1.9.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
     },
     "packages/eslint-config/src/dataconnect-generated": {
       "name": "@dataconnect/generated",
@@ -19149,15 +18973,6 @@
       "resolved": "packages/observability/src/dataconnect-generated",
       "link": true
     },
-    "packages/observability/node_modules/@opentelemetry/api": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
-      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "packages/observability/src/dataconnect-generated": {
       "name": "@dataconnect/generated",
       "version": "1.0.0",
@@ -19173,13 +18988,9 @@
       "name": "@eventrelay/state-manager",
       "version": "0.1.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "2.0.53",
-        "@ai-sdk/google": "2.0.44",
-        "@ai-sdk/openai": "2.0.76",
         "@dataconnect/generated": "file:src/dataconnect-generated",
         "@upstash/ratelimit": "^1.0.0",
         "@upstash/redis": "^1.28.0",
-        "ai": "5.0.106",
         "ioredis": "^5.3.0"
       },
       "devDependencies": {
@@ -19190,139 +19001,9 @@
         "vitest": "^4.0.15"
       }
     },
-    "packages/state-manager/node_modules/@ai-sdk/anthropic": {
-      "version": "2.0.53",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.53.tgz",
-      "integrity": "sha512-ih7NV+OFSNWZCF+tYYD7ovvvM+gv7TRKQblpVohg2ipIwC9Y0TirzocJVREzZa/v9luxUwFbsPji++DUDWWxsg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.18"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/state-manager/node_modules/@ai-sdk/gateway": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.18.tgz",
-      "integrity": "sha512-sDQcW+6ck2m0pTIHW6BPHD7S125WD3qNkx/B8sEzJp/hurocmJ5Cni0ybExg6sQMGo+fr/GWOwpHF1cmCdg5rQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.18",
-        "@vercel/oidc": "3.0.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/state-manager/node_modules/@ai-sdk/google": {
-      "version": "2.0.44",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.44.tgz",
-      "integrity": "sha512-c5dck36FjqiVoeeMJQLTEmUheoURcGTU/nBT6iJu8/nZiKFT/y8pD85KMDRB7RerRYaaQOtslR2d6/5PditiRw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.18"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/state-manager/node_modules/@ai-sdk/openai": {
-      "version": "2.0.76",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.76.tgz",
-      "integrity": "sha512-ryUkhTDVxe3D1GSAGc94vPZsJlSY8ZuBDLkpf4L81Dm7Ik5AgLfhQrZa8+0hD4kp0dxdVaIoxhpa3QOt1CmncA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.18"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/state-manager/node_modules/@ai-sdk/provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
-      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/state-manager/node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.18.tgz",
-      "integrity": "sha512-ypv1xXMsgGcNKUP+hglKqtdDuMg68nWHucPPAhIENrbFAI+xCHiqPVN8Zllxyv1TNZwGWUghPxJXU+Mqps0YRQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
     "packages/state-manager/node_modules/@dataconnect/generated": {
       "resolved": "packages/state-manager/src/dataconnect-generated",
       "link": true
-    },
-    "packages/state-manager/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/state-manager/node_modules/@vercel/oidc": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.5.tgz",
-      "integrity": "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "packages/state-manager/node_modules/ai": {
-      "version": "5.0.106",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.106.tgz",
-      "integrity": "sha512-M5obwavxSJJ3tGlAFqI6eltYNJB0D20X6gIBCFx/KVorb/X1fxVVfiZZpZb+Gslu4340droSOjT0aKQFCarNVg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/gateway": "2.0.18",
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.18",
-        "@opentelemetry/api": "1.9.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
     },
     "packages/state-manager/src/dataconnect-generated": {
       "name": "@dataconnect/generated",
@@ -19391,13 +19072,9 @@
       "name": "@eventrelay/vector-store",
       "version": "0.1.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "2.0.53",
-        "@ai-sdk/google": "2.0.44",
-        "@ai-sdk/openai": "2.0.76",
         "@dataconnect/generated": "file:src/dataconnect-generated",
         "@pinecone-database/pinecone": "^2.0.0",
         "@supabase/supabase-js": "^2.39.0",
-        "ai": "5.0.106",
         "openai": "^4.20.0"
       },
       "devDependencies": {
@@ -19407,145 +19084,15 @@
         "vitest": "^4.0.15"
       }
     },
-    "packages/vector-store/node_modules/@ai-sdk/anthropic": {
-      "version": "2.0.53",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.53.tgz",
-      "integrity": "sha512-ih7NV+OFSNWZCF+tYYD7ovvvM+gv7TRKQblpVohg2ipIwC9Y0TirzocJVREzZa/v9luxUwFbsPji++DUDWWxsg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.18"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/vector-store/node_modules/@ai-sdk/gateway": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.18.tgz",
-      "integrity": "sha512-sDQcW+6ck2m0pTIHW6BPHD7S125WD3qNkx/B8sEzJp/hurocmJ5Cni0ybExg6sQMGo+fr/GWOwpHF1cmCdg5rQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.18",
-        "@vercel/oidc": "3.0.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/vector-store/node_modules/@ai-sdk/google": {
-      "version": "2.0.44",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.44.tgz",
-      "integrity": "sha512-c5dck36FjqiVoeeMJQLTEmUheoURcGTU/nBT6iJu8/nZiKFT/y8pD85KMDRB7RerRYaaQOtslR2d6/5PditiRw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.18"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/vector-store/node_modules/@ai-sdk/openai": {
-      "version": "2.0.76",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.76.tgz",
-      "integrity": "sha512-ryUkhTDVxe3D1GSAGc94vPZsJlSY8ZuBDLkpf4L81Dm7Ik5AgLfhQrZa8+0hD4kp0dxdVaIoxhpa3QOt1CmncA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.18"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/vector-store/node_modules/@ai-sdk/provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
-      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/vector-store/node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.18.tgz",
-      "integrity": "sha512-ypv1xXMsgGcNKUP+hglKqtdDuMg68nWHucPPAhIENrbFAI+xCHiqPVN8Zllxyv1TNZwGWUghPxJXU+Mqps0YRQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
     "packages/vector-store/node_modules/@dataconnect/generated": {
       "resolved": "packages/vector-store/src/dataconnect-generated",
       "link": true
-    },
-    "packages/vector-store/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "packages/vector-store/node_modules/@types/node": {
       "version": "18.19.130",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "packages/vector-store/node_modules/@vercel/oidc": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.5.tgz",
-      "integrity": "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "packages/vector-store/node_modules/ai": {
-      "version": "5.0.106",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.106.tgz",
-      "integrity": "sha512-M5obwavxSJJ3tGlAFqI6eltYNJB0D20X6gIBCFx/KVorb/X1fxVVfiZZpZb+Gslu4340droSOjT0aKQFCarNVg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/gateway": "2.0.18",
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.18",
-        "@opentelemetry/api": "1.9.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "packages/vector-store/node_modules/openai": {

--- a/packages/ai-gateway/package.json
+++ b/packages/ai-gateway/package.json
@@ -13,16 +13,16 @@
     "test": "jest"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^2.0.53",
-    "@ai-sdk/google": "^2.0.44",
-    "@ai-sdk/openai": "^2.0.76",
+    "@ai-sdk/anthropic": "^3.0.82",
+    "@ai-sdk/google": "^3.0.80",
+    "@ai-sdk/openai": "^3.0.69",
     "@dataconnect/generated": "file:src/dataconnect-generated",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@temporalio/activity": "^1.15.0",
     "@temporalio/client": "^1.15.0",
     "@temporalio/worker": "^1.15.0",
     "@temporalio/workflow": "^1.15.0",
-    "ai": "^5.0.106",
+    "ai": "^6.0.200",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/ai-gateway/src/activities/competitiveAnalysisActivities.ts
+++ b/packages/ai-gateway/src/activities/competitiveAnalysisActivities.ts
@@ -1,4 +1,4 @@
-import { generateText, tool } from 'ai';
+import { generateText, stepCountIs } from 'ai';
 import { google } from '@ai-sdk/google';
 import { z } from 'zod';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -37,29 +37,31 @@ export async function extractUrlContent(url: string): Promise<string> {
   await mcpClient.connect(transport);
   
   try {
+    const browserTools = {
+      navigate: {
+        description: 'Navigate the active Chrome tab to a URL',
+        inputSchema: z.object({ url: z.string() }),
+        execute: async ({ url }: { url: string }) => {
+          console.log(`[MCP Tool] Navigating to ${url}`);
+          return await mcpClient.callTool({ name: 'navigate', arguments: { url } });
+        },
+      },
+      evaluate_script: {
+        description: 'Evaluate JavaScript in the active Chrome tab to extract content from the DOM',
+        inputSchema: z.object({ script: z.string() }),
+        execute: async ({ script }: { script: string }) => {
+          console.log(`[MCP Tool] Evaluating script...`);
+          return await mcpClient.callTool({ name: 'evaluate_script', arguments: { script } });
+        },
+      },
+    } as any;
+
     const { text } = await generateText({
       model: MODEL,
       system: "You are an AI agent with Computer Use capabilities via the Chrome DevTools MCP. Navigate to the user's requested URL, extract product offerings and pricing, and return a clean summary. Use your browser tools to evaluate the DOM and navigate.",
       prompt: `Target URL: ${url}`,
-      tools: {
-        navigate: tool({
-          description: 'Navigate the active Chrome tab to a URL',
-          parameters: z.object({ url: z.string() }),
-          execute: async ({ url }) => {
-            console.log(`[MCP Tool] Navigating to ${url}`);
-            return await mcpClient.callTool({ name: 'navigate', arguments: { url } });
-          }
-        }),
-        evaluate_script: tool({
-          description: 'Evaluate JavaScript in the active Chrome tab to extract content from the DOM',
-          parameters: z.object({ script: z.string() }),
-          execute: async ({ script }) => {
-            console.log(`[MCP Tool] Evaluating script...`);
-            return await mcpClient.callTool({ name: 'evaluate_script', arguments: { script } });
-          }
-        })
-      },
-      maxSteps: 10, // Let the model reason and call tools iteratively
+      tools: browserTools,
+      stopWhen: stepCountIs(10), // Let the model reason and call tools iteratively
     });
     return text;
   } finally {

--- a/packages/ai-gateway/src/index.ts
+++ b/packages/ai-gateway/src/index.ts
@@ -1,5 +1,6 @@
 import { generateText, streamText } from 'ai';
 import { ModelRegistry, DEFAULT_FALLBACK_ORDER } from './models';
+import type { RegisteredModel } from './models';
 import type {
   AIProvider,
   AIGatewayConfig,
@@ -34,10 +35,10 @@ export class AIGateway {
       }
 
       try {
-        const model = this.registry.getModel(provider);
-        if (!model) continue;
+        const registeredModel = this.registry.getModel(provider);
+        if (!registeredModel) continue;
 
-        const result = await this.generateWithTimeout(model, provider, options);
+        const result = await this.generateWithTimeout(registeredModel, provider, options);
         return result;
       } catch (error) {
         errors.push({
@@ -66,21 +67,21 @@ export class AIGateway {
       }
 
       try {
-        const model = this.registry.getModel(provider);
-        if (!model) continue;
+        const registeredModel = this.registry.getModel(provider);
+        if (!registeredModel) continue;
 
         const { textStream } = await streamText({
-          model,
+          model: registeredModel.model,
           prompt: options.prompt,
           system: options.system,
-          maxTokens: options.maxTokens,
+          maxOutputTokens: options.maxTokens,
           temperature: options.temperature,
         });
 
         return {
           textStream,
           provider,
-          model: model.modelId || 'unknown',
+          model: registeredModel.modelId,
         };
       } catch (error) {
         errors.push({
@@ -100,7 +101,7 @@ export class AIGateway {
    * Generate with timeout enforcement
    */
   private async generateWithTimeout(
-    model: any,
+    registeredModel: RegisteredModel,
     provider: AIProvider,
     options: GenerateOptions
   ): Promise<GenerateResult> {
@@ -109,10 +110,10 @@ export class AIGateway {
     );
 
     const generatePromise = generateText({
-      model,
+      model: registeredModel.model,
       prompt: options.prompt,
       system: options.system,
-      maxTokens: options.maxTokens,
+      maxOutputTokens: options.maxTokens,
       temperature: options.temperature,
     });
 
@@ -121,12 +122,14 @@ export class AIGateway {
     return {
       text: result.text,
       provider,
-      model: model.modelId || 'unknown',
+      model: registeredModel.modelId,
       usage: result.usage
         ? {
-            promptTokens: result.usage.promptTokens,
-            completionTokens: result.usage.completionTokens,
-            totalTokens: result.usage.totalTokens,
+            promptTokens: result.usage.inputTokens ?? 0,
+            completionTokens: result.usage.outputTokens ?? 0,
+            totalTokens:
+              result.usage.totalTokens ??
+              (result.usage.inputTokens ?? 0) + (result.usage.outputTokens ?? 0),
           }
         : undefined,
     };

--- a/packages/ai-gateway/src/models.ts
+++ b/packages/ai-gateway/src/models.ts
@@ -1,11 +1,16 @@
-import { openai } from '@ai-sdk/openai';
-import { anthropic } from '@ai-sdk/anthropic';
-import { google } from '@ai-sdk/google';
+import { createOpenAI } from '@ai-sdk/openai';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import type { LanguageModel } from 'ai';
 import type { AIProvider, ModelConfig } from './types';
 
+export interface RegisteredModel {
+  model: LanguageModel;
+  modelId: string;
+}
+
 export class ModelRegistry {
-  private models = new Map<AIProvider, LanguageModel>();
+  private models = new Map<AIProvider, RegisteredModel>();
 
   constructor(configs: ModelConfig[]) {
     for (const config of configs) {
@@ -14,43 +19,44 @@ export class ModelRegistry {
   }
 
   private registerModel(config: ModelConfig): void {
+    const modelId = config.model || DEFAULT_MODELS[config.provider];
     let model: LanguageModel;
 
     switch (config.provider) {
       case 'grok':
         // Grok uses OpenAI-compatible API
-        model = openai(config.model || 'grok-beta', {
+        model = createOpenAI({
           baseURL: 'https://api.x.ai/v1',
           apiKey: config.apiKey,
-        });
+        })(modelId);
         break;
 
       case 'claude':
-        model = anthropic(config.model || 'claude-opus-4-8', {
+        model = createAnthropic({
           apiKey: config.apiKey,
-        });
+        })(modelId);
         break;
 
       case 'gemini':
-        model = google(config.model || 'gemini-2.0-flash-exp', {
+        model = createGoogleGenerativeAI({
           apiKey: config.apiKey,
-        });
+        })(modelId);
         break;
 
       case 'openai':
-        model = openai(config.model || 'gpt-4o', {
+        model = createOpenAI({
           apiKey: config.apiKey,
-        });
+        })(modelId);
         break;
 
       default:
         throw new Error(`Unsupported provider: ${config.provider}`);
     }
 
-    this.models.set(config.provider, model);
+    this.models.set(config.provider, { model, modelId });
   }
 
-  getModel(provider: AIProvider): LanguageModel | undefined {
+  getModel(provider: AIProvider): RegisteredModel | undefined {
     return this.models.get(provider);
   }
 

--- a/packages/ai-gateway/src/workflows/competitiveAnalysisWorkflow.ts
+++ b/packages/ai-gateway/src/workflows/competitiveAnalysisWorkflow.ts
@@ -3,7 +3,7 @@ import type * as activities from '../activities/competitiveAnalysisActivities';
 
 // Set up proxy activities with retry policies and timeouts
 const proxyOptions = {
-  startToCloseTimeout: '10 minutes', // Computer use can take time
+  startToCloseTimeout: '10m' as const, // Computer use can take time
   retry: {
     maximumAttempts: 3,
   },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -9,10 +9,7 @@
     "eslint-config-prettier": "^9.0.0"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "2.0.53",
-    "@ai-sdk/openai": "2.0.76",
     "@dataconnect/generated": "file:src/dataconnect-generated",
-    "ai": "6.0.5",
     "next": "^16.2.6"
   }
 }

--- a/packages/state-manager/package.json
+++ b/packages/state-manager/package.json
@@ -12,13 +12,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "2.0.53",
-    "@ai-sdk/google": "2.0.44",
-    "@ai-sdk/openai": "2.0.76",
     "@dataconnect/generated": "file:src/dataconnect-generated",
     "@upstash/ratelimit": "^1.0.0",
     "@upstash/redis": "^1.28.0",
-    "ai": "5.0.106",
     "ioredis": "^5.3.0"
   },
   "devDependencies": {

--- a/packages/vector-store/package.json
+++ b/packages/vector-store/package.json
@@ -12,13 +12,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "2.0.53",
-    "@ai-sdk/google": "2.0.44",
-    "@ai-sdk/openai": "2.0.76",
     "@dataconnect/generated": "file:src/dataconnect-generated",
     "@pinecone-database/pinecone": "^2.0.0",
     "@supabase/supabase-js": "^2.39.0",
-    "ai": "5.0.106",
     "openai": "^4.20.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- update the AI gateway to AI SDK 6 provider packages and adapt call settings/tool definitions
- remove unused AI SDK dependencies from state-manager, vector-store, and eslint-config
- refresh the root lockfile, reducing root npm audit findings from 10 to 4 moderate findings

## Verification
- npm --prefix apps/web run lint
- npm run build:web
- npm --prefix apps/web audit --omit=dev
- npm audit --omit=dev
- npx tsc --noEmit -p packages/ai-gateway/tsconfig.json
- npx tsc --noEmit -p packages/state-manager/tsconfig.json
- npx tsc --noEmit -p packages/vector-store/tsconfig.json

## Notes
- Remaining root audit findings are Next/PostCSS and NextAuth/uuid transitive moderate advisories that require separate breaking dependency work.
- The package test scripts for state-manager/vector-store have no matching tests and exit before running assertions.