### PR TITLE
docs(ops): refresh Phase 1 gate status after prod env changes

### DIFF
--- a/docs/MASTER_ROADMAP.md
+++ b/docs/MASTER_ROADMAP.md
@@ -66,14 +66,16 @@ flowchart LR
 
 Source: [`docs/deployment/VERCEL_PRODUCTION_RUNBOOK.md`](./deployment/VERCEL_PRODUCTION_RUNBOOK.md)
 
-| Item | Current state | Fix location | Verify |
-|------|---------------|--------------|--------|
-| `BACKEND_URL` | Points at dead Railway host | Vercel → `garv1/v0-uvai` → Env → Production | `curl -sS $BACKEND_URL/api/v1/health` |
-| `api.uvai.io` | 503 | Cloud Run / DNS / service health | `curl -sS https://api.uvai.io/api/v1/health` |
-| `GEMINI_API_KEY` / billing | `BILLING_DISABLED` on project `688578214833` | GCP billing + API enablement | POST `/api/pipeline` with test video |
-| `OPENAI_API_KEY` | `insufficient_quota` | OpenAI project billing | `/api/transcribe` or STT fallback path |
-| `SENTRY_DSN` (web) | Optional — builds without it | Vercel env (Preview + Production) | Trigger test error on preview |
-| `SENTRY_AUTH_TOKEN` | Optional — source maps skipped without it | Vercel env + Sentry project | Build log shows upload or clean skip |
+| Item | Current state (2026-06-17) | Fix location | Verify |
+|------|---------------------------|--------------|--------|
+| `BACKEND_URL` | **Set** → `https://api.uvai.io` on Vercel | Redeploy production after env change | `curl -sS https://api.uvai.io/api/v1/health` |
+| `api.uvai.io` | **200** healthy | Cloud Run min-instances=1 | `curl -sS https://api.uvai.io/api/v1/health` |
+| `GEMINI_API_KEY` / billing | Live probes: no `BILLING_DISABLED` today | GCP billing if regressions return | POST `/api/pipeline` with test video |
+| `OPENAI_API_KEY` | Live probes: transcribe **200** | OpenAI dashboard if regressions return | `/api/transcribe` |
+| `SENTRY_DSN` (web) | **Set** on Vercel (`v0-uvai-web`) | Redeploy + client config PR pending | Deliberate smoke after deploy |
+| `SENTRY_DSN` (backend) | **Set** on Cloud Run (`eventrelay-backend`) | — | Backend logs: Sentry initialized |
+| `SENTRY_AUTH_TOKEN` | Optional — not set | Vercel env + Sentry auth token | Build log shows upload or clean skip |
+| `GITHUB_TOKEN` | **Set** on Vercel | — | Pipeline deploy path (no "token not configured") |
 
 **Smoke script (run after every prod promote):**
 

--- a/docs/deployment/VERCEL_PRODUCTION_RUNBOOK.md
+++ b/docs/deployment/VERCEL_PRODUCTION_RUNBOOK.md
@@ -1,6 +1,6 @@
 # UVAI Vercel Production Runbook
 
-Last reviewed: 2026-06-08
+Last reviewed: 2026-06-17
 
 This runbook tracks the Vercel launch gates for the public UVAI web app at
 `https://uvai.io`. It is intentionally short: code-verifiable items live in the
@@ -50,28 +50,31 @@ shipped code.
 - API routes return bounded JSON errors for bad inputs and provider outages.
 - `/api/docs` redirects to the public docs page at `/docs/api`.
 
-## Production Gates Not Yet Ready
+## Production Gates — Status (2026-06-17)
 
-These are dashboard or provider configuration items, not frontend code changes.
+Operator changes applied on 2026-06-17:
 
-- `BACKEND_URL` must point to a healthy backend. Current checks found:
-  - the Vercel production environment currently reports `BACKEND_URL` host
-    `eventrelay-production.up.railway.app`, which returns Railway
-    `404 Application not found`.
-  - `https://api.uvai.io/api/v1/health` returns `503`.
-  - the Cloud Run candidate returns `500`.
-- `GEMINI_API_KEY` / `GOOGLE_API_KEY` must be replaced with a key from a
-  billable project, or billing must be enabled for Google project
-  `688578214833`. Current provider error: `BILLING_DISABLED` for
-  `aiplatform.googleapis.com`.
-- `OPENAI_API_KEY` must be replaced with a key from a project with available
-  quota, or billing/quota must be fixed for OpenAI project
-  `proj_r6YRYxAKC2FeLk7NUmrBp9wg`. Current provider error:
-  `insufficient_quota`.
-- Where to fix them: Vercel dashboard -> `garv1/v0-uvai` -> Settings ->
-  Environment Variables -> Production values for `BACKEND_URL`,
-  `EVENTRELAY_API_KEY`, `GEMINI_API_KEY` / `GOOGLE_API_KEY`, and
-  `OPENAI_API_KEY`.
+- **Vercel (`garv1/v0-uvai`)**: `BACKEND_URL`, `NEXT_PUBLIC_BACKEND_URL`, and
+  `NEXT_PUBLIC_API_URL` set to `https://api.uvai.io`; `GITHUB_TOKEN` added;
+  `SENTRY_DSN` / `SENTRY_ORG` / `SENTRY_PROJECT` configured for `v0-uvai-web`.
+- **Cloud Run (`uvai-backend`)**: `min-instances=1`; `SENTRY_DSN` +
+  `ENVIRONMENT=production` on service revision.
+- **Sentry (`rdo-llc`)**: projects `v0-uvai-web` and `eventrelay-backend`
+  created and linked to `groupthinking/EventRelay`.
+
+Live verification (post-change):
+
+- `https://api.uvai.io/api/v1/health` → **200** healthy.
+- `https://uvai-backend-gpwz4wb5na-uc.a.run.app/api/v1/health` → **200**.
+- `eventrelay-production.up.railway.app` → **404** (legacy; do not use).
+- `POST /api/transcribe` on `uvai.io` → **200** (OpenAI path working).
+- `POST /api/pipeline` → bounded JSON; backend link may still timeout until
+  the next Vercel production redeploy picks up env changes.
+
+Remaining dashboard items (optional / follow-up):
+
+- `SENTRY_AUTH_TOKEN` on Vercel for source-map upload at build time.
+- Configure Vercel Log Drains for persistent logs.
 - Configure Vercel Log Drains for persistent logs.
 - Configure Vercel WAF/bot rules and any IP blocks required for launch.
 - Configure Deployment Protection for preview deployments.


### PR DESCRIPTION
Updates `VERCEL_PRODUCTION_RUNBOOK.md` and `MASTER_ROADMAP.md` Phase 1 table to reflect 2026-06-17 operator changes:

- Vercel env: `BACKEND_URL` → `https://api.uvai.io`, Sentry + GitHub token
- Cloud Run: min-instances=1, backend `SENTRY_DSN`
- Live verification notes (api.uvai.io 200, providers passing today)

No application code changes.