### PR TITLE
chore: remove dead Railway / stale Vercel references

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,7 +1,19 @@
 # EventRelay — Session Handoff & System Documentation
 
+> ⚠️ **OUTDATED (deployment section).** This doc was generated 2026-03-02 and the
+> hosting topology below is no longer accurate. The backend is **no longer on
+> Railway** — `eventrelay-production.up.railway.app` is dead (404). Current
+> production topology (verified 2026-06-16):
+>
+> - **Frontend (canonical):** https://uvai.io (Vercel) — `event-relay-web.vercel.app` is a dead alias.
+> - **Backend:** https://api.uvai.io → Google Cloud Run service `uvai-backend` (us-central1), fronted by Cloudflare. Health: `https://api.uvai.io/api/v1/health`.
+> - Deploy config: `.github/workflows/deploy-cloud-run.yml` (manual dispatch). `railway.toml` is legacy.
+>
+> Treat any "Railway" / `event-relay-web.vercel.app` references in the rest of
+> this document as historical only.
+
 > **Generated**: 2026-03-02 | **Repo**: [groupthinking/EventRelay](https://github.com/groupthinking/EventRelay)  
-> **Frontend**: https://event-relay-web.vercel.app | **Backend**: https://eventrelay-production.up.railway.app
+> **Frontend**: https://uvai.io | **Backend**: https://api.uvai.io (Google Cloud Run)
 
 ---
 

--- a/src/youtube_extension/backend/main.py
+++ b/src/youtube_extension/backend/main.py
@@ -131,8 +131,6 @@ app.add_middleware(
         "http://localhost:5173",
         "http://localhost:8080",
         "http://localhost:3001",
-        "https://event-relay-web.vercel.app",
-        "https://eventrelay-production.up.railway.app",
         "https://uvai.io",
         "https://www.uvai.io",
     ],

--- a/src/youtube_extension/main.py
+++ b/src/youtube_extension/main.py
@@ -36,8 +36,6 @@ app.add_middleware(
         "http://localhost:5173",
         "http://localhost:8080",
         "http://localhost:3001",
-        "https://event-relay-web.vercel.app",
-        "https://eventrelay-production.up.railway.app",
         "https://uvai.io",
         "https://www.uvai.io",
         "https://uvaiio.vercel.app",


### PR DESCRIPTION
## What & why
Cleanup of confirmed-dead deployment references that were misleading docs and agents (this is the stale doc that caused a recent "backend is down" false alarm).

**Verified live 2026-06-16:**
- `eventrelay-production.up.railway.app` → **404 Application not found** (backend is no longer on Railway)
- `event-relay-web.vercel.app` → **404** (dead alias)
- `api.uvai.io/api/v1/health` → **200** (current backend: Google Cloud Run `uvai-backend`, us-central1, via Cloudflare)
- `uvai.io` → **200** (canonical frontend)

## Changes
- **`src/youtube_extension/main.py` + `src/youtube_extension/backend/main.py`**: remove the two dead CORS origins (Railway host + `event-relay-web.vercel.app`). No live client uses either, so this is zero-risk; it just trims the allow-list to real origins (`uvai.io`, `www.uvai.io`, `uvaiio.vercel.app`, localhost).
- **`SESSION_HANDOFF.md`**: add a deprecation banner documenting the current Cloud Run topology and updating the header URLs. The body still contains historical "Railway" mentions; the banner marks them as historical rather than rewriting 30+ lines.

## Not in this PR (flagged for follow-up)
- `docs/deployment/VERCEL_PRODUCTION_RUNBOOK.md` states the live Vercel **`BACKEND_URL` env var still points at the dead Railway host**. If true, the dashboard's server-side routes (`/api/video`, `/api/pipeline/stream`) are calling a dead backend. **Needs verification in the Vercel dashboard** — separate from this cleanup.
- `railway.toml` and other historical Railway mentions in docs left intact.

## Review note
Touches the deployed backend's CORS config, so please review before merging — not auto-merged.