### PR TITLE
fix(test): make list_videos pagination mock honor limit/offset

### DIFF
--- a/tests/unit/test_v1_router_extended.py
+++ b/tests/unit/test_v1_router_extended.py
@@ -167,9 +167,12 @@ def _make_cache_svc():
 
 def _make_data_svc():
     svc = MagicMock()
-    svc.get_videos_summary.return_value = [
-        {"video_id": "auJzb1D-fag", "title": "Test"}
-    ]
+    _videos_summary = [{"video_id": "auJzb1D-fag", "title": "Test"}]
+    # Honor limit/offset so pagination behaves like the real data service
+    # (the /videos endpoint delegates slicing to get_videos_summary).
+    svc.get_videos_summary.side_effect = (
+        lambda limit=50, offset=0, **_: _videos_summary[offset : offset + limit]
+    )
     svc.count_videos.return_value = 1
     svc.get_video_detail.return_value = {
         "video_id": "auJzb1D-fag",


### PR DESCRIPTION
## Summary

The `test` required CI check is failing on `main` (and therefore on **every open PR** — the whole queue currently shows `blocked`/`unstable`). The failure is a single Python unit test:

```
FAILED tests/unit/test_v1_router_extended.py::TestDataEndpoints::test_list_videos_pagination
AssertionError: assert [{'video_id': 'auJzb1D-fag', 'title': 'Test'}] == []
= 1 failed, 6894 passed, 1 skipped ...
```

## Root cause

This is a bug in the **test double**, not the product.

`test_list_videos_pagination` requests `GET /api/v1/videos?limit=10&offset=100`. The endpoint (`list_videos_v1`) correctly delegates pagination to the data service:

```python
total = data_service.count_videos()
paginated_videos = data_service.get_videos_summary(limit=limit, offset=offset)
```

But the shared `_make_data_svc()` mock returned a fixed 1-item list from `get_videos_summary` **regardless of `limit`/`offset`**, so `offset=100` returned a video instead of an empty page, and the assertion `data["videos"] == []` failed.

## Fix

Replace the static `return_value` with a `side_effect` that slices the summary list by `offset`/`limit`, so the mock paginates like the real data service:

```python
svc.get_videos_summary.side_effect = (
    lambda limit=50, offset=0, **_: _videos_summary[offset : offset + limit]
)
```

This follows the repo policy of fixing the test mock to match real behaviour rather than weakening production code.

## Verification

- `offset=100, limit=10` → `videos == []`, `has_more is False` ✅ (the previously failing case)
- `offset=0, limit=10` → returns the one video, `total == 1` ✅ (`test_list_videos` unchanged)
- default `offset=0, limit=50` callers → unchanged ✅

Logic verified in isolation (the full suite needs the editable install `pip install -e .[dev,youtube,ml]`, which CI provides); CI on this PR will confirm the `test` job goes green.

## Notes / out of scope

This unblocks the **`test`** required check only. A second, independent base-branch failure blocks the **`build`** check (`Module not found: Can't resolve 'react-dom' / 'react-dom/client'` in the web build) — that fix appears to already exist in draft PR #412 ("repair broken Vercel build — align react/react-dom to v19"). Both checks need to be green before the open-PR queue can merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H416NXfnkC1jzNGWcb9Wgb)_