### PR TITLE
fix(web): revert tailwindcss to v3 to unblock the production build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,7 +43,7 @@
     "eslint": "^9",
     "eslint-config-next": "^16.2.7",
     "postcss": "^8.5.10",
-    "tailwindcss": "^4.3.1",
+    "tailwindcss": "^3.4.19",
     "typescript": "^5",
     "vite": "^8.0.16",
     "vitest": "4.1.9"

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "eslint": "^9",
         "eslint-config-next": "^16.2.7",
         "postcss": "^8.5.10",
-        "tailwindcss": "^4.3.1",
+        "tailwindcss": "^3.4.19",
         "typescript": "^5",
         "vite": "^8.0.16",
         "vitest": "4.1.9"


### PR DESCRIPTION
## Problem

The web `build` check is **failing on `main` and on every open PR** (and the Vercel deploy errors). The Turbopack build dies on:

```
./apps/web/src/app/globals.css
Error: It looks like you're trying to use `tailwindcss` directly as a PostCSS plugin.
The PostCSS plugin has moved to a separate package, so to continue using Tailwind CSS
with PostCSS you'll need to install `@tailwindcss/postcss` and update your PostCSS configuration.
```

## Root cause

`#354` (`chore(deps-dev): bump tailwindcss from 3.4.19 to 4.3.1`) — a Dependabot **major** bump — landed on `main` **without** the accompanying Tailwind v4 migration. `apps/web` is authored entirely for v3:

- `globals.css` uses the v3 `@tailwind base/components/utilities` directives
- `postcss.config.js` loads `tailwindcss` directly as a PostCSS plugin (removed in v4)
- `tailwind.config.js` is a v3-style JS config

In Tailwind v4 the PostCSS plugin moved to `@tailwindcss/postcss` and the directives changed, so v4 + this config cannot build.

## Fix

Revert the dependency to `^3.4.19`, restoring the known-good state (the build was green before #354). This is the minimal, low-risk remediation.

A genuine v4 upgrade (CSS-first `@import "tailwindcss"`, `@tailwindcss/postcss`, `@theme`) should be done deliberately as its own change — not as an unmigrated Dependabot bump.

## Notes

- CI installs with `npm install --legacy-peer-deps` (no `npm ci`), so the resolved `tailwindcss` entry in the lockfile is reconciled to v3 on install. The declared range is updated here.
- Verification: the `build` check on this PR will confirm the build goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM6gVbk68mPaR3vEiyGH92

---
_Generated by [Claude Code](https://claude.ai/code/session_01MM6gVbk68mPaR3vEiyGH92)_