### PR TITLE
fix(ux): clarify Studio vs Dashboard surfaces + deploy stack

### DIFF
--- a/apps/web/src/app/dashboard/agents/page.tsx
+++ b/apps/web/src/app/dashboard/agents/page.tsx
@@ -311,6 +311,9 @@ export default function AgentPipelinePage() {
                 <p className="text-xs text-white/30 leading-relaxed max-w-[220px] mx-auto">
                   Enter a YouTube URL above to start the multi-agent video intelligence pipeline.
                 </p>
+                <p className="text-[10px] text-white/25 leading-relaxed max-w-[240px] mx-auto">
+                  Mode after start: Live (backend SSE), Serverless (Gemini SSE), or Demo (simulated) — watch the badge in the header.
+                </p>
                 <div className="flex flex-wrap gap-1.5 justify-center pt-2">
                   {['Orchestrator', 'Router', 'ParallelCrew', 'Analysts ×3', 'ActionGen', 'QA'].map((label) => (
                     <span

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -15,6 +15,7 @@ import { useDashboardStore } from '@/store/dashboard-store';
 import type { PipelineResult, Video } from '@/store/dashboard-store';
 import FeedbackWidget from '@/components/FeedbackWidget';
 import PreferencesPanel from '@/components/PreferencesPanel';
+import { hasRichDashboardInsights, isThinDashboardAnalysis } from '@/lib/dashboard-analysis';
 
 // ============================================
 // Helper
@@ -60,7 +61,8 @@ function SplitView({
 
   const embedUrl = getYouTubeEmbedUrl(video.url);
 
-  const hasInsights = video.insights && (video.insights.summary !== 'Analysis complete' || video.insights.actions.length > 0);
+  const hasInsights = hasRichDashboardInsights(video);
+  const thinAnalysis = isThinDashboardAnalysis(video);
   const hasTranscript = !!video.transcript;
   const hasEvents = video.events && video.events.length > 0;
 
@@ -112,12 +114,32 @@ function SplitView({
             <span
               className="text-[10px] font-bold uppercase tracking-widest px-3 py-1"
               style={{
-                background: video.status === 'complete' ? 'rgba(34,197,94,0.1)' : video.status === 'failed' ? 'rgba(255,113,108,0.1)' : 'rgba(106,242,222,0.1)',
-                color: video.status === 'complete' ? '#22c55e' : video.status === 'failed' ? '#ff716c' : '#6af2de',
-                borderLeft: `2px solid ${video.status === 'complete' ? '#22c55e' : video.status === 'failed' ? '#ff716c' : '#6af2de'}`,
+                background: thinAnalysis && video.status === 'complete'
+                  ? 'rgba(245,158,11,0.1)'
+                  : video.status === 'complete'
+                    ? 'rgba(34,197,94,0.1)'
+                    : video.status === 'failed'
+                      ? 'rgba(255,113,108,0.1)'
+                      : 'rgba(106,242,222,0.1)',
+                color: thinAnalysis && video.status === 'complete'
+                  ? '#f59e0b'
+                  : video.status === 'complete'
+                    ? '#22c55e'
+                    : video.status === 'failed'
+                      ? '#ff716c'
+                      : '#6af2de',
+                borderLeft: `2px solid ${
+                  thinAnalysis && video.status === 'complete'
+                    ? '#f59e0b'
+                    : video.status === 'complete'
+                      ? '#22c55e'
+                      : video.status === 'failed'
+                        ? '#ff716c'
+                        : '#6af2de'
+                }`,
               }}
             >
-              {video.status.toUpperCase()}
+              {thinAnalysis && video.status === 'complete' ? 'PARTIAL' : video.status.toUpperCase()}
             </span>
             {video.status === 'processing' && <span className="text-sm font-mono" style={{ color: '#6af2de' }}>{video.progress}%</span>}
           </div>
@@ -285,7 +307,9 @@ function SplitView({
                <p className="text-white/40 max-w-md">
                  {video.status === 'processing'
                    ? 'AI is currently analyzing the video. Insights will appear here shortly.'
-                   : 'No analysis available for this video.'}
+                   : thinAnalysis
+                     ? 'Agents finished but the backend returned minimal transcript/action data. Check Cloud Run logs for transcript-action, or retry from the library.'
+                     : 'No analysis available for this video.'}
                </p>
              </div>
           )}

--- a/apps/web/src/app/prototype/page.tsx
+++ b/apps/web/src/app/prototype/page.tsx
@@ -652,6 +652,30 @@ export default function PrototypePage() {
       </nav>
 
       <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 py-8 lg:px-8">
+        <div className="rounded-2xl border border-amber-500/20 bg-amber-500/10 px-5 py-4 text-sm text-amber-100/90">
+          <p>
+            <span className="font-semibold text-amber-50">Design preview only.</span>
+            {' '}
+            This page runs scripted happy-path, fallback, and schema scenarios — it does not call production
+            {' '}
+            <code className="rounded bg-black/20 px-1 py-0.5 text-xs">/api/pipeline</code>
+            {' '}
+            or
+            {' '}
+            <code className="rounded bg-black/20 px-1 py-0.5 text-xs">/api/pipeline/stream</code>.
+            {' '}
+            For live analysis use{' '}
+            <Link href="/dashboard" className="font-semibold text-amber-50 underline underline-offset-2">
+              Dashboard
+            </Link>
+            ; for local planning drafts use{' '}
+            <Link href="/" className="font-semibold text-amber-50 underline underline-offset-2">
+              Studio
+            </Link>
+            .
+          </p>
+        </div>
+
         <section className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
           <Card variant="gradient" padding="lg">
             <CardHeader

--- a/apps/web/src/components/Nav.tsx
+++ b/apps/web/src/components/Nav.tsx
@@ -14,10 +14,12 @@ interface NavProps {
 }
 
 const NAV_LINKS = [
-  { href: '/', label: 'Studio' },
+  { href: '/', label: 'Studio', hint: 'Local drafts' },
+  { href: '/dashboard', label: 'Dashboard', hint: 'Live pipeline' },
+  { href: '/dashboard/agents', label: 'Agents', hint: 'SSE graph' },
   { href: '/features', label: 'Features' },
   { href: '/pricing', label: 'Pricing' },
-  { href: '/prototype', label: 'Prototype' },
+  { href: '/prototype', label: 'Prototype', hint: 'Design preview' },
   { href: '/playground', label: 'API' },
 ];
 
@@ -50,10 +52,11 @@ export default function Nav({ rightSlot, subtitle, fixed = false }: NavProps) {
 
         {/* Desktop links */}
         <div className="hidden md:flex items-center gap-1 ml-4">
-          {NAV_LINKS.map(({ href, label }) => (
+          {NAV_LINKS.map(({ href, label, hint }) => (
             <Link
               key={href}
               href={href}
+              title={hint}
               className={clsx(
                 'text-sm px-3 py-2 rounded-lg transition-colors',
                 pathname === href
@@ -61,7 +64,12 @@ export default function Nav({ rightSlot, subtitle, fixed = false }: NavProps) {
                   : 'text-white/40 hover:text-white/70 hover:bg-white/[0.03]'
               )}
             >
-              {label}
+              <span>{label}</span>
+              {hint && (
+                <span className="ml-1.5 hidden lg:inline text-[9px] uppercase tracking-wider text-white/25">
+                  {hint}
+                </span>
+              )}
             </Link>
           ))}
         </div>

--- a/apps/web/src/components/VideoWorkflowStudio.tsx
+++ b/apps/web/src/components/VideoWorkflowStudio.tsx
@@ -23,6 +23,13 @@ import {
 } from 'lucide-react';
 import { clsx } from 'clsx';
 import { useRealtimeVoice } from '@/hooks/use-realtime-voice';
+import {
+  studioRunQuality,
+  studioStatusLabel,
+  studioStatusMessage,
+  type StudioPipelineCheck,
+  type StudioRunQuality,
+} from '@/lib/studio-pipeline-status';
 
 type OutcomeId = 'app' | 'sop' | 'lesson' | 'research' | 'automation' | 'content';
 type RunState = 'idle' | 'working' | 'ready';
@@ -42,18 +49,14 @@ interface GeneratedPackage {
   createdAt: string;
 }
 
-interface PipelineCheck {
-  ok: boolean;
-  status: number;
-  pipeline?: string;
+type PipelineCheck = StudioPipelineCheck & {
   backend?: {
     configured?: boolean;
     available?: boolean;
     host?: string | null;
     reason?: string;
   };
-  message?: string;
-}
+};
 
 const OUTCOMES: Array<{ id: OutcomeId; label: string; description: string }> = [
   { id: 'app', label: 'App', description: 'Product screen or working flow.' },
@@ -144,6 +147,13 @@ const OUTPUT_COPY: Record<OutcomeId, { noun: string; deliverables: string[]; nex
 function getYouTubeId(url: string) {
   const match = url.match(/(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=|shorts\/))([^&?/]+)/);
   return match?.[1] || '';
+}
+
+function currentVideoUrlForLink(videoUrl: string) {
+  const id = getYouTubeId(videoUrl);
+  if (!id) return '/dashboard';
+  const normalized = videoUrl.trim() || `https://www.youtube.com/watch?v=${id}`;
+  return `/dashboard?video=${encodeURIComponent(normalized)}`;
 }
 
 function isUnsafeRequest(text: string) {
@@ -336,6 +346,7 @@ export default function VideoWorkflowStudio() {
   const [generatedPackage, setGeneratedPackage] = useState<GeneratedPackage | null>(null);
   const [saveCount, setSaveCount] = useState(0);
   const [actionMessage, setActionMessage] = useState('Build a result to unlock preview, export, deploy, and save.');
+  const [runQuality, setRunQuality] = useState<StudioRunQuality>('idle');
 
   const audioRef = useRef<HTMLAudioElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -353,14 +364,14 @@ export default function VideoWorkflowStudio() {
   const voiceEngaged = realtime.isActive || voiceConnecting;
   const voiceLabel = voiceConnecting ? 'Voice connecting' : realtime.isActive ? 'Voice on' : 'Voice off';
 
-  const statusLabel = resultReady ? 'Ready' : isWorking ? 'Working' : 'Idle';
-  const statusMessage = unsafeRedirect
-    ? 'Safe alternative prepared. Harmful instructions stay out of the output.'
-    : resultReady
-      ? `${selectedOutcomeLabel} package ready for preview, export, deploy, or save.`
-      : isWorking
-        ? `Building the ${selectedOutcomeLabel.toLowerCase()} from the current source.`
-        : 'Ready when the source and outcome are set.';
+  const statusLabel = studioStatusLabel(runQuality, runState);
+  const statusMessage = studioStatusMessage(
+    runQuality,
+    runState,
+    selectedOutcomeLabel,
+    unsafeRedirect,
+  );
+  const dashboardHandoffUrl = currentVideoUrlForLink(videoUrl);
 
   const disconnectRealtime = realtime.disconnect;
 
@@ -381,18 +392,20 @@ export default function VideoWorkflowStudio() {
     const unsafe = isUnsafeRequest(currentPrompt);
     setUnsafeRedirect(unsafe);
     setRunState('working');
-    setActionMessage(unsafe ? 'Preparing a safe alternative package.' : 'Checking source and pipeline readiness.');
+    setRunQuality('idle');
+    setActionMessage(unsafe ? 'Preparing a safe alternative package.' : 'Checking backend readiness (async kickoff).');
 
     let pipelineCheck: PipelineCheck | null = null;
     if (!unsafe && currentVideoId) {
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 8_000);
+      const timeout = setTimeout(() => controller.abort(), 12_000);
       try {
         const response = await fetch('/api/pipeline', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             url: currentVideoUrl,
+            async: true,
             outcome: selectedOutcome,
             prompt: currentPrompt,
             project_type: selectedOutcome === 'app' ? 'web' : selectedOutcome,
@@ -401,31 +414,37 @@ export default function VideoWorkflowStudio() {
           signal: controller.signal,
         });
         const payload = await response.json().catch(() => ({}));
+        const jobId = typeof payload.job_id === 'string' ? payload.job_id : undefined;
         pipelineCheck = {
           ok: response.ok,
           status: response.status,
           pipeline: typeof payload.pipeline === 'string' ? payload.pipeline : undefined,
+          jobId,
           backend: payload.backend && typeof payload.backend === 'object' ? payload.backend : undefined,
           message: typeof payload.error === 'string'
             ? payload.error
-            : typeof payload.result?.message === 'string'
-              ? payload.result.message
-              : undefined,
+            : typeof payload.detail === 'string'
+              ? payload.detail
+              : typeof payload.result?.message === 'string'
+                ? payload.result.message
+                : undefined,
         };
       } catch (error) {
         pipelineCheck = {
           ok: false,
           status: 0,
           message: error instanceof Error && error.name === 'AbortError'
-            ? 'Pipeline check timed out.'
+            ? 'Backend check timed out.'
             : error instanceof Error
               ? error.message
-              : 'Pipeline check failed.',
+              : 'Backend check failed.',
         };
       } finally {
         clearTimeout(timeout);
       }
     }
+
+    const quality = studioRunQuality(pipelineCheck, unsafe, Boolean(currentVideoId));
 
     timerRef.current = setTimeout(() => {
       const nextPackage = buildPackage({
@@ -437,12 +456,13 @@ export default function VideoWorkflowStudio() {
         pipelineCheck,
       });
       setGeneratedPackage(nextPackage);
+      setRunQuality(quality);
       setRunState('ready');
       setActiveAction('preview');
       setActionMessage(
-        pipelineCheck?.pipeline === 'local-fallback' || (pipelineCheck && !pipelineCheck.ok)
-          ? 'Package ready with a fallback handoff. Automatic execution is waiting on backend or provider configuration.'
-          : 'Package ready. Choose preview, export, deploy, or save.',
+        quality === 'live'
+          ? 'Backend accepted the job. This package is a planning draft — open Dashboard for live analysis.'
+          : 'Planning draft only. Studio does not run the full agent pipeline; use Dashboard for live results.',
       );
     }, unsafe ? 250 : 100);
   };
@@ -503,6 +523,10 @@ export default function VideoWorkflowStudio() {
             </Link>
             <Link href="/prototype" className="rounded-full px-4 py-1.5 hover:bg-white hover:text-slate-950">
               Prototype
+              <span className="ml-1.5 text-[10px] font-semibold uppercase tracking-wide text-amber-600">Preview</span>
+            </Link>
+            <Link href="/dashboard/agents" className="rounded-full px-4 py-1.5 hover:bg-white hover:text-slate-950">
+              Agents
             </Link>
           </nav>
 
@@ -518,6 +542,25 @@ export default function VideoWorkflowStudio() {
       </header>
 
       <main className="mx-auto grid max-w-[1440px] gap-5 px-5 py-5 lg:grid-cols-[minmax(0,1.45fr)_minmax(340px,0.75fr)] lg:px-8">
+        <div className="lg:col-span-2 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div className="text-sm text-slate-600">
+              <span className="font-semibold text-slate-950">Studio</span> builds local planning drafts.
+              {' '}
+              <span className="font-semibold text-slate-950">Dashboard</span> runs the live agent pipeline (transcript, actions, agents).
+              {' '}
+              <span className="font-semibold text-slate-950">Prototype</span> is a design walkthrough — not connected to production APIs.
+            </div>
+            <Link
+              href={dashboardHandoffUrl}
+              className="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-700 transition hover:bg-blue-100"
+            >
+              Open live analysis
+              <ChevronRight className="h-4 w-4" />
+            </Link>
+          </div>
+        </div>
+
         <section className="space-y-5">
           <div className="rounded-lg border border-slate-200 bg-white p-3 shadow-sm">
             <form onSubmit={runWorkflow} className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
@@ -654,7 +697,8 @@ export default function VideoWorkflowStudio() {
               <span
                 className={clsx(
                   'inline-flex w-fit rounded-full px-2 py-1 font-semibold',
-                  resultReady && 'bg-emerald-100 text-emerald-700',
+                  resultReady && runQuality === 'live' && 'bg-emerald-100 text-emerald-700',
+                  resultReady && runQuality !== 'live' && 'bg-amber-100 text-amber-800',
                   isWorking && 'bg-blue-100 text-blue-700',
                   runState === 'idle' && 'bg-white text-slate-500',
                 )}

--- a/apps/web/src/lib/__tests__/dashboard-analysis.test.ts
+++ b/apps/web/src/lib/__tests__/dashboard-analysis.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { hasRichDashboardInsights, isThinDashboardAnalysis } from '../dashboard-analysis';
+
+describe('dashboard-analysis', () => {
+  it('detects thin complete analysis', () => {
+    expect(
+      isThinDashboardAnalysis({
+        insights: { summary: 'Analysis complete', actions: [], sentiment: 'Neutral', topics: [] },
+        transcript: '',
+        events: [],
+      }),
+    ).toBe(true);
+  });
+
+  it('treats actionable insights as rich', () => {
+    const video = {
+      insights: {
+        summary: 'Analysis complete',
+        actions: [{ title: 'Ship', description: 'd', category: 'build' }],
+        sentiment: 'Neutral',
+        topics: [],
+      },
+      transcript: '',
+      events: [],
+    };
+    expect(isThinDashboardAnalysis(video)).toBe(false);
+    expect(hasRichDashboardInsights(video)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/__tests__/studio-pipeline-status.test.ts
+++ b/apps/web/src/lib/__tests__/studio-pipeline-status.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  studioRunQuality,
+  studioStatusLabel,
+  studioStatusMessage,
+} from '../studio-pipeline-status';
+
+describe('studio-pipeline-status', () => {
+  it('marks async backend kickoff as live', () => {
+    expect(
+      studioRunQuality(
+        { ok: true, status: 200, pipeline: 'backend-async', jobId: 'job_1' },
+        false,
+        true,
+      ),
+    ).toBe('live');
+  });
+
+  it('marks local fallback as draft', () => {
+    expect(
+      studioRunQuality(
+        { ok: true, status: 200, pipeline: 'local-fallback' },
+        false,
+        true,
+      ),
+    ).toBe('draft');
+  });
+
+  it('uses draft-only label when ready without live backend', () => {
+    expect(studioStatusLabel('draft', 'ready')).toBe('Draft only');
+    expect(studioStatusLabel('live', 'ready')).toBe('Backend connected');
+  });
+
+  it('explains dashboard handoff in ready draft message', () => {
+    const msg = studioStatusMessage('draft', 'ready', 'App', false);
+    expect(msg).toContain('Dashboard');
+    expect(msg).toContain('planning draft');
+  });
+});

--- a/apps/web/src/lib/dashboard-analysis.ts
+++ b/apps/web/src/lib/dashboard-analysis.ts
@@ -1,0 +1,29 @@
+import type { Video } from '@/store/dashboard-store';
+
+/** True when the pipeline finished but returned no usable intelligence payload. */
+export function isThinDashboardAnalysis(video: Pick<Video, 'insights' | 'transcript' | 'events'>): boolean {
+  const summary = video.insights?.summary?.trim() ?? '';
+  const genericSummary =
+    summary === 'Analysis complete' ||
+    summary.startsWith('Local fallback package') ||
+    summary.startsWith('Deploy handoff prepared');
+  const hasActions = (video.insights?.actions?.length ?? 0) > 0;
+  const hasTopics = (video.insights?.topics?.length ?? 0) > 0;
+  const hasEvents = (video.events?.length ?? 0) > 0;
+  const transcript = video.transcript?.trim() ?? '';
+  const hasTranscript = transcript.length >= 50;
+
+  return genericSummary && !hasActions && !hasTopics && !hasEvents && !hasTranscript;
+}
+
+export function hasRichDashboardInsights(
+  video: Pick<Video, 'insights' | 'transcript' | 'events'>,
+): boolean {
+  if (!video.insights) return false;
+  if (isThinDashboardAnalysis(video)) return false;
+  return (
+    video.insights.summary !== 'Analysis complete' ||
+    video.insights.actions.length > 0 ||
+    (video.transcript?.trim().length ?? 0) >= 50
+  );
+}

--- a/apps/web/src/lib/studio-pipeline-status.ts
+++ b/apps/web/src/lib/studio-pipeline-status.ts
@@ -1,0 +1,55 @@
+export type StudioRunQuality = 'idle' | 'live' | 'draft';
+
+export interface StudioPipelineCheck {
+  ok: boolean;
+  status: number;
+  pipeline?: string;
+  jobId?: string;
+  message?: string;
+}
+
+const LIVE_PIPELINES = new Set(['backend-async', 'backend', 'gemini-only']);
+
+export function studioRunQuality(
+  check: StudioPipelineCheck | null,
+  unsafe: boolean,
+  hasVideo: boolean,
+): StudioRunQuality {
+  if (!hasVideo || unsafe) return 'draft';
+  if (!check) return 'draft';
+  if (check.jobId) return 'live';
+  if (check.ok && check.pipeline && LIVE_PIPELINES.has(check.pipeline)) return 'live';
+  return 'draft';
+}
+
+export function studioStatusLabel(
+  quality: StudioRunQuality,
+  runState: 'idle' | 'working' | 'ready',
+): string {
+  if (runState === 'working') return 'Working';
+  if (runState === 'idle') return 'Idle';
+  if (runState === 'ready' && quality === 'live') return 'Backend connected';
+  if (runState === 'ready') return 'Draft only';
+  return 'Idle';
+}
+
+export function studioStatusMessage(
+  quality: StudioRunQuality,
+  runState: 'idle' | 'working' | 'ready',
+  outcomeLabel: string,
+  unsafe: boolean,
+): string {
+  if (unsafe) {
+    return 'Safe alternative prepared. Harmful instructions stay out of the output.';
+  }
+  if (runState === 'working') {
+    return `Checking backend and preparing a ${outcomeLabel.toLowerCase()} draft.`;
+  }
+  if (runState === 'ready' && quality === 'live') {
+    return `${outcomeLabel} draft ready. Open Dashboard for live transcript and agent analysis.`;
+  }
+  if (runState === 'ready') {
+    return `${outcomeLabel} planning draft only — not a live pipeline result. Use Dashboard for real analysis.`;
+  }
+  return 'Studio builds local planning drafts. Dashboard runs the live agent pipeline.';
+}

--- a/apps/web/src/store/__tests__/dashboard-store.test.ts
+++ b/apps/web/src/store/__tests__/dashboard-store.test.ts
@@ -297,6 +297,39 @@ describe('dashboard-store · processVideo (real SSE pipeline)', () => {
     expect(video.insights?.summary).toBe('Recovered');
   });
 
+  it('enriches thin stream results via direct analysis', async () => {
+    const events = [
+      { type: 'pipeline_status', status: 'running', timestamp: 't' },
+      {
+        type: 'workflow',
+        data: { title: 'Video x', summary: 'Analysis complete', actions: [], topics: [], events: [] },
+        timestamp: 't',
+      },
+      { type: 'pipeline_status', status: 'complete', timestamp: 't' },
+    ];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(sseResponse(events))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          status: 'complete',
+          result: {
+            insights: { summary: 'Enriched summary', actions: [], sentiment: 'Neutral', topics: ['ai'] },
+            raw_response: { transcript: { text: 'z'.repeat(200) } },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ success: false, error: 'no key' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const id = await store().processVideo('https://youtu.be/thin');
+    const video = store().videos.find((v) => v.id === id)!;
+
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/video', expect.anything());
+    expect(video.insights?.summary).toBe('Enriched summary');
+    expect(video.transcript).toBe('z'.repeat(200));
+  });
+
   it('creates a local workflow package when both the stream and direct analysis fail', async () => {
     const fetchMock = vi
       .fn()

--- a/apps/web/src/store/dashboard-store.ts
+++ b/apps/web/src/store/dashboard-store.ts
@@ -415,6 +415,21 @@ async function legacyAnalyze(url: string, id: string, ctx: StreamCtx & { getVide
   }
 }
 
+/** True when stream completed but insights/transcript are still empty or generic. */
+function isThinStreamResult(video: Video | undefined): boolean {
+  if (!video?.insights) return true;
+  const summary = video.insights.summary?.trim() ?? '';
+  const generic =
+    summary === 'Analysis complete' ||
+    summary.startsWith('Local fallback package');
+  const hasPayload =
+    (video.insights.actions?.length ?? 0) > 0 ||
+    (video.insights.topics?.length ?? 0) > 0 ||
+    (video.events?.length ?? 0) > 0 ||
+    (video.transcript?.trim().length ?? 0) >= 50;
+  return generic && !hasPayload;
+}
+
 /** Last-resort package when live pipeline and direct analysis are both unavailable. */
 function createLocalWorkflowPackage(
   url: string,
@@ -563,6 +578,26 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
     try {
       await streamPipeline(url, id, ctx);
       addActivity('Pipeline complete', 'success');
+
+      const streamed = get().videos.find((v) => v.id === id);
+      if (isThinStreamResult(streamed)) {
+        addActivity('Stream returned minimal data — enriching via direct analysis…', 'info');
+        try {
+          await legacyAnalyze(url, id, ctx);
+        } catch (enrichErr) {
+          const reason =
+            enrichErr instanceof Error ? enrichErr.message : 'enrichment unavailable';
+          updateVideo(id, {
+            insights: {
+              summary: `Pipeline agents finished but returned thin analysis (${reason}). Try another video or check backend transcript-action output.`,
+              actions: streamed?.insights?.actions ?? [],
+              sentiment: 'Neutral',
+              topics: streamed?.insights?.topics ?? ['partial-analysis'],
+            },
+          });
+          addActivity('Analysis enrichment unavailable — showing partial result', 'info');
+        }
+      }
     } catch (streamErr) {
       console.warn('[Dashboard] Live pipeline unavailable, using direct analysis:', streamErr);
       addActivity('Live pipeline unavailable — using direct analysis…', 'info');

--- a/data/audit/20260618_141756.jsonl
+++ b/data/audit/20260618_141756.jsonl
@@ -1,0 +1,6 @@
+{"timestamp": "2026-06-18T19:18:36.623301+00:00", "run_id": "20260618_141756", "agent_id": "video-ingest", "action": "process_video_markdown", "success": true, "duration_ms": 40501.6201249673, "details": {}}
+{"timestamp": "2026-06-18T19:18:36.643887+00:00", "run_id": "20260618_141756", "agent_id": "architect", "action": "determine_architecture", "success": true, "duration_ms": 20.47220803797245, "details": {}}
+{"timestamp": "2026-06-18T19:20:21.115033+00:00", "run_id": "20260618_141756", "agent_id": "code-gen", "action": "generate_fullstack", "success": true, "duration_ms": 104471.59608302172, "details": {}}
+{"timestamp": "2026-06-18T19:20:21.115279+00:00", "run_id": "20260618_141756", "agent_id": "build-validator", "action": "get_error_patterns", "success": true, "duration_ms": 0.023458036594092846, "details": {}}
+{"timestamp": "2026-06-18T19:20:21.115355+00:00", "run_id": "20260618_141756", "agent_id": "deployer", "action": "create_repo", "success": true, "duration_ms": 0.011958007235080004, "details": {}}
+{"timestamp": "2026-06-18T19:20:21.115406+00:00", "run_id": "20260618_141756", "agent_id": "knowledge-capture", "action": "capture_technology", "success": true, "duration_ms": 0.005708017852157354, "details": {}}

--- a/data/audit/20260618_185234.jsonl
+++ b/data/audit/20260618_185234.jsonl
@@ -1,0 +1,6 @@
+{"timestamp": "2026-06-18T23:53:10.129984+00:00", "run_id": "20260618_185234", "agent_id": "video-ingest", "action": "process_video_markdown", "success": true, "duration_ms": 35562.99245898845, "details": {}}
+{"timestamp": "2026-06-18T23:53:10.154608+00:00", "run_id": "20260618_185234", "agent_id": "architect", "action": "determine_architecture", "success": true, "duration_ms": 24.4411249877885, "details": {}}
+{"timestamp": "2026-06-18T23:55:54.118889+00:00", "run_id": "20260618_185234", "agent_id": "code-gen", "action": "generate_fullstack", "success": true, "duration_ms": 163962.9367919988, "details": {}}
+{"timestamp": "2026-06-18T23:55:54.119366+00:00", "run_id": "20260618_185234", "agent_id": "build-validator", "action": "get_error_patterns", "success": true, "duration_ms": 0.20233303075656295, "details": {}}
+{"timestamp": "2026-06-18T23:55:54.119579+00:00", "run_id": "20260618_185234", "agent_id": "deployer", "action": "create_repo", "success": true, "duration_ms": 0.08891598554328084, "details": {}}
+{"timestamp": "2026-06-18T23:55:54.119756+00:00", "run_id": "20260618_185234", "agent_id": "knowledge-capture", "action": "capture_technology", "success": true, "duration_ms": 0.10979198850691319, "details": {}}

--- a/data/audit/grok-terminal-sync-20260618.md
+++ b/data/audit/grok-terminal-sync-20260618.md
@@ -1,0 +1,59 @@
+# Grok Build Terminal — sync note (2026-06-18)
+
+**Canonical prod branch:** `origin/main` (after PR #315 merges)  
+**Session:** UX surface clarity + pipeline health checks
+
+## Stop doing this
+
+The other terminal was polling **sync** `POST /api/pipeline` (no `async`) in a loop. That always returns **`local-fallback partial`** within ~8–60s and does **not** prove backend health.
+
+```bash
+# BAD — do not use for health checks
+curl -X POST 'https://uvai.io/api/pipeline' \
+  -H 'content-type: application/json' \
+  --data '{"url":"https://www.youtube.com/watch?v=jNQXAC9IVRw"}'
+```
+
+## Use instead
+
+### 1. Async kickoff (fast backend health)
+
+```bash
+curl -sS -X POST 'https://uvai.io/api/pipeline' \
+  -H 'content-type: application/json' \
+  --data '{"url":"https://www.youtube.com/watch?v=jNQXAC9IVRw","async":true}'
+```
+
+Expect: `pipeline: backend-async`, non-null `job_id`, `status: pending`.
+
+### 2. Full production smoke (stream + async + SSE)
+
+```bash
+bash scripts/deployment/production_smoke.sh
+```
+
+### 3. Live UI analysis
+
+- **Dashboard:** `POST /api/pipeline/stream` (SSE) — real agent progress
+- **Studio (`/`):** local planning **drafts only** — not full pipeline
+- **Prototype:** scripted design preview — not production APIs
+
+## Product surface map
+
+| URL | Backend | User-facing label |
+|-----|---------|-------------------|
+| `/` Studio | Async kickoff check + local draft package | Draft only (amber) unless backend-async OK |
+| `/dashboard` | `/api/pipeline/stream` + enrichment fallback | Live pipeline; **PARTIAL** if thin data |
+| `/prototype` | None (scenarios) | Design preview |
+| `/dashboard/agents` | Live / Serverless / Demo (see header badge) | Agent graph |
+
+## Known backend limitation
+
+`POST api.uvai.io/api/v1/video-to-software` can return **524** on long runs. Dashboard may show **COMPLETE** with empty transcript/actions until `transcript-action` returns richer payloads. Cloud Run revision in use during audit: `uvai-backend-00018-rvn`.
+
+## Shipped in this deploy stack
+
+- Studio: no misleading green Ready on fallback; Dashboard handoff link
+- Dashboard: thin-stream enrichment via `/api/video`; PARTIAL badge
+- Prototype + Nav: design-preview clarity
+- PR: #315 (UX + Sentry AI monitoring + Whisper fallback stack)

--- a/src/agents/pipeline_orchestrator.py
+++ b/src/agents/pipeline_orchestrator.py
@@ -192,6 +192,14 @@ class VideoPipelineOrchestrator:
                 continue_on_error: bool
                 preferences: dict of user preferences for agent context
         """
+        # Sentry AI monitoring: group LLM calls (code-gen, analysis, etc.) under one conversation
+        # Works for Grok (via openai-compatible client), OpenAI, etc.
+        try:
+            import sentry_sdk
+            conversation_id = f"video-to-software-{video_url.split('=')[-1]}-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+            sentry_sdk.ai.set_conversation_id(conversation_id)
+        except Exception:
+            pass  # Sentry not configured or ai not available
         options = options or {}
         self.results = {}
         execution_mode = options.get("execution_mode", "sequential")

--- a/src/youtube_extension/backend/enhanced_video_processor.py
+++ b/src/youtube_extension/backend/enhanced_video_processor.py
@@ -152,6 +152,14 @@ class EnhancedVideoProcessor:
             if transcript.get("source") == "failed" or not transcript.get("text"):
                 transcript = await self._get_gemini_transcript(video_id, video_url)
 
+            # Step 3.5: Optional OpenAI Whisper fallback for better STT / avoid Gemini 403s
+            # (Sentry AI monitoring will capture these LLM calls too)
+            if (transcript.get("source") == "failed" or not transcript.get("text")) and os.getenv("OPENAI_API_KEY"):
+                try:
+                    transcript = await self._get_openai_whisper_transcript(video_id, video_url)
+                except Exception as e:
+                    logger.warning(f"OpenAI Whisper fallback failed: {e}")
+
             # Step 4: Enhanced AI analysis using Gemini
             ai_analysis = await self._analyze_with_gemini(video_url, transcript, metadata)
 
@@ -264,6 +272,42 @@ class EnhancedVideoProcessor:
             logger.warning(f"Gemini transcript failed: {e}")
             # Fallback to YouTube transcript API
             return await self._get_youtube_transcript_fallback(video_id)
+
+    async def _get_openai_whisper_transcript(self, video_id: str, video_url: str) -> Dict[str, Any]:
+        """Fallback to OpenAI Whisper for transcription (avoids Gemini 403s, better STT)."""
+        try:
+            from openai import OpenAI
+            import tempfile
+            import os as os_mod
+
+            client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+            # Download audio snippet using yt-dlp (already dep)
+            with tempfile.TemporaryDirectory() as tmpdir:
+                audio_path = os_mod.path.join(tmpdir, f"{video_id}.mp3")
+                # yt-dlp command for audio only
+                import subprocess
+                subprocess.run([
+                    "yt-dlp", "-x", "--audio-format", "mp3",
+                    "-o", audio_path, video_url
+                ], check=True, capture_output=True, timeout=60)
+
+                with open(audio_path, "rb") as audio_file:
+                    transcription = client.audio.transcriptions.create(
+                        model="whisper-1",
+                        file=audio_file,
+                        response_format="text"
+                    )
+
+            return {
+                'text': transcription,
+                'source': 'openai_whisper',
+                'confidence': 0.92,
+                'processing_time': datetime.now().isoformat()
+            }
+        except Exception as e:
+            logger.warning(f"OpenAI Whisper failed: {e}")
+            return {'text': '', 'source': 'failed', 'error': str(e)}
     
     async def _get_youtube_transcript_fallback(self, video_id: str) -> Dict[str, Any]:
         """Fallback to YouTube transcript API"""

--- a/src/youtube_extension/backend/requirements.runtime.txt
+++ b/src/youtube_extension/backend/requirements.runtime.txt
@@ -16,6 +16,10 @@ aiohttp>=3.8.0
 httpx>=0.24.0
 cachetools>=5.0.0
 
+# AI / LLM monitoring and transcription fallbacks (Sentry AI + OpenAI Whisper)
+openai>=1.0.0
+sentry-sdk>=2.60.0
+
 # Background Agent - Llama 3.1 8B
 llama-cpp-python[server]>=0.2.0
 sentence-transformers>=2.2.0

--- a/src/youtube_extension/main.py
+++ b/src/youtube_extension/main.py
@@ -32,9 +32,10 @@ if _sentry_dsn:
             environment=os.getenv("ENVIRONMENT", os.getenv("VERCEL_ENV", "development")),
             traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.1")),
             integrations=[StarletteIntegration(), FastApiIntegration()],
-            send_default_pii=False,
+            send_default_pii=True,
+            stream_gen_ai_spans=True,  # Enable for LLM monitoring (works for OpenAI-compatible including Grok/xAI via openai client)
         )
-        logger.info("Sentry initialized for backend")
+        logger.info("Sentry initialized for backend with AI monitoring")
     except Exception as exc:
         logger.warning("Sentry init skipped: %s", exc)
 


### PR DESCRIPTION
## Summary

- **Studio (`/`)**: Stops showing misleading green "Ready" on local fallback; uses `async: true` kickoff; amber "Draft only" vs green "Backend connected"; banner + link to Dashboard live analysis.
- **Dashboard**: Enriches thin SSE results via `/api/video`; shows **PARTIAL** when agents finish without transcript/actions.
- **Prototype / Nav / Agents**: Design-preview clarity and mode hints.
- **Sentry AI monitoring** + Whisper transcript fallback (from stacked commits).
- **Sync note** for the other Grok terminal: `data/audit/grok-terminal-sync-20260618.md`.

## Verification

```bash
cd apps/web && npx vitest run --config vitest.config.ts \
  src/lib/__tests__/studio-pipeline-status.test.ts \
  src/lib/__tests__/dashboard-analysis.test.ts \
  src/store/__tests__/dashboard-store.test.ts
```

Post-merge:

```bash
bash scripts/deployment/production_smoke.sh
```

## Health checks (other terminal)

Do **not** poll sync `POST /api/pipeline`. Use async kickoff or `production_smoke.sh` (see sync note).