### PR TITLE
fix(test): unbreak baseline `test` CI — add knowledge_dir to data-service test mock

### DIFF
--- a/tests/unit/test_service_container.py
+++ b/tests/unit/test_service_container.py
@@ -453,6 +453,7 @@ class TestServiceFactories:
         sc._config = {
             "enhanced_analysis_dir": "/tmp/test_enhanced",
             "feedback_dir": "/tmp/test_feedback",
+            "knowledge_dir": "/tmp/test_knowledge",
         }
         service = sc._create_data_service()
         from youtube_extension.backend.services.data_service import DataService

--- a/tests/unit/test_service_container.py
+++ b/tests/unit/test_service_container.py
@@ -36,7 +36,7 @@ def _bare_container() -> ServiceContainer:
 class TestLoadConfiguration:
     def test_defaults_set_without_env(self, monkeypatch):
         for key in [
-            "CACHE_DIR", "ENHANCED_ANALYSIS_DIR", "FEEDBACK_DIR",
+            "CACHE_DIR", "ENHANCED_ANALYSIS_DIR", "FEEDBACK_DIR", "KNOWLEDGE_DIR",
             "RATE_LIMIT_RPS", "MAX_RECENT_REQUESTS", "VIDEO_PROCESSOR_TYPE",
             "USE_LANGEXTRACT_FALLBACK", "LIVEKIT_URL", "MOZILLA_AI_URL",
             "GEMINI_API_KEY", "GOOGLE_API_KEY", "YOUTUBE_API_KEY",
@@ -49,6 +49,7 @@ class TestLoadConfiguration:
         assert sc._config["cache_dir"] == "/tmp/uvai_cache/markdown_analysis"
         assert sc._config["enhanced_analysis_dir"] == "/tmp/uvai_cache/enhanced_analysis"
         assert sc._config["feedback_dir"] == "/tmp/uvai_cache/feedback"
+        assert sc._config["knowledge_dir"] == "/tmp/uvai_cache/knowledge"
         assert sc._config["rate_limit_rps"] == 5
         assert sc._config["max_recent_requests"] == 1000
         assert sc._config["video_processor_type"] == "auto"


### PR DESCRIPTION
## Problem

The baseline `test` CI check has been **red on `main`** (and therefore on every open PR, leaving them `mergeable_state: blocked`). The failure is a single unit test:

```
FAILED tests/unit/test_service_container.py::TestServiceFactories::test_create_data_service - KeyError: 'knowledge_dir'
= 1 failed, 6887 passed, 1 skipped ...
```

## Root cause

The "backend knowledge ingest" feature added a `knowledge_dir` to the data service:

- `service_container.py:50` populates `"knowledge_dir": os.getenv("KNOWLEDGE_DIR", "/tmp/uvai_cache/knowledge")` in the real config.
- `service_container.py:223` — `_create_data_service()` passes `knowledge_dir=self._config["knowledge_dir"]` to `DataService(...)`.

The production config is correct, but `test_create_data_service` hand-sets `_config` with only `enhanced_analysis_dir` and `feedback_dir`, so the new required key raises `KeyError`.

## Fix

Add `"knowledge_dir"` to the test's mock `_config`, matching the real config shape (per CLAUDE.md: *fix the test mock to match the real shape; don't weaken the source*). One line, test-only.

## Verification

- **Before** (on `main`): `KeyError` at `service_container.py:223` — reproduced locally.
- **After**: `tests/unit/test_service_container.py::TestServiceFactories::test_create_data_service PASSED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTQzRK2JaGjC2N9JKN4SRc)_