### PR TITLE
chore(coderabbit): reconcile config into a single version-controlled …

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,10 +1,17 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# Single source of truth for CodeRabbit. Settings that previously lived only in
+# the CodeRabbit dashboard (inheritance, auto_assign_reviewers, finishing
+# touches, knowledge base, issue enrichment, presidio) are version-controlled
+# here so every change is reviewable in a PR. `inheritance: true` still lets the
+# org-level config layer underneath this file.
 language: en-US
 tone_instructions: >-
   Be assertive and direct. Focus on real bugs, security issues, and performance
   problems — not style nitpicks. Flag anything that could break in production.
   When you find an issue, explain why it matters and suggest a concrete fix.
 early_access: true
+inheritance: true
 reviews:
   profile: assertive
   request_changes_workflow: true
@@ -12,11 +19,37 @@ reviews:
   high_level_summary_in_walkthrough: true
   review_details: true
   fail_commit_status: true
+  auto_assign_reviewers: true
   auto_review:
     enabled: true
+    # Drafts are not auto-reviewed (reduces cost/noise); mark the PR ready when you want feedback.
     drafts: false
     base_branches:
       - main
+    # Skip work-in-progress PRs that are not opened as drafts.
+    ignore_title_keywords:
+      - WIP
+      - DO NOT MERGE
+      - "[skip ci]"
+  finishing_touches:
+    simplify:
+      enabled: true
+  # Generated, vendored, lock files, and test directories are excluded so reviews stay
+  # signal-rich. The hand-maintained SDK (sdk/python/**) is intentionally NOT
+  # excluded — CLAUDE.md requires it stay in sync with the backend models. Test files are
+  # excluded to prevent PII scanner false positives on mock/fixture data.
+  path_filters:
+    - "!**/package-lock.json"
+    - "!**/*.lock"
+    - "!src/dataconnect-generated/**"
+    - "!**/__pycache__/**"
+    - "!**/dist/**"
+    - "!**/build/**"
+    - "!**/.next/**"
+    - "!**/.turbo/**"
+    - "!**/coverage/**"
+    - "!**/htmlcov/**"
+    - "!tests/**"
   path_instructions:
     - path: "**/*.ts"
       instructions: >-
@@ -73,6 +106,12 @@ reviews:
         Stainless SDK integration. Verify the SDK is actually wired into real API calls —
         not just installed as a dependency. Flag any ad-hoc fetch() calls that should be
         using the type-safe Stainless-generated client instead.
+    - path: "sdk/python/eventrelay_sdk/**"
+      instructions: >-
+        Hand-maintained Python SDK that MUST stay in sync with
+        src/youtube_extension/backend/api/v1/models.py (the source of truth). Flag drift:
+        required backend fields weakened to Optional, enum fields typed as str instead of the
+        SDK enum, or response shapes that diverge from the backend models.
   tools:
     shellcheck:
       enabled: true
@@ -93,6 +132,8 @@ reviews:
     checkov:
       enabled: true
     ast-grep:
+      enabled: true
+    presidio:
       enabled: true
   labeling_instructions:
     - label: security
@@ -127,3 +168,12 @@ chat:
 knowledge_base:
   learnings:
     scope: auto
+  linear:
+    usage: enabled
+  mcp:
+    usage: enabled
+issue_enrichment:
+  auto_enrich:
+    enabled: true
+  labeling:
+    auto_apply_labels: true

--- a/tests/unit/test_coderabbit_config.py
+++ b/tests/unit/test_coderabbit_config.py
@@ -1,0 +1,335 @@
+"""Tests for .coderabbit.yaml configuration.
+
+Validates the fields added or changed in the PR that version-controlled
+CodeRabbit settings from the dashboard into the repository:
+  - inheritance
+  - auto_assign_reviewers
+  - auto_review.drafts (false) and ignore_title_keywords
+  - finishing_touches
+  - path_filters
+  - new path_instructions entry for sdk/python/eventrelay_sdk/**
+  - tools.presidio
+  - knowledge_base.linear and knowledge_base.mcp
+  - issue_enrichment
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+def _find_repo_root(start: Path) -> Path:
+    """Walk up from *start* until a directory containing ``.git`` is found.
+
+    This is more robust than a hardcoded ``parents[N]`` index: it works
+    regardless of how deeply nested the test file is within the repository.
+    """
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    raise FileNotFoundError(
+        f"Could not locate repository root (no .git directory) starting from {start}"
+    )
+
+
+REPO_ROOT = _find_repo_root(Path(__file__).parent)
+CONFIG_PATH = REPO_ROOT / ".coderabbit.yaml"
+
+
+
+@pytest.fixture(scope="module")
+def config() -> dict:
+    """Load and return the parsed .coderabbit.yaml as a plain dict."""
+    with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+# ---------------------------------------------------------------------------
+# File-level sanity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_config_file_exists():
+    assert CONFIG_PATH.exists(), f".coderabbit.yaml not found at {CONFIG_PATH}"
+
+
+@pytest.mark.unit
+def test_config_parses_as_valid_yaml():
+    """The file must be syntactically valid YAML."""
+    with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    assert isinstance(data, dict), "Top-level YAML document must be a mapping"
+
+
+# ---------------------------------------------------------------------------
+# inheritance (new field)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_inheritance_enabled(config):
+    """inheritance: true lets the org-level config layer underneath this file."""
+    assert config.get("inheritance") is True
+
+
+# ---------------------------------------------------------------------------
+# reviews.auto_assign_reviewers (new field)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_auto_assign_reviewers_enabled(config):
+    reviews = config["reviews"]
+    assert reviews.get("auto_assign_reviewers") is True
+
+
+# ---------------------------------------------------------------------------
+# reviews.auto_review changes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_auto_review_drafts_is_false(config):
+    """drafts is disabled (reduces cost/noise and avoids a stale
+    request-changes review silently blocking a PR once it is marked ready)."""
+    auto_review = config["reviews"]["auto_review"]
+    assert auto_review.get("drafts") is False
+
+
+@pytest.mark.unit
+def test_auto_review_ignore_title_keywords_present(config):
+    auto_review = config["reviews"]["auto_review"]
+    keywords = auto_review.get("ignore_title_keywords")
+    assert isinstance(keywords, list), "ignore_title_keywords must be a list"
+    assert len(keywords) > 0, "ignore_title_keywords must not be empty"
+
+
+@pytest.mark.unit
+def test_auto_review_ignores_wip(config):
+    keywords = config["reviews"]["auto_review"]["ignore_title_keywords"]
+    assert "WIP" in keywords
+
+
+@pytest.mark.unit
+def test_auto_review_ignores_do_not_merge(config):
+    keywords = config["reviews"]["auto_review"]["ignore_title_keywords"]
+    assert "DO NOT MERGE" in keywords
+
+
+@pytest.mark.unit
+def test_auto_review_ignores_skip_ci(config):
+    keywords = config["reviews"]["auto_review"]["ignore_title_keywords"]
+    assert "[skip ci]" in keywords
+
+
+@pytest.mark.unit
+def test_auto_review_base_branches_unchanged(config):
+    """The base_branches list must still contain 'main' after the PR."""
+    base_branches = config["reviews"]["auto_review"]["base_branches"]
+    assert "main" in base_branches
+
+
+# ---------------------------------------------------------------------------
+# reviews.finishing_touches (new section)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_finishing_touches_simplify_enabled(config):
+    finishing = config["reviews"].get("finishing_touches", {})
+    assert finishing.get("simplify", {}).get("enabled") is True
+
+
+# ---------------------------------------------------------------------------
+# reviews.path_filters (new section)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_path_filters_is_list(config):
+    path_filters = config["reviews"].get("path_filters")
+    assert isinstance(path_filters, list), "path_filters must be a list"
+    assert len(path_filters) > 0
+
+
+@pytest.mark.unit
+def test_path_filters_all_are_exclusions(config):
+    """Every filter added in this PR is an exclusion (starts with '!')."""
+    path_filters = config["reviews"]["path_filters"]
+    for f in path_filters:
+        assert f.startswith("!"), f"path_filter {f!r} must start with '!' to be an exclusion"
+
+
+@pytest.mark.unit
+def test_path_filters_excludes_package_lock(config):
+    assert "!**/package-lock.json" in config["reviews"]["path_filters"]
+
+
+@pytest.mark.unit
+def test_path_filters_excludes_lock_files(config):
+    assert "!**/*.lock" in config["reviews"]["path_filters"]
+
+
+@pytest.mark.unit
+def test_path_filters_excludes_dist(config):
+    assert "!**/dist/**" in config["reviews"]["path_filters"]
+
+
+@pytest.mark.unit
+def test_path_filters_excludes_build(config):
+    assert "!**/build/**" in config["reviews"]["path_filters"]
+
+
+@pytest.mark.unit
+def test_path_filters_excludes_coverage(config):
+    path_filters = config["reviews"]["path_filters"]
+    assert "!**/coverage/**" in path_filters
+    assert "!**/htmlcov/**" in path_filters
+
+
+@pytest.mark.unit
+def test_path_filters_does_not_exclude_sdk_python(config):
+    """sdk/python/** must NOT be in path_filters — it is intentionally kept
+    in-scope so it stays in sync with backend models (per the comment in the
+    file)."""
+    path_filters = config["reviews"]["path_filters"]
+    sdk_exclusions = [f for f in path_filters if "sdk/python" in f]
+    assert sdk_exclusions == [], (
+        "sdk/python must not be excluded from reviews; it must stay in sync "
+        f"with backend models. Found exclusions: {sdk_exclusions}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# reviews.path_instructions — new entry for sdk/python/eventrelay_sdk/**
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def path_instructions(config) -> list:
+    return config["reviews"].get("path_instructions", [])
+
+
+@pytest.mark.unit
+def test_sdk_python_path_instruction_exists(path_instructions):
+    paths = [entry["path"] for entry in path_instructions]
+    assert "sdk/python/eventrelay_sdk/**" in paths, (
+        "Expected a path_instructions entry for 'sdk/python/eventrelay_sdk/**'"
+    )
+
+
+@pytest.mark.unit
+def test_sdk_python_path_instruction_has_non_empty_instructions(path_instructions):
+    entry = next(
+        (e for e in path_instructions if e["path"] == "sdk/python/eventrelay_sdk/**"),
+        None,
+    )
+    assert entry is not None
+    instructions = entry.get("instructions", "").strip()
+    assert instructions, "sdk/python/eventrelay_sdk/** instructions must not be empty"
+
+
+@pytest.mark.unit
+def test_sdk_python_path_instruction_mentions_sync(path_instructions):
+    """Instructions should mention keeping the SDK in sync with backend models."""
+    entry = next(
+        (e for e in path_instructions if e["path"] == "sdk/python/eventrelay_sdk/**"),
+        None,
+    )
+    assert entry is not None
+    instructions = entry.get("instructions", "")
+    assert "sync" in instructions.lower() or "models.py" in instructions, (
+        "Path instructions for sdk/python/eventrelay_sdk/** should reference "
+        "sync requirement with backend models"
+    )
+
+
+# ---------------------------------------------------------------------------
+# reviews.tools.presidio (new tool)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_presidio_tool_enabled(config):
+    tools = config["reviews"].get("tools", {})
+    assert tools.get("presidio", {}).get("enabled") is True
+
+
+# ---------------------------------------------------------------------------
+# knowledge_base additions (linear, mcp)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_knowledge_base_linear_usage_enabled(config):
+    kb = config.get("knowledge_base", {})
+    assert kb.get("linear", {}).get("usage") == "enabled"
+
+
+@pytest.mark.unit
+def test_knowledge_base_mcp_usage_enabled(config):
+    kb = config.get("knowledge_base", {})
+    assert kb.get("mcp", {}).get("usage") == "enabled"
+
+
+# ---------------------------------------------------------------------------
+# issue_enrichment (entirely new section)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_issue_enrichment_section_exists(config):
+    assert "issue_enrichment" in config, "issue_enrichment top-level key must exist"
+
+
+@pytest.mark.unit
+def test_issue_enrichment_auto_enrich_enabled(config):
+    auto_enrich = config["issue_enrichment"].get("auto_enrich", {})
+    assert auto_enrich.get("enabled") is True
+
+
+@pytest.mark.unit
+def test_issue_enrichment_labeling_auto_apply(config):
+    labeling = config["issue_enrichment"].get("labeling", {})
+    assert labeling.get("auto_apply_labels") is True
+
+
+# ---------------------------------------------------------------------------
+# Regression / boundary: pre-existing fields not broken by the PR
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_language_still_en_us(config):
+    assert config.get("language") == "en-US"
+
+
+@pytest.mark.unit
+def test_early_access_still_true(config):
+    assert config.get("early_access") is True
+
+
+@pytest.mark.unit
+def test_reviews_profile_still_assertive(config):
+    assert config["reviews"].get("profile") == "assertive"
+
+
+@pytest.mark.unit
+def test_reviews_fail_commit_status_still_true(config):
+    assert config["reviews"].get("fail_commit_status") is True
+
+
+@pytest.mark.unit
+def test_auto_review_still_enabled(config):
+    assert config["reviews"]["auto_review"].get("enabled") is True
+
+
+@pytest.mark.unit
+def test_knowledge_base_learnings_scope_still_auto(config):
+    assert config["knowledge_base"]["learnings"].get("scope") == "auto"


### PR DESCRIPTION
…source of truth (#268)

* chore(coderabbit): reconcile config into single source of truth

Merge dashboard-only settings into the version-controlled .coderabbit.yaml and apply review-tuning best practices:

- Add path_filters to exclude generated/vendored/lock files (package-lock, dataconnect-generated, build/dist/.next/coverage, etc.); keep the hand-maintained sdk/python/** under review.
- Pull in dashboard-only settings: inheritance, auto_assign_reviewers, finishing_touches.simplify, presidio PII scanning, knowledge_base (linear + mcp), and issue_enrichment.
- Resolve the auto_review.drafts conflict (dashboard true vs file false) in favor of false; add ignore_title_keywords to skip non-draft WIP PRs.
- Add an sdk/python/eventrelay_sdk path_instruction enforcing the SDK <-> backend models contract from CLAUDE.md.

https://claude.ai/code/session_017PcnB4h3qMhSvEyYQkvtvT

* chore(coderabbit): auto-review drafts (drafts: true)

Flip auto_review.drafts to true so CodeRabbit reviews draft PRs too, matching the prior dashboard behavior.

https://claude.ai/code/session_017PcnB4h3qMhSvEyYQkvtvT

* 📝 CodeRabbit Chat: Add generated unit tests

* Fix: Presidio PII scanner produces false positives on mock/fixture data in test files

This commit fixes the issue reported at .coderabbit.yaml:136

## The Problem

The `.coderabbit.yaml` file enables the Presidio PII scanner without excluding test directories. Test files throughout the repository contain mock PII data (emails like `alice@example.com`, `jane@example.com`, `user@test.org`, etc.) used in fixtures and test cases.

When CodeRabbit reviews PRs that touch test files, Presidio scans these mock emails and generates false-positive PII warnings, causing:

*   Review noise and clutter from non-security issues
*   Unnecessary dismissals on every PR that modifies tests
*   Signal dilution that obscures actual PII issues in production code

## Evidence

Located mock PII in multiple test files:

*   `tests/unit/test_cloud_routes.py`: `"user_email": "alice@example.com"`, `"user_email": "bob@example.com"`
*   `tests/unit/test_user_video_models.py`: `"jane@example.com"`

Test structure confirmed:

*   `tests/` exists with test subdirectories (`tests/unit/`, etc.)
*   Multiple test files follow pytest naming conventions (`test_*.py`)

## The Fix

Added one exclusion pattern to the `path_filters` list:

1.  `!tests/**` - Excludes the main tests directory and all its contents

This keeps Presidio (and all other CodeRabbit tools) enabled for production code while preventing false positives on test fixtures.

**Note:** This exclusion suppresses ALL CodeRabbit tools (ruff, shellcheck, etc.) on test files, not just Presidio. This is acceptable if the team wants to focus those tools on production code.

Updated the comment to clarify that test files are excluded specifically to prevent PII scanner false positives on mock/fixture data.





* Fix: `[skip ci]` is included in `ignore_title_keywords` but it is a commit-message convention, not a PR-title convention, making it ineffective for skipping reviews

This commit fixes the issue reported at .coderabbit.yaml:33

## Issue Analysis

**Why This Is a Bug:**

The `ignore_title_keywords` configuration in CodeRabbit is used to skip auto-reviews when PR titles contain specific keywords. However, `[skip ci]` is a **commit message convention** recognized by CI systems (GitHub Actions, GitLab CI, etc.), not a PR title convention.

**How the Bug Manifests:**

- When CodeRabbit's auto-review system checks a PR, it examines the **PR title** for keywords in `ignore_title_keywords`
- `[skip ci]` is placed in **commit messages** to tell CI systems not to run workflows
- It is almost never placed in PR titles by teams
- Therefore, `[skip ci]` in `ignore_title_keywords` will almost never match anything, making it ineffective
- This wastes configuration and misleads teams into thinking they can skip CodeRabbit reviews using `[skip ci]`

**Correct PR Title Conventions:**

Teams actually use these in PR titles:
- `WIP` — work in progress (kept in config ✓)
- `DO NOT MERGE` — blocking merge (kept in config ✓)
- Draft status (`drafts: true` in config) — also handles true work-in-progress PRs

**The Fix:**

Removed `[skip ci]` from the `ignore_title_keywords` list. Also removed the corresponding test assertion `test_auto_review_ignores_skip_ci` that was validating this incorrect behavior.

The remaining keywords (`WIP`, `DO NOT MERGE`) are sufficient and actually match real PR title conventions that teams use.




* 📝 CodeRabbit Chat: Implement requested code changes (#294)

* 📝 CodeRabbit Chat: Implement requested code changes

* Fix: The @pytest.fixture(scope="module") decorator is missing from the config() function, causing pytest to fail injecting it into test functions that depend on it.

This commit fixes the issue reported at tests/unit/test_coderabbit_config.py:43

## Problem

The `config()` function in `tests/unit/test_coderabbit_config.py` (lines 45-48) is missing the `@pytest.fixture(scope="module")` decorator. Without this decorator, pytest will not recognize `config` as a fixture and cannot inject it into test functions.

## Evidence of the Bug

The test file contains numerous test functions that expect `config` as a parameter, which can only work if `config` is registered as a pytest fixture:

- `test_inheritance_enabled(config)` (line 72)
- `test_auto_assign_reviewers_enabled(config)` (line 82)
- `test_auto_review_drafts_is_true(config)` (line 92)
- `test_auto_review_ignore_title_keywords_present(config)` (line 99)
- `test_auto_review_ignores_wip(config)` (line 107)
- `test_auto_review_ignores_do_not_merge(config)` (line 112)
- `test_auto_review_ignores_skip_ci(config)` (line 117)
- And many more throughout the file...

Additionally, the file contains another fixture `path_instructions()` (line 167) that **is decorated** with `@pytest.fixture(scope="module")` and explicitly depends on `config` as a parameter. This demonstrates the pattern: fixtures must be decorated to be injected.

## Impact

Without the decorator:
- Pytest will fail to resolve `config` as a fixture in any test function that requests it
- All dependent tests will fail with a "fixture not found" or similar error
- The entire test suite for this configuration file will be broken

## The Fix

The `@pytest.fixture(scope="module")` decorator was restored to the `config()` function. This allows pytest to:
1. Recognize `config` as a module-scoped fixture
2. Load and parse the `.coderabbit.yaml` file once for the entire module
3. Inject the parsed config dict into all test functions that request it as a parameter





---------






---------