### PR TITLE
fix(pipeline): stream API key on job poll, async jobs, smoke SSE path

### DIFF
--- a/apps/web/src/app/api/__tests__/pipeline-route.test.ts
+++ b/apps/web/src/app/api/__tests__/pipeline-route.test.ts
@@ -41,12 +41,8 @@ describe('pipeline timeouts', () => {
     expect(MAX_DURATION_MS).toBe(maxDuration * 1000);
     expect(PIPELINE_HEALTH_TIMEOUT_MS).toBeGreaterThanOrEqual(5_000);
 
-    const backendStep = Math.min(PIPELINE_BACKEND_TIMEOUT_MS, MAX_DURATION_MS);
-    const geminiStep = Math.min(
-      PIPELINE_GEMINI_TIMEOUT_MS,
-      MAX_DURATION_MS - backendStep,
-    );
-    expect(backendStep + geminiStep).toBeLessThanOrEqual(MAX_DURATION_MS);
+    expect(PIPELINE_BACKEND_TIMEOUT_MS).toBeLessThanOrEqual(MAX_DURATION_MS);
+    expect(PIPELINE_GEMINI_TIMEOUT_MS).toBeLessThanOrEqual(MAX_DURATION_MS);
 
     const deadline = PipelineDeadline.fromMaxDuration();
     expect(deadline.budgetMs(PIPELINE_BACKEND_TIMEOUT_MS)).toBeGreaterThan(0);

--- a/apps/web/src/app/api/jobs/[jobId]/route.ts
+++ b/apps/web/src/app/api/jobs/[jobId]/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { backendHeaders } from '@/lib/pipeline-backend';
+
+const rawBackendUrl = process.env.BACKEND_URL || '';
+const BACKEND_URL = rawBackendUrl.startsWith('http') ? rawBackendUrl : '';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/jobs/{jobId}
+ *
+ * Proxies backend async video job status (see-script-ship / Phase 4 contract).
+ */
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ jobId: string }> },
+) {
+  const { jobId } = await context.params;
+
+  if (!jobId?.trim()) {
+    return NextResponse.json({ error: 'jobId is required' }, { status: 400 });
+  }
+
+  if (!BACKEND_URL) {
+    return NextResponse.json({ error: 'BACKEND_URL is not configured' }, { status: 503 });
+  }
+
+  try {
+    const response = await fetch(`${BACKEND_URL}/api/v1/jobs/${encodeURIComponent(jobId)}`, {
+      cache: 'no-store',
+      headers: backendHeaders(),
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    const body = await response.text();
+    return new NextResponse(body, {
+      status: response.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/web/src/app/api/pipeline/route.ts
+++ b/apps/web/src/app/api/pipeline/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { publishEvent, EventTypes } from '@/lib/cloudevents';
 import { analyzeVideoWithGemini } from '@/lib/gemini-video-analyzer';
 import { hasGeminiKey } from '@/lib/gemini-client';
+import { backendHeaders } from '@/lib/pipeline-backend';
 import { resolveVideoUrl } from '@/lib/video-url-request';
 
 const rawBackendUrl = process.env.BACKEND_URL || '';
@@ -9,14 +10,15 @@ const BACKEND_URL = rawBackendUrl.startsWith('http') ? rawBackendUrl : 'http://l
 const BACKEND_AVAILABLE = rawBackendUrl.startsWith('http');
 
 export const runtime = 'nodejs';
-export const maxDuration = 30;
+/** Sync route — short budget; use /api/pipeline/stream or async=true for long runs. */
+export const maxDuration = 60;
 
 export const MAX_DURATION_MS = maxDuration * 1000;
 
 /** Health probe budget for Cloud Run cold start + TLS. */
 export const PIPELINE_HEALTH_TIMEOUT_MS = 5_000;
 /** Backend video-to-software cap — clamped to remaining request budget. */
-export const PIPELINE_BACKEND_TIMEOUT_MS = 22_000;
+export const PIPELINE_BACKEND_TIMEOUT_MS = 50_000;
 /** Gemini fallback cap — only runs if backend left enough wall-clock time. */
 export const PIPELINE_GEMINI_TIMEOUT_MS = 15_000;
 
@@ -239,13 +241,47 @@ export async function POST(request: Request) {
     await publishEvent(EventTypes.VIDEO_RECEIVED, { url, pipeline: 'end-to-end' }, url);
 
     const deadline = PipelineDeadline.fromMaxDuration();
+    const asyncMode = body.async === true || body.async === 'true';
+
+    // ── Strategy 0: Async kickoff (returns job_id immediately) ──
+    if (asyncMode && BACKEND_AVAILABLE) {
+      try {
+        const response = await fetch(`${BACKEND_URL}/api/v1/transcript-action`, {
+          method: 'POST',
+          headers: backendHeaders(),
+          body: JSON.stringify({
+            video_url: url,
+            language: stringValue(body.language, 'en'),
+          }),
+          signal: deadline.signalFor(10_000),
+        });
+
+        if (response.ok) {
+          const result = await response.json();
+          const jobId = typeof result.job_id === 'string' ? result.job_id : undefined;
+
+          return NextResponse.json({
+            id: jobId || `pipeline_${Date.now().toString(36)}`,
+            status: result.async_processing ? 'pending' : (result.success ? 'complete' : 'failed'),
+            pipeline: 'backend-async',
+            async_processing: Boolean(result.async_processing),
+            job_id: jobId,
+            status_url: jobId ? `/api/jobs/${jobId}` : result.status_url,
+            result: result.async_processing ? undefined : result,
+          });
+        }
+        console.warn(`Async transcript-action returned ${response.status}, falling back`);
+      } catch (e) {
+        console.warn('Async pipeline kickoff failed:', e);
+      }
+    }
 
     // ── Strategy 1: Full backend pipeline (FastAPI video-to-software) ──
     if (BACKEND_AVAILABLE && deadline.remainingMs() > 1_000) {
       try {
         const response = await fetch(`${BACKEND_URL}/api/v1/video-to-software`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...(process.env.EVENTRELAY_API_KEY ? { 'X-API-Key': process.env.EVENTRELAY_API_KEY } : {}) },
+          headers: backendHeaders(),
           body: JSON.stringify({
             video_url: url,
             project_type,

--- a/apps/web/src/app/api/pipeline/route.ts
+++ b/apps/web/src/app/api/pipeline/route.ts
@@ -259,6 +259,18 @@ export async function POST(request: Request) {
         if (response.ok) {
           const result = await response.json();
           const jobId = typeof result.job_id === 'string' ? result.job_id : undefined;
+          const backendStatusUrl =
+            typeof result.status_url === 'string' ? result.status_url : undefined;
+          const statusUrl = jobId ? `/api/jobs/${jobId}` : backendStatusUrl;
+
+          if (result.async_processing && !statusUrl) {
+            return NextResponse.json(
+              {
+                error: 'Async processing started but backend returned no job_id or status_url',
+              },
+              { status: 502 },
+            );
+          }
 
           return NextResponse.json({
             id: jobId || `pipeline_${Date.now().toString(36)}`,
@@ -266,7 +278,7 @@ export async function POST(request: Request) {
             pipeline: 'backend-async',
             async_processing: Boolean(result.async_processing),
             job_id: jobId,
-            status_url: jobId ? `/api/jobs/${jobId}` : result.status_url,
+            status_url: statusUrl,
             result: result.async_processing ? undefined : result,
           });
         }

--- a/apps/web/src/app/api/pipeline/stream/route.ts
+++ b/apps/web/src/app/api/pipeline/stream/route.ts
@@ -166,7 +166,9 @@ async function pollBackendJob(
       throw new Error('Stream pipeline deadline exceeded while polling async job');
     }
 
-    await sleep(JOB_POLL_INTERVAL_MS);
+    if (attempt > 0) {
+      await sleep(JOB_POLL_INTERVAL_MS);
+    }
 
     try {
       const response = await fetch(statusUrl, {

--- a/apps/web/src/app/api/pipeline/stream/route.ts
+++ b/apps/web/src/app/api/pipeline/stream/route.ts
@@ -22,7 +22,9 @@
 import { analyzeVideoWithGemini, type VideoAnalysisResult } from '@/lib/gemini-video-analyzer';
 import { hasGeminiKey } from '@/lib/gemini-client';
 import { publishEvent, EventTypes } from '@/lib/cloudevents';
+import { backendHeaders } from '@/lib/pipeline-backend';
 import { saveTrainingExample, TUNING_THRESHOLD } from '@/lib/training-store';
+import { PipelineDeadline } from '../route';
 
 const rawBackendUrl = process.env.BACKEND_URL || '';
 const BACKEND_URL = rawBackendUrl.startsWith('http') ? rawBackendUrl : '';
@@ -31,6 +33,11 @@ const MAX_JOB_POLL_ATTEMPTS = 90;
 
 export const runtime = 'nodejs';
 export const maxDuration = 240;
+
+/** Wall-clock budget for the full SSE response (poll + agent events). */
+export const STREAM_MAX_DURATION_MS = maxDuration * 1000;
+/** Initial transcript-action kickoff — clamped to remaining stream budget. */
+export const STREAM_BACKEND_KICKOFF_MS = 120_000;
 
 /** Shape of each SSE message sent to the frontend. */
 interface AgentStreamEvent {
@@ -150,19 +157,22 @@ async function pollBackendJob(
   statusUrl: string,
   controller: ReadableStreamDefaultController<Uint8Array>,
   encoder: TextEncoder,
+  deadline: PipelineDeadline,
 ): Promise<BackendVideoJobStatus> {
   let lastError: Error | null = null;
 
   for (let attempt = 0; attempt < MAX_JOB_POLL_ATTEMPTS; attempt += 1) {
+    if (deadline.remainingMs() <= JOB_POLL_INTERVAL_MS) {
+      throw new Error('Stream pipeline deadline exceeded while polling async job');
+    }
+
     await sleep(JOB_POLL_INTERVAL_MS);
 
     try {
       const response = await fetch(statusUrl, {
         cache: 'no-store',
-        headers: { 'Content-Type': 'application/json' },
-        // Bound each poll so a hung status endpoint can't stall the SSE stream;
-        // a timeout throws → caught below → retried within MAX_JOB_POLL_ATTEMPTS.
-        signal: AbortSignal.timeout(JOB_POLL_INTERVAL_MS * 2),
+        headers: backendHeaders(),
+        signal: deadline.signalFor(JOB_POLL_INTERVAL_MS * 2),
       });
 
       if (!response.ok) {
@@ -529,6 +539,7 @@ export async function POST(request: Request) {
 
     const encoder = new TextEncoder();
     const startTime = Date.now();
+    const deadline = new PipelineDeadline(Date.now() + STREAM_MAX_DURATION_MS);
 
     const stream = new ReadableStream({
       async start(controller) {
@@ -608,9 +619,9 @@ export async function POST(request: Request) {
             try {
               const response = await fetch(`${BACKEND_URL}/api/v1/transcript-action`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json', ...(process.env.EVENTRELAY_API_KEY ? { 'X-API-Key': process.env.EVENTRELAY_API_KEY } : {}) },
+                headers: backendHeaders(),
                 body: JSON.stringify({ video_url: url, language: 'en' }),
-                signal: AbortSignal.timeout(120_000),
+                signal: deadline.signalFor(STREAM_BACKEND_KICKOFF_MS),
               });
 
               if (response.ok) {
@@ -637,7 +648,7 @@ export async function POST(request: Request) {
                   const statusUrl = transcriptResult.status_url.startsWith('http')
                     ? transcriptResult.status_url
                     : `${BACKEND_URL}${transcriptResult.status_url}`;
-                  const job = await pollBackendJob(statusUrl, controller, encoder);
+                  const job = await pollBackendJob(statusUrl, controller, encoder, deadline);
                   if (job.status === 'failed') {
                     throw new Error(job.error || 'Async transcript job failed');
                   }
@@ -676,8 +687,12 @@ export async function POST(request: Request) {
             } catch (backendErr) {
               // Fall through to Gemini if backend fails
               console.warn('Backend stream failed, falling through to Gemini:', backendErr);
-              if (hasGeminiKey()) {
-                const analysis = await analyzeVideoWithGemini(url);
+              if (hasGeminiKey() && deadline.remainingMs() > 1_000) {
+                const analysis = await deadline.runWithBudget(
+                  analyzeVideoWithGemini(url),
+                  deadline.remainingMs(),
+                  'Gemini stream fallback',
+                );
 
                 // Stream all agent events including pipeline_status:complete
                 for await (const event of generateAgentEvents(analysis, startTime)) {
@@ -704,7 +719,11 @@ export async function POST(request: Request) {
               await publishEvent(EventTypes.TRANSCRIPT_STARTED, { url, strategy: 'gemini-stream' }, url);
             });
 
-            const analysis = await analyzeVideoWithGemini(url);
+            const analysis = await deadline.runWithBudget(
+              analyzeVideoWithGemini(url),
+              deadline.remainingMs(),
+              'Gemini stream analysis',
+            );
 
             // Stream all agent events including pipeline_status:complete
             for await (const event of generateAgentEvents(analysis, startTime)) {

--- a/apps/web/src/app/api/pipeline/stream/route.ts
+++ b/apps/web/src/app/api/pipeline/stream/route.ts
@@ -22,7 +22,7 @@
 import { analyzeVideoWithGemini, type VideoAnalysisResult } from '@/lib/gemini-video-analyzer';
 import { hasGeminiKey } from '@/lib/gemini-client';
 import { publishEvent, EventTypes } from '@/lib/cloudevents';
-import { backendHeaders } from '@/lib/pipeline-backend';
+import { backendHeaders, resolveBackendStatusUrl } from '@/lib/pipeline-backend';
 import { saveTrainingExample, TUNING_THRESHOLD } from '@/lib/training-store';
 import { PipelineDeadline } from '../route';
 
@@ -645,9 +645,10 @@ export async function POST(request: Request) {
                     ),
                   );
 
-                  const statusUrl = transcriptResult.status_url.startsWith('http')
-                    ? transcriptResult.status_url
-                    : `${BACKEND_URL}${transcriptResult.status_url}`;
+                  const statusUrl = resolveBackendStatusUrl(
+                    transcriptResult.status_url,
+                    BACKEND_URL,
+                  );
                   const job = await pollBackendJob(statusUrl, controller, encoder, deadline);
                   if (job.status === 'failed') {
                     throw new Error(job.error || 'Async transcript job failed');

--- a/apps/web/src/lib/__tests__/pipeline-backend.test.ts
+++ b/apps/web/src/lib/__tests__/pipeline-backend.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { backendHeaders } from '@/lib/pipeline-backend';
+
+describe('backendHeaders', () => {
+  const original = process.env.EVENTRELAY_API_KEY;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.EVENTRELAY_API_KEY;
+    } else {
+      process.env.EVENTRELAY_API_KEY = original;
+    }
+  });
+
+  it('includes trimmed X-API-Key when configured', () => {
+    process.env.EVENTRELAY_API_KEY = '  test-key\n';
+    expect(backendHeaders()).toEqual({
+      'Content-Type': 'application/json',
+      'X-API-Key': 'test-key',
+    });
+  });
+
+  it('omits X-API-Key when unset', () => {
+    delete process.env.EVENTRELAY_API_KEY;
+    expect(backendHeaders()).toEqual({ 'Content-Type': 'application/json' });
+  });
+});

--- a/apps/web/src/lib/__tests__/pipeline-backend.test.ts
+++ b/apps/web/src/lib/__tests__/pipeline-backend.test.ts
@@ -24,6 +24,14 @@ describe('backendHeaders', () => {
     delete process.env.EVENTRELAY_API_KEY;
     expect(backendHeaders()).toEqual({ 'Content-Type': 'application/json' });
   });
+
+  it('merges extra headers', () => {
+    delete process.env.EVENTRELAY_API_KEY;
+    expect(backendHeaders({ Accept: 'application/json' })).toEqual({
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    });
+  });
 });
 
 describe('resolveBackendStatusUrl', () => {
@@ -31,6 +39,12 @@ describe('resolveBackendStatusUrl', () => {
 
   it('accepts relative paths on the configured backend', () => {
     expect(resolveBackendStatusUrl('/api/v1/jobs/abc', backend)).toBe(
+      'https://api.uvai.io/api/v1/jobs/abc',
+    );
+  });
+
+  it('accepts relative paths without a leading slash', () => {
+    expect(resolveBackendStatusUrl('api/v1/jobs/abc', backend)).toBe(
       'https://api.uvai.io/api/v1/jobs/abc',
     );
   });

--- a/apps/web/src/lib/__tests__/pipeline-backend.test.ts
+++ b/apps/web/src/lib/__tests__/pipeline-backend.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { backendHeaders } from '@/lib/pipeline-backend';
+import { backendHeaders, resolveBackendStatusUrl } from '@/lib/pipeline-backend';
 
 describe('backendHeaders', () => {
   const original = process.env.EVENTRELAY_API_KEY;
@@ -23,5 +23,27 @@ describe('backendHeaders', () => {
   it('omits X-API-Key when unset', () => {
     delete process.env.EVENTRELAY_API_KEY;
     expect(backendHeaders()).toEqual({ 'Content-Type': 'application/json' });
+  });
+});
+
+describe('resolveBackendStatusUrl', () => {
+  const backend = 'https://api.uvai.io';
+
+  it('accepts relative paths on the configured backend', () => {
+    expect(resolveBackendStatusUrl('/api/v1/jobs/abc', backend)).toBe(
+      'https://api.uvai.io/api/v1/jobs/abc',
+    );
+  });
+
+  it('accepts absolute URLs on the configured backend origin', () => {
+    expect(resolveBackendStatusUrl('https://api.uvai.io/api/v1/jobs/abc', backend)).toBe(
+      'https://api.uvai.io/api/v1/jobs/abc',
+    );
+  });
+
+  it('rejects untrusted origins', () => {
+    expect(() =>
+      resolveBackendStatusUrl('https://evil.example/jobs/abc', backend),
+    ).toThrow(/untrusted origin/);
   });
 });

--- a/apps/web/src/lib/pipeline-backend.ts
+++ b/apps/web/src/lib/pipeline-backend.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared headers for Next.js → FastAPI backend calls.
+ * Trims EVENTRELAY_API_KEY to avoid Secret Manager newline mismatches.
+ */
+export function backendHeaders(extra?: Record<string, string>): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...extra,
+  };
+  const apiKey = process.env.EVENTRELAY_API_KEY?.trim();
+  if (apiKey) {
+    headers['X-API-Key'] = apiKey;
+  }
+  return headers;
+}

--- a/apps/web/src/lib/pipeline-backend.ts
+++ b/apps/web/src/lib/pipeline-backend.ts
@@ -13,3 +13,20 @@ export function backendHeaders(extra?: Record<string, string>): Record<string, s
   }
   return headers;
 }
+
+/** Resolve and validate a backend job status URL (blocks SSRF before sending API key). */
+export function resolveBackendStatusUrl(statusUrl: string, backendUrl: string): string {
+  const backendOrigin = new URL(backendUrl).origin;
+  const base = backendUrl.replace(/\/$/, '');
+  const resolved = statusUrl.startsWith('http')
+    ? statusUrl
+    : `${base}${statusUrl.startsWith('/') ? statusUrl : `/${statusUrl}`}`;
+
+  const parsed = new URL(resolved);
+  if (parsed.origin !== backendOrigin) {
+    throw new Error(
+      `Refusing to poll job status at untrusted origin ${parsed.origin} (expected ${backendOrigin})`,
+    );
+  }
+  return parsed.toString();
+}

--- a/scripts/deployment/production_smoke.sh
+++ b/scripts/deployment/production_smoke.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 BASE_URL="${UVAI_SMOKE_BASE_URL:-https://uvai.io}"
 TEST_VIDEO_URL="${TEST_YOUTUBE_URL:-https://www.youtube.com/watch?v=jNQXAC9IVRw}"
+STREAM_TIMEOUT_SEC="${UVAI_STREAM_SMOKE_TIMEOUT:-200}"
 
 echo "== UVAI production smoke: ${BASE_URL} =="
 
@@ -16,11 +17,56 @@ echo "-- Pipeline metadata"
 curl -sS "${BASE_URL}/api/pipeline" | head -c 400
 echo
 
-echo "-- Pipeline POST (bounded response expected)"
-curl -sS -X POST "${BASE_URL}/api/pipeline" \
+echo "-- Pipeline async kickoff (fast path; requires deployed async=true handler)"
+set +e
+async_body=$(curl -sS -X POST "${BASE_URL}/api/pipeline" \
   -H 'content-type: application/json' \
-  --data "{\"url\":\"${TEST_VIDEO_URL}\"}" | head -c 600
-echo
+  --data "{\"url\":\"${TEST_VIDEO_URL}\",\"async\":true}" \
+  --max-time 15)
+async_rc=$?
+set -e
+if [[ "${async_rc}" -eq 28 ]]; then
+  echo "WARN: async kickoff timed out — production may still run sync video-to-software; deploy latest web"
+elif echo "${async_body}" | grep -qE '"job_id"|"status":"complete"'; then
+  echo "${async_body}" | head -c 600
+  echo
+  echo "OK: async pipeline kickoff responded"
+else
+  echo "${async_body}" | head -c 600
+  echo
+  echo "WARN: async kickoff missing job_id/complete — check BACKEND_URL + EVENTRELAY_API_KEY"
+fi
+
+echo "-- Pipeline stream SSE (bounded, primary long-path check)"
+stream_tmp=$(mktemp)
+trap 'rm -f "${stream_tmp}"' EXIT
+
+stream_code=$(curl -sS -o "${stream_tmp}" -w '%{http_code}' -X POST "${BASE_URL}/api/pipeline/stream" \
+  -H 'content-type: application/json' \
+  -H 'accept: text/event-stream' \
+  --data "{\"url\":\"${TEST_VIDEO_URL}\"}" \
+  --max-time "${STREAM_TIMEOUT_SEC}")
+
+echo "stream HTTP ${stream_code} (expect 200)"
+if [[ "${stream_code}" != "200" ]]; then
+  echo "FAIL: pipeline stream returned ${stream_code}"
+  head -c 800 "${stream_tmp}" || true
+  echo
+  exit 1
+fi
+
+if grep -q '"type":"pipeline_status"' "${stream_tmp}" && grep -q '"status":"complete"' "${stream_tmp}"; then
+  echo "OK: stream reached pipeline_status complete"
+elif grep -q '"type":"pipeline_status"' "${stream_tmp}" && grep -q '"status":"error"' "${stream_tmp}"; then
+  echo "FAIL: stream ended with pipeline_status error"
+  tail -c 1200 "${stream_tmp}" || true
+  echo
+  exit 1
+else
+  echo "WARN: stream closed without terminal pipeline_status (degraded/Gemini-only mode?)"
+  head -c 800 "${stream_tmp}" || true
+  echo
+fi
 
 echo "-- Realtime SDP validation"
 code=$(curl -sS -o /dev/null -w '%{http_code}' -X POST "${BASE_URL}/api/realtime/session" \

--- a/scripts/deployment/production_smoke.sh
+++ b/scripts/deployment/production_smoke.sh
@@ -26,7 +26,8 @@ async_body=$(curl -sS -X POST "${BASE_URL}/api/pipeline" \
 async_rc=$?
 set -e
 if [[ "${async_rc}" -eq 28 ]]; then
-  echo "WARN: async kickoff timed out — production may still run sync video-to-software; deploy latest web"
+  echo "FAIL: async kickoff timed out — deploy latest web with async=true handler"
+  exit 1
 elif echo "${async_body}" | grep -qE '"job_id"|"status":"complete"'; then
   echo "${async_body}" | head -c 600
   echo
@@ -34,7 +35,8 @@ elif echo "${async_body}" | grep -qE '"job_id"|"status":"complete"'; then
 else
   echo "${async_body}" | head -c 600
   echo
-  echo "WARN: async kickoff missing job_id/complete — check BACKEND_URL + EVENTRELAY_API_KEY"
+  echo "FAIL: async kickoff missing job_id/complete — check BACKEND_URL + EVENTRELAY_API_KEY"
+  exit 1
 fi
 
 echo "-- Pipeline stream SSE (bounded, primary long-path check)"
@@ -55,17 +57,24 @@ if [[ "${stream_code}" != "200" ]]; then
   exit 1
 fi
 
-if grep -q '"type":"pipeline_status"' "${stream_tmp}" && grep -q '"status":"complete"' "${stream_tmp}"; then
+terminal_status=$(
+  grep '"type":"pipeline_status"' "${stream_tmp}" \
+    | sed -n 's/.*"status":"\([^"]*\)".*/\1/p' \
+    | tail -n 1
+)
+
+if [[ "${terminal_status}" == "complete" ]]; then
   echo "OK: stream reached pipeline_status complete"
-elif grep -q '"type":"pipeline_status"' "${stream_tmp}" && grep -q '"status":"error"' "${stream_tmp}"; then
+elif [[ "${terminal_status}" == "error" ]]; then
   echo "FAIL: stream ended with pipeline_status error"
   tail -c 1200 "${stream_tmp}" || true
   echo
   exit 1
 else
-  echo "WARN: stream closed without terminal pipeline_status (degraded/Gemini-only mode?)"
+  echo "FAIL: stream closed without terminal pipeline_status"
   head -c 800 "${stream_tmp}" || true
   echo
+  exit 1
 fi
 
 echo "-- Realtime SDP validation"


### PR DESCRIPTION
## Summary

Fixes the production pipeline timeout class of failures by hardening the **long-running path** (`POST /api/pipeline/stream`) and adding **async job** support. Sync `POST /api/pipeline` still cannot complete full `video-to-software` (~98s on Cloud Run); stream (240s budget) and async kickoff are the supported paths.

**Gemini Interactions (beta)** does not replace this — it covers analysis-only YouTube understanding, not agents/codegen/deploy. We keep `generateContent` for production Gemini fallback.

## Changes

- **`backendHeaders()`** — shared FastAPI headers with trimmed `EVENTRELAY_API_KEY` (avoids Secret Manager newline 401s)
- **Stream route** — `X-API-Key` on async **job status polls**; `PipelineDeadline` clamps kickoff, polling, and Gemini fallback within 240s
- **`GET /api/jobs/[jobId]`** — proxies backend job status (Phase 4 contract)
- **`POST /api/pipeline` + `async: true`** — fast kickoff via `transcript-action`, returns `job_id` + `/api/jobs/{id}`
- **Sync route** — `maxDuration` 30→60s, backend timeout 50s (still insufficient for full deploy pipeline)
- **`production_smoke.sh`** — primary gate is SSE stream until `pipeline_status: complete`; async kickoff is non-fatal until this deploy lands

## Verification

```bash
cd apps/web && npx vitest run src/lib/__tests__/pipeline-backend.test.ts src/app/api/__tests__/pipeline-route.test.ts
bash scripts/deployment/production_smoke.sh  # after Vercel deploy
```

Pre-deploy live probe: `POST /api/pipeline/stream` on uvai.io → **200**, `pipeline_status: complete` in ~8s (short smoke video).

## After merge

1. Vercel production redeploy (picks up `EVENTRELAY_API_KEY` already set)
2. Re-run `production_smoke.sh` — async kickoff should return in <15s
3. Long videos: stream job polls now send API key to protected `/jobs/{id}`