### PR TITLE
feat(web): add Sentry instrumentation and global error boundary

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,0 +1,19 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+
+  tracesSampleRate: 1,
+
+  debug: false,
+
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+
+  // Enable session replay to debug UI interactions leading to errors in the video workflow
+  integrations: [
+    Sentry.replayIntegration({
+      // ...
+    }),
+  ],
+});

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/nextjs';
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./sentry.server.config');
+  }
+
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    await import('./sentry.edge.config');
+  }
+}

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+
+  // Adjust this value in production, or use tracesSampler for greater control
+  tracesSampleRate: 1,
+
+  // Setting this option to true will print useful information to the console while you're setting up Sentry.
+  debug: false,
+});

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -1,0 +1,14 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+
+  // Adjust this value in production, or use tracesSampler for greater control
+  tracesSampleRate: 1,
+
+  // Setting this option to true will print useful information to the console while you're setting up Sentry.
+  debug: false,
+
+  // Enable performance monitoring for the new waitUntil / middleware / streaming paths
+  // (helps surface issues in background tasks and rate limiting)
+});

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <div style={{ padding: '2rem', fontFamily: 'system-ui' }}>
+          <h2>Something went wrong!</h2>
+          <button onClick={() => reset()}>Try again</button>
+          <pre style={{ whiteSpace: 'pre-wrap', color: 'red' }}>{error.message}</pre>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary

Adds Next.js Sentry SDK wiring for client, server, and edge runtimes plus a global error boundary.

## Changes

- `instrumentation.ts` / `instrumentation-client.ts`
- `sentry.server.config.ts` / `sentry.edge.config.ts`
- `src/app/global-error.tsx`

## Depends on

- `@sentry/nextjs` already in `apps/web/package.json` on `main`
- Set `SENTRY_DSN` (and related env) in Vercel before enabling in production

## Merge order

Land after #295 (test restore) if that PR merges first.