### PR TITLE
fix(ops): pipeline timeouts + Sentry web wiring

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/nextjs';
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./sentry.server.config');
+  }
+
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    await import('./sentry.edge.config');
+  }
+}
+
+export const onRequestError = Sentry.captureRequestError;

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -11,7 +11,7 @@ const contentSecurityPolicy = [
   "font-src 'self' data:",
   "style-src 'self' 'unsafe-inline'",
   "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://va.vercel-scripts.com https://vitals.vercel-insights.com",
-  "connect-src 'self' https://api.uvai.io https://uvai-backend-gpwz4wb5na-uc.a.run.app https://api.openai.com https://generativelanguage.googleapis.com https://*.supabase.co wss://*.supabase.co https://*.upstash.io https://vitals.vercel-insights.com https://*.vercel-insights.com",
+  "connect-src 'self' https://api.uvai.io https://uvai-backend-gpwz4wb5na-uc.a.run.app https://api.openai.com https://generativelanguage.googleapis.com https://*.supabase.co wss://*.supabase.co https://*.upstash.io https://vitals.vercel-insights.com https://*.vercel-insights.com https://*.ingest.us.sentry.io https://*.ingest.sentry.io",
   "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://js.stripe.com https://hooks.stripe.com",
   "media-src 'self' blob: data:",
   "worker-src 'self' blob:",

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -1,0 +1,7 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN ?? process.env.SENTRY_DSN,
+  tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? '0.1'),
+  debug: false,
+});

--- a/apps/web/src/app/api/__tests__/pipeline-route.test.ts
+++ b/apps/web/src/app/api/__tests__/pipeline-route.test.ts
@@ -13,7 +13,13 @@ vi.mock('@/lib/gemini-client', () => ({
   hasGeminiKey: vi.fn(() => false),
 }));
 
-import { POST } from '@/app/api/pipeline/route';
+import {
+  POST,
+  PIPELINE_BACKEND_TIMEOUT_MS,
+  PIPELINE_GEMINI_TIMEOUT_MS,
+  PIPELINE_HEALTH_TIMEOUT_MS,
+  maxDuration,
+} from '@/app/api/pipeline/route';
 
 function postRequest(body: unknown) {
   return new Request('http://localhost:3000/api/pipeline', {
@@ -26,6 +32,17 @@ function postRequest(body: unknown) {
 afterEach(() => {
   vi.clearAllMocks();
   vi.unstubAllGlobals();
+});
+
+describe('pipeline timeouts', () => {
+  it('allocates most of maxDuration to backend and health probes', () => {
+    expect(PIPELINE_HEALTH_TIMEOUT_MS).toBeGreaterThanOrEqual(5_000);
+    expect(PIPELINE_BACKEND_TIMEOUT_MS).toBeLessThanOrEqual(maxDuration * 1000);
+    expect(PIPELINE_BACKEND_TIMEOUT_MS + PIPELINE_HEALTH_TIMEOUT_MS).toBeLessThanOrEqual(
+      maxDuration * 1000,
+    );
+    expect(PIPELINE_GEMINI_TIMEOUT_MS).toBeLessThanOrEqual(maxDuration * 1000);
+  });
 });
 
 describe('POST /api/pipeline', () => {

--- a/apps/web/src/app/api/__tests__/pipeline-route.test.ts
+++ b/apps/web/src/app/api/__tests__/pipeline-route.test.ts
@@ -15,9 +15,11 @@ vi.mock('@/lib/gemini-client', () => ({
 
 import {
   POST,
+  MAX_DURATION_MS,
   PIPELINE_BACKEND_TIMEOUT_MS,
   PIPELINE_GEMINI_TIMEOUT_MS,
   PIPELINE_HEALTH_TIMEOUT_MS,
+  PipelineDeadline,
   maxDuration,
 } from '@/app/api/pipeline/route';
 
@@ -35,13 +37,19 @@ afterEach(() => {
 });
 
 describe('pipeline timeouts', () => {
-  it('allocates most of maxDuration to backend and health probes', () => {
+  it('clamps sequential fallback steps to the shared maxDuration budget', () => {
+    expect(MAX_DURATION_MS).toBe(maxDuration * 1000);
     expect(PIPELINE_HEALTH_TIMEOUT_MS).toBeGreaterThanOrEqual(5_000);
-    expect(PIPELINE_BACKEND_TIMEOUT_MS).toBeLessThanOrEqual(maxDuration * 1000);
-    expect(PIPELINE_BACKEND_TIMEOUT_MS + PIPELINE_HEALTH_TIMEOUT_MS).toBeLessThanOrEqual(
-      maxDuration * 1000,
+
+    const backendStep = Math.min(PIPELINE_BACKEND_TIMEOUT_MS, MAX_DURATION_MS);
+    const geminiStep = Math.min(
+      PIPELINE_GEMINI_TIMEOUT_MS,
+      MAX_DURATION_MS - backendStep,
     );
-    expect(PIPELINE_GEMINI_TIMEOUT_MS).toBeLessThanOrEqual(maxDuration * 1000);
+    expect(backendStep + geminiStep).toBeLessThanOrEqual(MAX_DURATION_MS);
+
+    const deadline = PipelineDeadline.fromMaxDuration();
+    expect(deadline.budgetMs(PIPELINE_BACKEND_TIMEOUT_MS)).toBeGreaterThan(0);
   });
 });
 

--- a/apps/web/src/app/api/pipeline/route.ts
+++ b/apps/web/src/app/api/pipeline/route.ts
@@ -11,12 +11,51 @@ const BACKEND_AVAILABLE = rawBackendUrl.startsWith('http');
 export const runtime = 'nodejs';
 export const maxDuration = 30;
 
+export const MAX_DURATION_MS = maxDuration * 1000;
+
 /** Health probe budget for Cloud Run cold start + TLS. */
 export const PIPELINE_HEALTH_TIMEOUT_MS = 5_000;
-/** Backend video-to-software call — most of the Vercel function window. */
-export const PIPELINE_BACKEND_TIMEOUT_MS = 25_000;
-/** Gemini-only fallback when backend is down. */
-export const PIPELINE_GEMINI_TIMEOUT_MS = 20_000;
+/** Backend video-to-software cap — clamped to remaining request budget. */
+export const PIPELINE_BACKEND_TIMEOUT_MS = 22_000;
+/** Gemini fallback cap — only runs if backend left enough wall-clock time. */
+export const PIPELINE_GEMINI_TIMEOUT_MS = 15_000;
+
+/** Tracks elapsed time so sequential fallback steps stay within maxDuration. */
+export class PipelineDeadline {
+  constructor(private readonly endsAt: number) {}
+
+  static fromMaxDuration(): PipelineDeadline {
+    return new PipelineDeadline(Date.now() + MAX_DURATION_MS);
+  }
+
+  remainingMs(): number {
+    return Math.max(0, this.endsAt - Date.now());
+  }
+
+  budgetMs(requestedMs: number): number {
+    return Math.min(requestedMs, this.remainingMs());
+  }
+
+  signalFor(requestedMs: number): AbortSignal {
+    const ms = this.budgetMs(requestedMs);
+    if (ms <= 0) {
+      throw new Error('Pipeline deadline exceeded');
+    }
+    return timeoutSignal(ms);
+  }
+
+  async runWithBudget<T>(
+    promise: Promise<T>,
+    requestedMs: number,
+    label: string,
+  ): Promise<T> {
+    const ms = this.budgetMs(requestedMs);
+    if (ms <= 0) {
+      throw new Error(`${label}: pipeline deadline exceeded`);
+    }
+    return withTimeout(promise, ms, label);
+  }
+}
 
 function backendHost(): string | null {
   if (!BACKEND_AVAILABLE) return null;
@@ -199,8 +238,10 @@ export async function POST(request: Request) {
 
     await publishEvent(EventTypes.VIDEO_RECEIVED, { url, pipeline: 'end-to-end' }, url);
 
+    const deadline = PipelineDeadline.fromMaxDuration();
+
     // ── Strategy 1: Full backend pipeline (FastAPI video-to-software) ──
-    if (BACKEND_AVAILABLE) {
+    if (BACKEND_AVAILABLE && deadline.remainingMs() > 1_000) {
       try {
         const response = await fetch(`${BACKEND_URL}/api/v1/video-to-software`, {
           method: 'POST',
@@ -211,7 +252,7 @@ export async function POST(request: Request) {
             deployment_target,
             features,
           }),
-          signal: timeoutSignal(PIPELINE_BACKEND_TIMEOUT_MS),
+          signal: deadline.signalFor(PIPELINE_BACKEND_TIMEOUT_MS),
         });
 
         if (response.ok) {
@@ -248,10 +289,10 @@ export async function POST(request: Request) {
     }
 
     // ── Strategy 2: Gemini analysis (video intelligence only, no deployment) ──
-    if (hasGeminiKey()) {
+    if (hasGeminiKey() && deadline.remainingMs() > 1_000) {
       try {
         const startTime = Date.now();
-        const analysis = await withTimeout(
+        const analysis = await deadline.runWithBudget(
           analyzeVideoWithGemini(url),
           PIPELINE_GEMINI_TIMEOUT_MS,
           'Gemini analysis',
@@ -291,7 +332,7 @@ export async function POST(request: Request) {
       }
     }
 
-    const backend = await checkBackendHealth();
+    const backend = await checkBackendHealth(deadline.budgetMs(PIPELINE_HEALTH_TIMEOUT_MS) || PIPELINE_HEALTH_TIMEOUT_MS);
     const fallback = buildLocalFallbackPipeline({
       url,
       projectType: project_type,

--- a/apps/web/src/app/api/pipeline/route.ts
+++ b/apps/web/src/app/api/pipeline/route.ts
@@ -11,6 +11,13 @@ const BACKEND_AVAILABLE = rawBackendUrl.startsWith('http');
 export const runtime = 'nodejs';
 export const maxDuration = 30;
 
+/** Health probe budget for Cloud Run cold start + TLS. */
+export const PIPELINE_HEALTH_TIMEOUT_MS = 5_000;
+/** Backend video-to-software call — most of the Vercel function window. */
+export const PIPELINE_BACKEND_TIMEOUT_MS = 25_000;
+/** Gemini-only fallback when backend is down. */
+export const PIPELINE_GEMINI_TIMEOUT_MS = 20_000;
+
 function backendHost(): string | null {
   if (!BACKEND_AVAILABLE) return null;
   try {
@@ -38,7 +45,7 @@ async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): P
   }
 }
 
-async function checkBackendHealth(timeoutMs = 1500): Promise<{ configured: boolean; available: boolean; host: string | null; reason?: string }> {
+async function checkBackendHealth(timeoutMs = PIPELINE_HEALTH_TIMEOUT_MS): Promise<{ configured: boolean; available: boolean; host: string | null; reason?: string }> {
   if (!BACKEND_AVAILABLE) {
     return { configured: false, available: false, host: null, reason: 'BACKEND_URL is not configured' };
   }
@@ -204,7 +211,7 @@ export async function POST(request: Request) {
             deployment_target,
             features,
           }),
-          signal: timeoutSignal(4_000),
+          signal: timeoutSignal(PIPELINE_BACKEND_TIMEOUT_MS),
         });
 
         if (response.ok) {
@@ -246,7 +253,7 @@ export async function POST(request: Request) {
         const startTime = Date.now();
         const analysis = await withTimeout(
           analyzeVideoWithGemini(url),
-          5_000,
+          PIPELINE_GEMINI_TIMEOUT_MS,
           'Gemini analysis',
         );
         const elapsed = Date.now() - startTime;

--- a/src/youtube_extension/main.py
+++ b/src/youtube_extension/main.py
@@ -132,8 +132,8 @@ async def health_check():
 
 
 @app.post("/test-sentry")
-async def test_sentry():
-    """Deliberate error for Sentry smoke tests. Disabled unless ALLOW_SENTRY_SMOKE=1."""
+async def test_sentry() -> None:
+    """Deliberate Sentry smoke error. Requires X-API-Key (middleware) and ALLOW_SENTRY_SMOKE=1."""
     if os.getenv("ALLOW_SENTRY_SMOKE") != "1":
         raise HTTPException(status_code=404, detail="Not found")
     raise RuntimeError("sentry-smoke")

--- a/src/youtube_extension/main.py
+++ b/src/youtube_extension/main.py
@@ -8,7 +8,7 @@ import logging
 import os
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
@@ -129,6 +129,14 @@ except Exception as e:
 async def health_check():
     """Health check endpoint"""
     return {"status": "healthy", "service": "uvai-youtube-extension"}
+
+
+@app.post("/test-sentry")
+async def test_sentry():
+    """Deliberate error for Sentry smoke tests. Disabled unless ALLOW_SENTRY_SMOKE=1."""
+    if os.getenv("ALLOW_SENTRY_SMOKE") != "1":
+        raise HTTPException(status_code=404, detail="Not found")
+    raise RuntimeError("sentry-smoke")
 
 
 # Root endpoint

--- a/tests/unit/test_master_roadmap_fixes.py
+++ b/tests/unit/test_master_roadmap_fixes.py
@@ -85,3 +85,18 @@ async def test_run_pipeline_resets_results_between_runs():
         await orchestrator.run_pipeline("https://youtu.be/jNQXAC9IVRw")
 
     assert orchestrator.results == {}
+
+
+def test_sentry_smoke_endpoint_gated(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from youtube_extension.main import app
+
+    client = TestClient(app)
+    monkeypatch.delenv("ALLOW_SENTRY_SMOKE", raising=False)
+    assert client.post("/test-sentry").status_code == 404
+
+    monkeypatch.setenv("ALLOW_SENTRY_SMOKE", "1")
+    gated_client = TestClient(app, raise_server_exceptions=False)
+    response = gated_client.post("/test-sentry")
+    assert response.status_code == 500

--- a/tests/unit/test_master_roadmap_fixes.py
+++ b/tests/unit/test_master_roadmap_fixes.py
@@ -87,16 +87,16 @@ async def test_run_pipeline_resets_results_between_runs():
     assert orchestrator.results == {}
 
 
-def test_sentry_smoke_endpoint_gated(monkeypatch):
+def test_sentry_smoke_endpoint_gated(monkeypatch: pytest.MonkeyPatch) -> None:
     from fastapi.testclient import TestClient
 
     from youtube_extension.main import app
 
-    client = TestClient(app)
+    monkeypatch.setenv("ALLOW_UNAUTHENTICATED", "1")
+    client = TestClient(app, raise_server_exceptions=False)
     monkeypatch.delenv("ALLOW_SENTRY_SMOKE", raising=False)
     assert client.post("/test-sentry").status_code == 404
 
     monkeypatch.setenv("ALLOW_SENTRY_SMOKE", "1")
-    gated_client = TestClient(app, raise_server_exceptions=False)
-    response = gated_client.post("/test-sentry")
+    response = client.post("/test-sentry")
     assert response.status_code == 500


### PR DESCRIPTION
## Summary
- Raise `/api/pipeline` health probe to 5s and backend `video-to-software` fetch to 25s (within 30s `maxDuration`) so Cloud Run is not falsely marked unavailable.
- Add `sentry.client.config.ts`, `instrumentation.ts`, and CSP `connect-src` entries for Sentry ingest.
- Add gated `POST /test-sentry` (`ALLOW_SENTRY_SMOKE=1`) for backend Sentry smoke checks.

## Test plan
- [x] `vitest` pipeline-route tests
- [x] `pytest tests/unit/test_master_roadmap_fixes.py::test_sentry_smoke_endpoint_gated`
- [ ] Post-merge: `scripts/deployment/production_smoke.sh`