### PR TITLE
test(e2e): harden withBypass header merge against non-object HeadersInit

### DIFF
--- a/tests/e2e/pipeline.test.ts
+++ b/tests/e2e/pipeline.test.ts
@@ -39,14 +39,13 @@ const VERCEL_BYPASS_SECRET = process.env.VERCEL_AUTOMATION_BYPASS_SECRET || '';
 /** Merge the Vercel protection-bypass header into a request init, when configured. */
 function withBypass(init?: RequestInit): RequestInit {
   if (!VERCEL_BYPASS_SECRET) return init ?? {};
-  return {
-    ...init,
-    headers: {
-      ...(init?.headers as Record<string, string> | undefined),
-      'x-vercel-protection-bypass': VERCEL_BYPASS_SECRET,
-      'x-vercel-set-bypass-cookie': 'true',
-    },
-  };
+  // Normalize via the Headers constructor so any HeadersInit shape (plain
+  // object, Headers instance, or [key, value][] array) is preserved — a bare
+  // spread would silently drop a Headers/array-typed init.headers.
+  const headers = new Headers(init?.headers);
+  headers.set('x-vercel-protection-bypass', VERCEL_BYPASS_SECRET);
+  headers.set('x-vercel-set-bypass-cookie', 'true');
+  return { ...init, headers };
 }
 
 /** Fetch with a hard timeout and automatic retry for transient network errors. */


### PR DESCRIPTION
## What

Follow-up addressing a review finding on #265: `withBypass` cast `init?.headers` to `Record<string,string>` and spread it, which **silently drops headers** if a caller passes a `Headers` instance or a `[key, value][]` array.

```diff
-  return {
-    ...init,
-    headers: {
-      ...(init?.headers as Record<string, string> | undefined),
-      'x-vercel-protection-bypass': VERCEL_BYPASS_SECRET,
-      'x-vercel-set-bypass-cookie': 'true',
-    },
-  };
+  const headers = new Headers(init?.headers);
+  headers.set('x-vercel-protection-bypass', VERCEL_BYPASS_SECRET);
+  headers.set('x-vercel-set-bypass-cookie', 'true');
+  return { ...init, headers };
```

The `Headers` constructor accepts every `HeadersInit` shape and preserves existing headers.

## Why it was latent, not active
Every current call site passes a plain object (or no headers), so the unsafe cast happened to work and the suite passed 17/17. This hardens the helper against future callers.

## Verification
Ran against production with `VERCEL_AUTOMATION_BYPASS_SECRET` set, exercising both paths through the merge:
- GET smoke check (`beforeAll`) — ✅
- header-setting POST `/api/pipeline/stream` returns `text/event-stream` — ✅ (proves `Content-Type` survives the merge)

## Process note
First PR run through the corrected review loop: opened for CodeRabbit to review before merge, rather than insta-merged. Credit: the original cast was flagged by an automated review on #265.

https://claude.ai/code/session_01KTd1FKQ814af5V1ct3icQN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTd1FKQ814af5V1ct3icQN)_