### PR TITLE
fix(test): unbreak baseline `test` check — add missing knowledge_dir to test_create_data_service

### DIFF
--- a/tests/unit/test_service_container.py
+++ b/tests/unit/test_service_container.py
@@ -453,6 +453,7 @@ class TestServiceFactories:
         sc._config = {
             "enhanced_analysis_dir": "/tmp/test_enhanced",
             "feedback_dir": "/tmp/test_feedback",
+            "knowledge_dir": "/tmp/test_knowledge",
         }
         service = sc._create_data_service()
         from youtube_extension.backend.services.data_service import DataService


### PR DESCRIPTION
## Problem

The `test` CI check (the pytest suite) has been failing on **every** open PR with a single error:

```
FAILED tests/unit/test_service_container.py::TestServiceFactories::test_create_data_service - KeyError: 'knowledge_dir'
= 1 failed, 6887 passed, 1 skipped, 5 deselected, 5 xpassed in 136.57s
```

This surfaced via the Dependabot jest bump #350 (`synchronize` event), whose red `test` check looked like a jest 29→30 regression — but it is **not**. The jest bump's JS checks (`build`, `lint`, `npm-audit`, `dependency-review`) are all green; the failure is in the Python suite and is pre-existing on `main`, independent of the dependency change.

## Root cause

`ServiceContainer._create_data_service()` reads three config keys:

```python
return DataService(
    enhanced_analysis_dir=self._config["enhanced_analysis_dir"],
    feedback_dir=self._config["feedback_dir"],
    knowledge_dir=self._config["knowledge_dir"],   # <-- read here
)
```

The real container config always populates `knowledge_dir` (`KNOWLEDGE_DIR` env, `service_container.py:50`), but the unit test's hand-built `_config` fixture omitted it, so the factory raised `KeyError` before constructing the service. Stale test fixture, not a production bug.

## Fix

Add the missing `knowledge_dir` key to the test's `_config` dict (one line). No production code changes.

## Verification

- Reproduced the exact `KeyError: 'knowledge_dir'` from the old fixture.
- With the key added, `DataService(...)` constructs and the test's `isinstance(service, DataService)` assertion passes (verified by replicating the factory call in isolation; the full pytest run needs the `[dev,youtube,ml]` extras that aren't in this sandbox).

Once merged, this unblocks the baseline `test` check across all open PRs (including #350 after a rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011o9N6hoNVoy7hB72rvJX7j

---
_Generated by [Claude Code](https://claude.ai/code/session_011o9N6hoNVoy7hB72rvJX7j)_