### PR TITLE
test(e2e): default TEST_YOUTUBE_URL to the approved test video id

### DIFF
--- a/tests/e2e/pipeline.test.ts
+++ b/tests/e2e/pipeline.test.ts
@@ -13,7 +13,7 @@
  * Environment:
  *   BASE_URL — deployment URL (default: https://uvai.io)
  *   TEST_YOUTUBE_URL — short video for pipeline test
- *     (default: https://www.youtube.com/watch?v=dQw4w9WgXcQ — 3:33)
+ *     (default: https://www.youtube.com/watch?v=auJzb1D-fag)
  *
  * Red/Green Signal:
  *   - GREEN: all tests pass → stdout: "✅ ALL TESTS PASSED"
@@ -25,7 +25,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 const BASE_URL = process.env.BASE_URL || 'https://uvai.io';
 const TEST_YOUTUBE_URL =
   process.env.TEST_YOUTUBE_URL ||
-  'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+  'https://www.youtube.com/watch?v=auJzb1D-fag';
 
 // To exercise a protected deployment (e.g. a Vercel preview, which returns 401
 // to anonymous requests), set VERCEL_AUTOMATION_BYPASS_SECRET to the project's

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       BASE_URL: process.env.BASE_URL || 'https://uvai.io',
       TEST_YOUTUBE_URL:
         process.env.TEST_YOUTUBE_URL ||
-        'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        'https://www.youtube.com/watch?v=auJzb1D-fag',
     },
   },
 });


### PR DESCRIPTION
## What

Aligns the `TEST_YOUTUBE_URL` **default** with the repo guideline in `.github/copilot-instructions.md`:

> Always use the default test video ID `auJzb1D-fag` in test data. Never use `dQw4w9WgXcQ` (Rick Roll video).

Both `tests/e2e/pipeline.test.ts` (const + its doc comment) and `vitest.config.ts` still defaulted to the banned `dQw4w9WgXcQ`. CI overrides `TEST_YOUTUBE_URL` via env to the approved id, so it was harmless in CI — but local/default runs violated the guideline.

## Scope (deliberately tight)
- ✅ Swapped the default (and doc comment) in the two test-harness files.
- ⛔️ Left `scripts/testing/verify_tests.py`'s `banned_ids` list untouched — that's the *enforcement* of this very rule.
- ⛔️ Left `src/` schema/example occurrences alone — separate concern, not test data.

## Verification
Ran the suite with **no env override**, so the new vitest-config default (`auJzb1D-fag`) is what's exercised — the pipeline POST is accepted and the test passes. Full CI will exercise it end-to-end.

Found by CodeRabbit's review context on #274.

https://claude.ai/code/session_01KTd1FKQ814af5V1ct3icQN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTd1FKQ814af5V1ct3icQN)_