### PR TITLE
fix: remediate review findings + failing `test` CI on #360

### DIFF
--- a/apps/web/src/lib/transcription-service.ts
+++ b/apps/web/src/lib/transcription-service.ts
@@ -212,16 +212,17 @@ ${metadataContext ? `\nKNOWN METADATA:\n${metadataContext}` : ''}`,
     }
 
     if (candidates.length > 0) {
-      // Run all candidates concurrently. `Promise.race([])` is used as a
-      // "pending-forever" sentinel: mapping each result through
-      // `r ?? Promise.race([])` turns a null (no usable transcript) into a
-      // promise that never resolves, so the outer race() skips it and
-      // continues waiting for a non-null winner.
+      // Run all candidates concurrently and return the first non-null result.
+      // When a candidate resolves to null (no usable transcript found), we
+      // replace it with a never-resolving promise so Promise.race() skips it
+      // and continues waiting for a successful result from another candidate.
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      const PENDING_FOREVER = new Promise<never>(() => {});
       const winner = await Promise.race(
-        candidates.map(p => p.then(r => r ?? new Promise<never>(() => undefined)))
+        candidates.map(p => p.then(r => r ?? PENDING_FOREVER))
       ).catch(() => null);
       if (winner) return winner;
-      // If the race produced no winner (both resolved to null simultaneously),
+      // If the race produced no winner (all candidates resolved to null),
       // wait for all results and return the first usable one.
       const results = await Promise.allSettled(candidates);
       for (const r of results) {

--- a/apps/web/src/lib/transcription-service.ts
+++ b/apps/web/src/lib/transcription-service.ts
@@ -13,6 +13,12 @@ const rawBackendUrl = process.env.BACKEND_URL || '';
 const BACKEND_URL = rawBackendUrl.startsWith('http') ? rawBackendUrl : 'http://localhost:8000';
 const BACKEND_AVAILABLE = rawBackendUrl.startsWith('http');
 
+// A never-resolving promise used to skip null candidates in Promise.race():
+// when a candidate resolves to null we swap it for this so the race ignores it
+// and waits for a real result from another candidate.
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const PENDING_FOREVER = new Promise<never>(() => {});
+
 export interface TranscriptionOptions {
   url?: string;
   audioUrl?: string;
@@ -214,10 +220,8 @@ ${metadataContext ? `\nKNOWN METADATA:\n${metadataContext}` : ''}`,
     if (candidates.length > 0) {
       // Run all candidates concurrently and return the first non-null result.
       // When a candidate resolves to null (no usable transcript found), we
-      // replace it with a never-resolving promise so Promise.race() skips it
-      // and continues waiting for a successful result from another candidate.
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      const PENDING_FOREVER = new Promise<never>(() => {});
+      // replace it with PENDING_FOREVER so Promise.race() skips it and waits
+      // for a successful result from another candidate.
       const winner = await Promise.race(
         candidates.map(p => p.then(r => r ?? PENDING_FOREVER))
       ).catch(() => null);

--- a/apps/web/src/lib/transcription-service.ts
+++ b/apps/web/src/lib/transcription-service.ts
@@ -99,25 +99,33 @@ export async function fetchTranscript({
     }
   }
 
-  // Fetch YouTube metadata (description, chapters, title) — used by strategies below
+  // Fetch YouTube metadata (description, chapters, title) — shared by both fallback strategies
   let metadata: Awaited<ReturnType<typeof fetchYouTubeMetadata>> = null;
   if (url) {
     try {
-      metadata = await fetchYouTubeMetadata(url);
+      const controller = new AbortController();
+      const metadataTimeout = setTimeout(() => controller.abort(), 5_000);
+      metadata = await fetchYouTubeMetadata(url).finally(() => clearTimeout(metadataTimeout));
     } catch {
       console.log('YouTube metadata fetch failed, continuing without');
     }
   }
 
-  // Strategy 2: Gemini with Google Search grounding (PRIMARY for YouTube fallback)
-  if (url && !audioUrl && hasGeminiKey()) {
-    try {
-      const ai = getGeminiClient();
-      const metadataContext = metadata ? formatMetadataAsContext(metadata) : '';
+  // Strategies 2 & 3: Run Gemini and OpenAI in parallel — first successful result wins.
+  // This eliminates the worst-case sequential 30s+30s wait when both providers
+  // are available, cutting latency to the faster of the two.
+  if (url && !audioUrl) {
+    const candidates: Promise<TranscriptionResult | null>[] = [];
 
-      const result = await ai.models.generateContent({
-        model: 'gemini-3.1-pro-preview',
-        contents: `You are a video transcription assistant with access to Google Search.
+    // Strategy 2: Gemini with Google Search grounding
+    if (hasGeminiKey()) {
+      const metadataContext = metadata ? formatMetadataAsContext(metadata) : '';
+      const geminiPromise: Promise<TranscriptionResult | null> = (async () => {
+        try {
+          const ai = getGeminiClient();
+          const result = await ai.models.generateContent({
+            model: 'gemini-3.1-pro-preview',
+            contents: `You are a video transcription assistant with access to Google Search.
 
 For the following YouTube video, use your googleSearch tool to find the ACTUAL transcript,
 description, and chapter content. The video creator often provides detailed descriptions
@@ -134,70 +142,88 @@ INSTRUCTIONS:
 4. Be thorough — capture ALL key points, technical details, quotes, and actionable insights.
 5. Include timestamps in [MM:SS] format where possible.
 6. Do NOT return generic advice like "click Show Transcript" — return actual content.`,
-        config: {
-          temperature: 0.2,
-          tools: [{ googleSearch: {} }],
-        },
-      });
-      const text = result.text ?? '';
-
-      if (text.length > 100) {
-        return {
-          success: true,
-          transcript: text,
-          source: 'gemini-search',
-          wordCount: text.split(/\s+/).length,
-          metadata: metadata
-            ? {
-                title: metadata.title,
-                channel: metadata.channel,
-                chapters: metadata.chapters,
-              }
-            : undefined,
-        };
-      }
-    } catch (e) {
-      console.warn('Gemini Google Search transcript failed:', e);
+            config: {
+              temperature: 0.2,
+              tools: [{ googleSearch: {} }],
+            },
+          });
+          const text = result.text ?? '';
+          if (text.length > 100) {
+            return {
+              success: true,
+              transcript: text,
+              source: 'gemini-search',
+              wordCount: text.split(/\s+/).length,
+              metadata: metadata
+                ? {
+                    title: metadata.title,
+                    channel: metadata.channel,
+                    chapters: metadata.chapters,
+                  }
+                : undefined,
+            } satisfies TranscriptionResult;
+          }
+          return null;
+        } catch (e) {
+          console.warn('Gemini Google Search transcript failed:', e);
+          return null;
+        }
+      })();
+      candidates.push(geminiPromise);
     }
-  }
 
-  // Strategy 3: OpenAI Responses API with web_search (fallback)
-  if (url && !audioUrl && process.env.OPENAI_API_KEY) {
-    try {
+    // Strategy 3: OpenAI Responses API with web_search
+    if (process.env.OPENAI_API_KEY) {
       const metadataContext = metadata ? formatMetadataAsContext(metadata) : '';
-
-      const response = await getOpenAI().responses.create({
-        model: 'gpt-4o-mini',
-        instructions: `You are a video content transcription assistant.
+      const openaiPromise: Promise<TranscriptionResult | null> = (async () => {
+        try {
+          const response = await getOpenAI().responses.create({
+            model: 'gpt-4o-mini',
+            instructions: `You are a video content transcription assistant.
 Given a YouTube URL, use web search to find the video's ACTUAL transcript or detailed content.
 Return the full transcript text if available. If not, provide a comprehensive content summary
 based on the video's description, chapters, and any available reviews or summaries.
 Do NOT return instructions on how to find a transcript — return the actual content.
 Be thorough — capture all key points, quotes, technical details, and chapter breakdowns.`,
-        tools: [{ type: 'web_search' as const }],
-        input: `Find and return the full transcript or detailed content of this video: ${url}
+            tools: [{ type: 'web_search' as const }],
+            input: `Find and return the full transcript or detailed content of this video: ${url}
 ${metadataContext ? `\nKNOWN METADATA:\n${metadataContext}` : ''}`,
-      });
+          });
+          const text = response.output_text || '';
+          // Reject results that are just instructions rather than actual content
+          const isGarbage =
+            text.toLowerCase().includes('click show transcript') ||
+            text.toLowerCase().includes('click on the three dots') ||
+            text.toLowerCase().includes('steps to find') ||
+            (text.length < 300 && text.includes('transcript'));
+          if (text.length > 100 && !isGarbage) {
+            return {
+              success: true,
+              transcript: text,
+              source: 'openai-web-search',
+              wordCount: text.split(/\s+/).length,
+            } satisfies TranscriptionResult;
+          }
+          return null;
+        } catch (e) {
+          console.warn('OpenAI web_search transcript failed:', e);
+          return null;
+        }
+      })();
+      candidates.push(openaiPromise);
+    }
 
-      const text = response.output_text || '';
-
-      // Reject results that are just instructions rather than actual content
-      const isGarbage =
-        text.toLowerCase().includes('click show transcript') ||
-        text.toLowerCase().includes('click on the three dots') ||
-        text.toLowerCase().includes('steps to find') ||
-        (text.length < 300 && text.includes('transcript'));
-
-      if (text.length > 100 && !isGarbage) {
-        return {
-          success: true,
-          transcript: text,
-          source: 'openai-web-search',
-          wordCount: text.split(/\s+/).length,
-        };
+    if (candidates.length > 0) {
+      // race() but ignore null results — resolve with first non-null winner
+      const winner = await Promise.race(
+        candidates.map(p => p.then(r => r ?? Promise.race([])))
+      ).catch(() => null);
+      if (winner) return winner;
+      // If race produced no winner, wait for all to settle
+      const results = await Promise.allSettled(candidates);
+      for (const r of results) {
+        if (r.status === 'fulfilled' && r.value) return r.value;
       }
-    } catch (e) {
-      console.warn('OpenAI web_search transcript failed:', e);
     }
   }
 

--- a/apps/web/src/lib/transcription-service.ts
+++ b/apps/web/src/lib/transcription-service.ts
@@ -103,9 +103,7 @@ export async function fetchTranscript({
   let metadata: Awaited<ReturnType<typeof fetchYouTubeMetadata>> = null;
   if (url) {
     try {
-      const controller = new AbortController();
-      const metadataTimeout = setTimeout(() => controller.abort(), 5_000);
-      metadata = await fetchYouTubeMetadata(url).finally(() => clearTimeout(metadataTimeout));
+      metadata = await fetchYouTubeMetadata(url);
     } catch {
       console.log('YouTube metadata fetch failed, continuing without');
     }
@@ -214,12 +212,17 @@ ${metadataContext ? `\nKNOWN METADATA:\n${metadataContext}` : ''}`,
     }
 
     if (candidates.length > 0) {
-      // race() but ignore null results — resolve with first non-null winner
+      // Run all candidates concurrently. `Promise.race([])` is used as a
+      // "pending-forever" sentinel: mapping each result through
+      // `r ?? Promise.race([])` turns a null (no usable transcript) into a
+      // promise that never resolves, so the outer race() skips it and
+      // continues waiting for a non-null winner.
       const winner = await Promise.race(
-        candidates.map(p => p.then(r => r ?? Promise.race([])))
+        candidates.map(p => p.then(r => r ?? new Promise<never>(() => undefined)))
       ).catch(() => null);
       if (winner) return winner;
-      // If race produced no winner, wait for all to settle
+      // If the race produced no winner (both resolved to null simultaneously),
+      // wait for all results and return the first usable one.
       const results = await Promise.allSettled(candidates);
       for (const r of results) {
         if (r.status === 'fulfilled' && r.value) return r.value;

--- a/apps/web/src/lib/transcription-service.ts
+++ b/apps/web/src/lib/transcription-service.ts
@@ -24,7 +24,10 @@ function firstNonNull<T>(candidates: Promise<T | null>[]): Promise<T | null> {
       return;
     }
     const settle = (value: T | null) => {
-      if (value) {
+      // Null check, not a truthy check: a falsy-but-valid result (e.g. an
+      // empty string or 0 for other T) must count as a real result, not a
+      // failed candidate. null is the only "no result" sentinel here.
+      if (value !== null) {
         resolve(value);
       } else if (--remaining === 0) {
         resolve(null);

--- a/apps/web/src/lib/transcription-service.ts
+++ b/apps/web/src/lib/transcription-service.ts
@@ -13,11 +13,28 @@ const rawBackendUrl = process.env.BACKEND_URL || '';
 const BACKEND_URL = rawBackendUrl.startsWith('http') ? rawBackendUrl : 'http://localhost:8000';
 const BACKEND_AVAILABLE = rawBackendUrl.startsWith('http');
 
-// A never-resolving promise used to skip null candidates in Promise.race():
-// when a candidate resolves to null we swap it for this so the race ignores it
-// and waits for a real result from another candidate.
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const PENDING_FOREVER = new Promise<never>(() => {});
+// Resolve with the first non-null candidate, or null once every candidate has
+// settled (resolved null or rejected). Unlike Promise.race() over null-swapped
+// promises, this always settles — it cannot hang when all candidates fail.
+function firstNonNull<T>(candidates: Promise<T | null>[]): Promise<T | null> {
+  return new Promise(resolve => {
+    let remaining = candidates.length;
+    if (remaining === 0) {
+      resolve(null);
+      return;
+    }
+    const settle = (value: T | null) => {
+      if (value) {
+        resolve(value);
+      } else if (--remaining === 0) {
+        resolve(null);
+      }
+    };
+    for (const p of candidates) {
+      p.then(settle, () => settle(null));
+    }
+  });
+}
 
 export interface TranscriptionOptions {
   url?: string;
@@ -219,19 +236,12 @@ ${metadataContext ? `\nKNOWN METADATA:\n${metadataContext}` : ''}`,
 
     if (candidates.length > 0) {
       // Run all candidates concurrently and return the first non-null result.
-      // When a candidate resolves to null (no usable transcript found), we
-      // replace it with PENDING_FOREVER so Promise.race() skips it and waits
-      // for a successful result from another candidate.
-      const winner = await Promise.race(
-        candidates.map(p => p.then(r => r ?? PENDING_FOREVER))
-      ).catch(() => null);
+      // firstNonNull resolves as soon as a candidate yields a usable transcript,
+      // and resolves to null once all candidates have settled with no result —
+      // so a batch where every candidate fails falls through to Strategy 4
+      // instead of hanging forever.
+      const winner = await firstNonNull(candidates);
       if (winner) return winner;
-      // If the race produced no winner (all candidates resolved to null),
-      // wait for all results and return the first usable one.
-      const results = await Promise.allSettled(candidates);
-      for (const r of results) {
-        if (r.status === 'fulfilled' && r.value) return r.value;
-      }
     }
   }
 

--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -10,6 +10,7 @@ Provides versioned API endpoints with proper OpenAPI documentation.
 import asyncio
 import logging
 import os
+import time
 import uuid as _uuid
 from dataclasses import asdict
 from datetime import datetime
@@ -853,19 +854,15 @@ async def list_videos_v1(
 ):
     """Get paginated list of processed videos"""
     try:
-        all_videos = data_service.get_videos_summary()
-
-        # Apply pagination
-        start = offset
-        end = offset + limit
-        paginated_videos = all_videos[start:end]
+        total = data_service.count_videos()
+        paginated_videos = data_service.get_videos_summary(limit=limit, offset=offset)
 
         return {
             "videos": paginated_videos,
-            "total": len(all_videos),
+            "total": total,
             "limit": limit,
             "offset": offset,
-            "has_more": end < len(all_videos),
+            "has_more": (offset + limit) < total,
         }
 
     except Exception as e:
@@ -1087,9 +1084,101 @@ async def ingest_performance_report_v1(report: dict[str, Any]):
 # (Replace with Redis/DB in production)
 # ============================================================
 
-_video_jobs: dict[str, VideoJobStatusResponse] = {}
-_agent_executions: dict[str, AgentExecution] = {}
-_dispatches: dict[str, AgentDispatchResponse] = {}
+
+class _TTLDict(dict):  # type: ignore[type-arg]
+    """A dict subclass that evicts entries older than *ttl* seconds.
+
+    Eviction is lazy (on any mutation or `get`/`__getitem__`) plus an optional
+    periodic sweep via `evict_expired()`. A *max_size* cap prevents unbounded
+    growth: when the limit is reached the oldest entry is dropped first.
+    """
+
+    def __init__(
+        self,
+        ttl: float = 3600.0,
+        max_size: int = 2000,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._ttl = ttl
+        self._max_size = max_size
+        # Timestamps stored separately to avoid serialisation side-effects.
+        self._timestamps: dict[str, float] = {}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _touch(self, key: str) -> None:
+        self._timestamps[key] = time.monotonic()
+
+    def _is_expired(self, key: str) -> bool:
+        ts = self._timestamps.get(key)
+        return ts is None or (time.monotonic() - ts) > self._ttl
+
+    def evict_expired(self) -> None:
+        """Remove all entries whose TTL has elapsed."""
+        expired = [k for k in list(self._timestamps) if self._is_expired(k)]
+        for k in expired:
+            super().pop(k, None)
+            self._timestamps.pop(k, None)
+
+    def _enforce_max_size(self) -> None:
+        """Drop the oldest entry when the dict exceeds *max_size*."""
+        while len(self) > self._max_size:
+            oldest = min(self._timestamps, key=self._timestamps.__getitem__, default=None)
+            if oldest is None:
+                break
+            super().pop(oldest, None)
+            self._timestamps.pop(oldest, None)
+
+    # ------------------------------------------------------------------
+    # Overridden dict methods
+    # ------------------------------------------------------------------
+
+    def __setitem__(self, key: str, value: Any) -> None:  # type: ignore[override]
+        self.evict_expired()
+        super().__setitem__(key, value)
+        self._touch(key)
+        self._enforce_max_size()
+
+    def __getitem__(self, key: str) -> Any:
+        if self._is_expired(key):
+            super().pop(key, None)
+            self._timestamps.pop(key, None)
+            raise KeyError(key)
+        return super().__getitem__(key)
+
+    def __delitem__(self, key: str) -> None:
+        super().__delitem__(key)
+        self._timestamps.pop(key, None)
+
+    def get(self, key: str, default: Any = None) -> Any:  # type: ignore[override]
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def pop(self, key: str, *args: Any) -> Any:  # type: ignore[override]
+        self._timestamps.pop(key, None)
+        return super().pop(key, *args)
+
+    def __contains__(self, key: object) -> bool:
+        if isinstance(key, str) and self._is_expired(key):
+            super().pop(key, None)
+            self._timestamps.pop(key, None)
+            return False
+        return super().__contains__(key)
+
+
+# Default TTL: 2 hours; max 2 000 entries per store.
+_JOB_TTL: float = float(os.getenv("JOB_STORE_TTL_SECONDS", "7200"))
+_JOB_MAX_SIZE: int = int(os.getenv("JOB_STORE_MAX_SIZE", "2000"))
+
+_video_jobs: _TTLDict = _TTLDict(ttl=_JOB_TTL, max_size=_JOB_MAX_SIZE)
+_agent_executions: _TTLDict = _TTLDict(ttl=_JOB_TTL, max_size=_JOB_MAX_SIZE)
+_dispatches: _TTLDict = _TTLDict(ttl=_JOB_TTL, max_size=_JOB_MAX_SIZE)
 
 
 def _persist_video_job(job: VideoJobStatusResponse) -> None:
@@ -1461,44 +1550,81 @@ async def extract_events(request: EventExtractRequest):
     if not transcript_text:
         raise HTTPException(status_code=400, detail="No transcript available")
 
+    # Chunked AI extraction: process the transcript in overlapping windows so
+    # tail content is never silently dropped.  Each chunk is up to 24 000 chars
+    # with a 500-char overlap to preserve sentence context across boundaries.
+    _CHUNK_SIZE = 24_000
+    _CHUNK_OVERLAP = 500
+    _MAX_EVENTS = 50
+
+    def _build_chunks(text: str) -> list[str]:
+        if len(text) <= _CHUNK_SIZE:
+            return [text]
+        chunks = []
+        start = 0
+        while start < len(text):
+            end = start + _CHUNK_SIZE
+            chunks.append(text[start:end])
+            start += _CHUNK_SIZE - _CHUNK_OVERLAP
+        return chunks
+
+    transcript_chunks = _build_chunks(transcript_text)
+
     events: list[ExtractedEvent] = []
-    try:
-        processor = HybridProcessorService()
-        ai_result = await processor.process(
-            input_data=transcript_text[:8000],
-            prompt=(
-                "Extract key actionable events from this transcript. "
-                "For each event provide: type (action/mention/topic/insight), title, description, "
-                "and timestamp if mentioned."
-            ),
-        )
-        # process() returns a HybridResult dataclass whose payload is `.response`.
-        # REAL_MODE_ONLY: never synthesize events from a mocked or empty AI
-        # response -- fall through to the deterministic heuristic instead.
-        cloud_result = ai_result.cloud_result
-        backend = cloud_result.backend if cloud_result else None
-        raw_text = (ai_result.response or "") if ai_result.success else ""
-        if not raw_text.strip() or backend == "mock":
-            raise RuntimeError("AI extraction unavailable (no real Gemini response)")
-        for line in raw_text.strip().split("\n"):
-            line = line.strip("- •*")
-            if len(line) > 5:
-                events.append(
-                    ExtractedEvent(
-                        type=(
-                            "action"
-                            if any(
-                                w in line.lower()
-                                for w in ["do", "create", "build", "implement", "add"]
-                            )
-                            else "topic"
-                        ),
-                        title=line[:120],
-                        description=line if len(line) > 120 else None,
+    seen_titles: set[str] = set()
+
+    async def _extract_chunk(chunk: str) -> list[ExtractedEvent]:
+        """Run AI extraction on one chunk; returns events, empty list on failure."""
+        chunk_events: list[ExtractedEvent] = []
+        try:
+            processor = HybridProcessorService()
+            ai_result = await processor.process(
+                input_data=chunk,
+                prompt=(
+                    "Extract key actionable events from this transcript. "
+                    "For each event provide: type (action/mention/topic/insight), title, description, "
+                    "and timestamp if mentioned."
+                ),
+            )
+            # REAL_MODE_ONLY: never synthesize events from a mocked or empty AI
+            # response -- fall through to the deterministic heuristic instead.
+            cloud_result = ai_result.cloud_result
+            backend = cloud_result.backend if cloud_result else None
+            raw_text = (ai_result.response or "") if ai_result.success else ""
+            if not raw_text.strip() or backend == "mock":
+                raise RuntimeError("AI extraction unavailable (no real Gemini response)")
+            for line in raw_text.strip().split("\n"):
+                line = line.strip("- •*")
+                if len(line) > 5:
+                    chunk_events.append(
+                        ExtractedEvent(
+                            type=(
+                                "action"
+                                if any(
+                                    w in line.lower()
+                                    for w in ["do", "create", "build", "implement", "add"]
+                                )
+                                else "topic"
+                            ),
+                            title=line[:120],
+                            description=line if len(line) > 120 else None,
+                        )
                     )
-                )
+        except Exception as exc:
+            logger.warning(f"Direct Gemini extraction unavailable for chunk: {exc}")
+        return chunk_events
+
+    try:
+        for chunk in transcript_chunks:
+            if len(events) >= _MAX_EVENTS:
+                break
+            chunk_events = await _extract_chunk(chunk)
+            for ev in chunk_events:
+                if ev.title not in seen_titles and len(events) < _MAX_EVENTS:
+                    seen_titles.add(ev.title)
+                    events.append(ev)
     except Exception as exc:
-        logger.warning(f"Direct Gemini extraction unavailable: {exc}")
+        logger.warning(f"Chunked extraction failed: {exc}")
 
     # Real-AI fallback: if no events yet, try the Vercel AI Gateway (uses
     # VERCEL_API_KEY, routes to Gemini/GPT/Claude). This keeps the AI path

--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -1132,12 +1132,11 @@ class _TTLDict(dict[str, Any]):
         Python 3.7+ dicts preserve insertion order, so ``next(iter(...))``
         returns the oldest entry in O(1) without scanning all keys.
         """
-        while len(self) > self._max_size:
+        if len(self) > self._max_size:
             oldest = next(iter(self._timestamps), None)
-            if oldest is None:
-                break
-            super().pop(oldest, None)
-            self._timestamps.pop(oldest, None)
+            if oldest is not None:
+                super().pop(oldest, None)
+                self._timestamps.pop(oldest, None)
 
     # ------------------------------------------------------------------
     # Overridden dict methods
@@ -1570,8 +1569,22 @@ async def extract_events(request: EventExtractRequest):
         start = 0
         while start < len(text):
             end = start + _CHUNK_SIZE
+            if end < len(text):
+                # Find the nearest sentence boundary (. ! ?) before the hard
+                # cut by taking the rightmost (max) position across all three
+                # punctuation marks.  Fall back to the nearest space (word
+                # boundary) if no sentence end is found in the window.
+                boundary_pos = max(
+                    text.rfind(b, start, end) for b in ('.', '!', '?')
+                )
+                if boundary_pos != -1:
+                    end = boundary_pos + 1  # include the punctuation mark
+                else:
+                    space = text.rfind(' ', start, end)
+                    if space != -1:
+                        end = space + 1
             chunks.append(text[start:end])
-            start += _CHUNK_SIZE - _CHUNK_OVERLAP
+            start = end - _CHUNK_OVERLAP
         return chunks
 
     transcript_chunks = _build_chunks(transcript_text)

--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -1085,12 +1085,13 @@ async def ingest_performance_report_v1(report: dict[str, Any]):
 # ============================================================
 
 
-class _TTLDict(dict):  # type: ignore[type-arg]
+class _TTLDict(dict[str, Any]):
     """A dict subclass that evicts entries older than *ttl* seconds.
 
     Eviction is lazy (on any mutation or `get`/`__getitem__`) plus an optional
     periodic sweep via `evict_expired()`. A *max_size* cap prevents unbounded
-    growth: when the limit is reached the oldest entry is dropped first.
+    growth: when the limit is reached the oldest (first-inserted) entry is
+    dropped. Python 3.7+ insertion-order guarantees make this O(1).
     """
 
     def __init__(
@@ -1119,15 +1120,20 @@ class _TTLDict(dict):  # type: ignore[type-arg]
 
     def evict_expired(self) -> None:
         """Remove all entries whose TTL has elapsed."""
-        expired = [k for k in list(self._timestamps) if self._is_expired(k)]
+        # Iterate a snapshot so we can mutate during the loop.
+        expired = [k for k in self._timestamps if self._is_expired(k)]
         for k in expired:
             super().pop(k, None)
             self._timestamps.pop(k, None)
 
     def _enforce_max_size(self) -> None:
-        """Drop the oldest entry when the dict exceeds *max_size*."""
+        """Drop the first-inserted entry when the dict exceeds *max_size*.
+
+        Python 3.7+ dicts preserve insertion order, so ``next(iter(...))``
+        returns the oldest entry in O(1) without scanning all keys.
+        """
         while len(self) > self._max_size:
-            oldest = min(self._timestamps, key=self._timestamps.__getitem__, default=None)
+            oldest = next(iter(self._timestamps), None)
             if oldest is None:
                 break
             super().pop(oldest, None)

--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -1104,7 +1104,7 @@ class _TTLDict(dict[str, Any]):
         super().__init__(*args, **kwargs)
         self._ttl = ttl
         self._max_size = max_size
-        # Timestamps stored separately to avoid serialisation side-effects.
+        # Timestamps stored separately to avoid serialization side-effects.
         self._timestamps: dict[str, float] = {}
 
     # ------------------------------------------------------------------

--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -1568,23 +1568,31 @@ async def extract_events(request: EventExtractRequest):
         chunks = []
         start = 0
         while start < len(text):
-            end = start + _CHUNK_SIZE
+            end = min(start + _CHUNK_SIZE, len(text))
             if end < len(text):
                 # Find the nearest sentence boundary (. ! ?) before the hard
                 # cut by taking the rightmost (max) position across all three
                 # punctuation marks.  Fall back to the nearest space (word
-                # boundary) if no sentence end is found in the window.
+                # boundary) if no sentence end is found in the window.  Only
+                # snap to a boundary that leaves the chunk longer than the
+                # overlap, otherwise a boundary near `start` would collapse
+                # forward progress (and could push `start` backwards below).
+                min_end = start + _CHUNK_OVERLAP + 1
                 boundary_pos = max(
                     text.rfind(b, start, end) for b in ('.', '!', '?')
                 )
-                if boundary_pos != -1:
+                if boundary_pos != -1 and boundary_pos + 1 >= min_end:
                     end = boundary_pos + 1  # include the punctuation mark
                 else:
                     space = text.rfind(' ', start, end)
-                    if space != -1:
+                    if space != -1 and space + 1 >= min_end:
                         end = space + 1
             chunks.append(text[start:end])
-            start = end - _CHUNK_OVERLAP
+            if end >= len(text):
+                break
+            # Guarantee forward progress: advance by at least one character so
+            # a short chunk can never produce a non-advancing or negative start.
+            start = max(end - _CHUNK_OVERLAP, start + 1)
         return chunks
 
     transcript_chunks = _build_chunks(transcript_text)

--- a/src/youtube_extension/backend/services/data_service.py
+++ b/src/youtube_extension/backend/services/data_service.py
@@ -160,7 +160,7 @@ class DataService:
                 return []
 
             # ── Pass 1: collect file paths + mtimes (no JSON reads) ──────────
-            all_files: list[tuple[Any, float]] = []
+            all_files: list[tuple[Path, float]] = []
             for md_file in self.enhanced_analysis_dir.rglob("*_enhanced.md"):
                 try:
                     mtime = md_file.stat().st_mtime

--- a/src/youtube_extension/backend/services/data_service.py
+++ b/src/youtube_extension/backend/services/data_service.py
@@ -122,34 +122,70 @@ class DataService:
             logger.error(f"Error building learning log: {e}")
             return []
 
-    def get_videos_summary(self) -> list[dict[str, Any]]:
+    def count_videos(self) -> int:
+        """Return the total number of processed videos (fast — counts files only)."""
+        try:
+            if not self.enhanced_analysis_dir.exists():
+                return 0
+            return sum(1 for _ in self.enhanced_analysis_dir.rglob("*_enhanced.md"))
+        except Exception as e:
+            logger.error(f"Error counting videos: {e}")
+            return 0
+
+    def get_videos_summary(
+        self,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
         """
-        Get summary list of processed videos.
+        Get paginated summary list of processed videos.
+
+        Uses a two-pass approach: the first pass collects only file paths and
+        mtimes (cheap), sorts by newest-first, then the second pass reads
+        metadata JSON only for the requested page — avoiding loading every
+        file's metadata when the collection is large.
+
+        Args:
+            limit: Maximum number of results (``None`` = all).
+            offset: Number of entries to skip (default 0).
 
         Returns:
-            List of video summaries
+            List of video summaries for the requested page.
         """
         try:
-            results = []
-
             if not self.enhanced_analysis_dir.exists():
                 logger.warning(
                     f"Enhanced analysis directory does not exist: {self.enhanced_analysis_dir}"
                 )
-                return results
+                return []
 
-            # Use recursive glob for all enhanced markdown files
+            # ── Pass 1: collect file paths + mtimes (no JSON reads) ──────────
+            all_files: list[tuple[Any, float]] = []
             for md_file in self.enhanced_analysis_dir.rglob("*_enhanced.md"):
                 try:
-                    # Extract video ID from filename
+                    mtime = md_file.stat().st_mtime
+                    all_files.append((md_file, mtime))
+                except OSError:
+                    continue
+
+            # Sort by newest first
+            all_files.sort(key=lambda x: x[1], reverse=True)
+
+            # Apply pagination slice
+            end = offset + limit if limit is not None else len(all_files)
+            page_files = all_files[offset:end]
+
+            # ── Pass 2: read metadata only for the requested page ─────────────
+            results = []
+            for md_file, mtime in page_files:
+                try:
                     video_id = md_file.name.split("_")[0]
                     parent_dir = md_file.parent
 
-                    # Find corresponding metadata file in the same directory
                     metadata_file = next(
                         parent_dir.glob(f"{video_id}_*_metadata.json"), None
                     )
-                    metadata = {}
+                    metadata: dict[str, Any] = {}
 
                     if metadata_file and metadata_file.exists():
                         try:
@@ -160,20 +196,14 @@ class DataService:
                                 f"Failed to parse metadata file {metadata_file}: {e}"
                             )
 
-                    # Get file statistics
-                    stat = md_file.stat()
-
-                    # Extract information from metadata
                     title = (
                         metadata.get("title")
                         or metadata.get("snippet", {}).get("title")
                         or f"Video {video_id}"
                     )
-
                     published_at = metadata.get("published_at") or metadata.get(
                         "snippet", {}
                     ).get("publishedAt")
-
                     view_count = metadata.get("view_count") or metadata.get(
                         "statistics", {}
                     ).get("viewCount")
@@ -185,27 +215,20 @@ class DataService:
                             "category": parent_dir.relative_to(
                                 self.enhanced_analysis_dir
                             ).as_posix(),
-                            "timestamp": datetime.fromtimestamp(
-                                stat.st_mtime
-                            ).isoformat(),
+                            "timestamp": datetime.fromtimestamp(mtime).isoformat(),
                             "published_at": published_at,
                             "view_count": view_count,
-                            "last_modified": datetime.fromtimestamp(
-                                stat.st_mtime
-                            ).isoformat(),
+                            "last_modified": datetime.fromtimestamp(mtime).isoformat(),
                             "markdown_path": str(md_file),
                             "metadata_path": (
                                 str(metadata_file) if metadata_file else None
                             ),
                         }
                     )
-
                 except Exception as e:
                     logger.error(f"Error processing summary for {md_file}: {e}")
                     continue
 
-            # Sort by newest first
-            results.sort(key=lambda x: x["timestamp"], reverse=True)
             return results
 
         except Exception as e:

--- a/tests/unit/test_data_service.py
+++ b/tests/unit/test_data_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -160,7 +161,12 @@ class TestGetVideosSummary:
         cat = enhanced / "cat"
         cat.mkdir(parents=True)
         for i in range(5):
-            (cat / f"vid{i:03d}_test_enhanced.md").write_text("x")
+            f = cat / f"vid{i:03d}_test_enhanced.md"
+            f.write_text("x")
+            # Space out mtimes so newest-first ordering is deterministic;
+            # tight-loop writes can otherwise share an mtime at filesystem
+            # resolution and make the page ordering nondeterministic.
+            os.utime(f, (1_000_000 + i, 1_000_000 + i))
         svc = DataService(str(enhanced), str(tmp_path / "feedback"))
         all_results = svc.get_videos_summary()
         paged = svc.get_videos_summary(limit=5, offset=2)

--- a/tests/unit/test_data_service.py
+++ b/tests/unit/test_data_service.py
@@ -143,6 +143,62 @@ class TestGetVideosSummary:
         assert "markdown_path" in entry
         assert entry["markdown_path"].endswith(".md")
 
+    def test_pagination_limit(self, tmp_path):
+        """limit param returns at most that many entries."""
+        enhanced = tmp_path / "enhanced"
+        cat = enhanced / "cat"
+        cat.mkdir(parents=True)
+        for i in range(5):
+            (cat / f"vid{i:03d}_test_enhanced.md").write_text("x")
+        svc = DataService(str(enhanced), str(tmp_path / "feedback"))
+        result = svc.get_videos_summary(limit=3)
+        assert len(result) == 3
+
+    def test_pagination_offset(self, tmp_path):
+        """offset skips entries."""
+        enhanced = tmp_path / "enhanced"
+        cat = enhanced / "cat"
+        cat.mkdir(parents=True)
+        for i in range(5):
+            (cat / f"vid{i:03d}_test_enhanced.md").write_text("x")
+        svc = DataService(str(enhanced), str(tmp_path / "feedback"))
+        all_results = svc.get_videos_summary()
+        paged = svc.get_videos_summary(limit=5, offset=2)
+        assert len(paged) == 3
+        assert all_results[2]["video_id"] == paged[0]["video_id"]
+
+    def test_pagination_beyond_total_returns_empty(self, tmp_path):
+        """offset beyond total returns empty list."""
+        enhanced = tmp_path / "enhanced"
+        cat = enhanced / "cat"
+        cat.mkdir(parents=True)
+        (cat / "vid000_test_enhanced.md").write_text("x")
+        svc = DataService(str(enhanced), str(tmp_path / "feedback"))
+        result = svc.get_videos_summary(limit=10, offset=100)
+        assert result == []
+
+
+class TestCountVideos:
+    def test_missing_dir_returns_zero(self, svc):
+        assert svc.count_videos() == 0
+
+    def test_counts_enhanced_markdown_files(self, tmp_path):
+        enhanced = tmp_path / "enhanced"
+        cat = enhanced / "cat"
+        cat.mkdir(parents=True)
+        for i in range(3):
+            (cat / f"vid{i:03d}_test_enhanced.md").write_text("x")
+        svc = DataService(str(enhanced), str(tmp_path / "feedback"))
+        assert svc.count_videos() == 3
+
+    def test_does_not_count_non_enhanced_files(self, tmp_path):
+        enhanced = tmp_path / "enhanced"
+        enhanced.mkdir(parents=True)
+        (enhanced / "vid000_test_enhanced.md").write_text("x")
+        (enhanced / "other.md").write_text("y")
+        svc = DataService(str(enhanced), str(tmp_path / "feedback"))
+        assert svc.count_videos() == 1
+
 
 # ===========================================================================
 # get_video_detail

--- a/tests/unit/test_v1_router_extended.py
+++ b/tests/unit/test_v1_router_extended.py
@@ -167,9 +167,16 @@ def _make_cache_svc():
 
 def _make_data_svc():
     svc = MagicMock()
-    svc.get_videos_summary.return_value = [
-        {"video_id": "auJzb1D-fag", "title": "Test"}
-    ]
+    # Mirror the real DataService.get_videos_summary pagination contract:
+    # the router delegates slicing to the service, so the mock must honor
+    # limit/offset (offset beyond total → empty page).
+    _all_videos = [{"video_id": "auJzb1D-fag", "title": "Test"}]
+
+    def _videos_summary(limit=None, offset=0):
+        end = offset + limit if limit is not None else len(_all_videos)
+        return _all_videos[offset:end]
+
+    svc.get_videos_summary.side_effect = _videos_summary
     svc.count_videos.return_value = 1
     svc.get_video_detail.return_value = {
         "video_id": "auJzb1D-fag",

--- a/tests/unit/test_v1_router_extended.py
+++ b/tests/unit/test_v1_router_extended.py
@@ -170,6 +170,7 @@ def _make_data_svc():
     svc.get_videos_summary.return_value = [
         {"video_id": "auJzb1D-fag", "title": "Test"}
     ]
+    svc.count_videos.return_value = 1
     svc.get_video_detail.return_value = {
         "video_id": "auJzb1D-fag",
         "metadata": {"title": "Test", "transcript_text": "hello world"},


### PR DESCRIPTION
Stacked on top of #360 (`copilot/fix-performance-issues`). Merging this branch into #360's branch clears the three open review threads and the failing `test` job.

## What this fixes

**1. `_build_chunks()` infinite loop / negative slice** — `src/youtube_extension/backend/api/v1/router.py`
A sentence/word boundary found close to `start` made `start = end - overlap` stall or move backwards (infinite loop / negative slicing). Now we only snap to a boundary that leaves the chunk longer than the overlap, and `start` advances by at least one char every iteration. Verified against pathological inputs (boundary at offset 0, all-periods, no-boundary, boundary just past the overlap) — terminates cleanly in every case.

**2. `Promise.race()` hangs when all candidates resolve null** — `apps/web/src/lib/transcription-service.ts`
`p.then(r => r ?? PENDING_FOREVER)` produced a never-settling race when every candidate returned null, so the function never reached Strategy 4. Replaced with `firstNonNull()`, which resolves on the first usable transcript or `null` once all candidates have settled.

**3. `test_list_videos_pagination` failure (the failing `test` CI job)** — `tests/unit/test_v1_router_extended.py`
The router now delegates pagination to `DataService.get_videos_summary`, so the `MagicMock` must honor `limit`/`offset`. Switched the mock from a static `return_value` to a `side_effect` that slices (`offset` beyond total → empty page).

**4. Flaky mtime ordering** — `tests/unit/test_data_service.py`
`test_pagination_offset` created files in a tight loop that can share an mtime at filesystem resolution. Now spaces mtimes with `os.utime` so newest-first ordering is deterministic.

## Not addressed here
The `build` job fails on `Cannot find module '@opentelemetry/instrumentation'` (loaded via `@sentry/nextjs` in `next.config.js`). This PR touches none of `next.config.js`, `package.json`, or Sentry — it's a pre-existing dependency-resolution issue, not a regression from #360. Flagging for a separate dependency fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X461xhciwcK5s5fm1protx

---
_Generated by [Claude Code](https://claude.ai/code/session_01X461xhciwcK5s5fm1protx)_