### PR TITLE
fix(ci): repair anthropic-wif-test workflow (was a shell recipe → startup failure on every branch)

### DIFF
--- a/.github/workflows/anthropic-wif-test.yml
+++ b/.github/workflows/anthropic-wif-test.yml
@@ -1,11 +1,17 @@
-cd ~/dev/EventRelay
-git checkout main && git pull
-cat > .github/workflows/anthropic-wif-test.yml <<'EOF'
 name: anthropic-wif-test
-on: push
+
+# This auth smoke-test exercises GitHub OIDC -> Anthropic WIF federation.
+# Scoped to main + manual dispatch so it does not run on (and redden) every
+# feature/dependabot branch. Change to `on: push` for all-branch coverage.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
 permissions:
   id-token: write
   contents: read
+
 jobs:
   call-claude:
     runs-on: ubuntu-latest
@@ -31,7 +37,3 @@ jobs:
             "workspace_id": "wrkspc_01ADvvQXic1etGMwF8SSqRm7"
           }
           JSON
-EOF
-git add .github/workflows/anthropic-wif-test.yml
-git commit -m "Add valid Anthropic WIF test workflow"
-git push origin main


### PR DESCRIPTION
## Problem

`.github/workflows/anthropic-wif-test.yml` on `main` did not contain workflow YAML. It contained the **shell recipe used to generate** the workflow — the literal text:

```
cd ~/dev/EventRelay
git checkout main && git pull
cat > .github/workflows/anthropic-wif-test.yml <<'EOF'
name: anthropic-wif-test
...
EOF
git add ... && git commit ... && git push origin main
```

GitHub cannot parse that as a workflow, so every run is a **startup failure that produces 0 jobs**. Because the file triggers `on: push`, this fires on **every push to every branch**, stamping a red ✗ on `main` and on the entire open-PR queue (all 13 non-draft open PRs inherit it). This was the single failing check making the whole queue look red, and it shows `failure` on 100% of recent runs across `main`, all `dependabot/*`, `codex/*`, and `copilot/*` branches.

Note: this is **separate** from the earlier "main CI red across 30 runs" breakage (styled-jsx + video-processor mocks), which was already resolved on `main` by #416. The primary `CI` workflow is green again; this `anthropic-wif-test` startup failure is what remained.

## Fix

- Replace the file with the actual workflow YAML that was embedded in the heredoc (OIDC token fetch via `actions/github-script`, then exchange for an Anthropic access token).
- Scope the trigger to `push` on `main` + `workflow_dispatch` instead of `on: push`, so the auth smoke-test no longer runs on (and reddens) every feature/dependabot branch. Flip back to `on: push` if all-branch coverage is intended.

## Verify

After merge, confirm the run on `main` actually starts jobs (no longer a startup failure). If the OIDC→Anthropic exchange step itself fails, that's a federation/credential configuration question (the `federation_rule_id` / `service_account_id` / `workspace_id` were already committed in the original file), not a YAML problem — and it will no longer affect PR branches.

Opened as a draft for human review; not auto-merged (protected `main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNsqBDTy59XrizU4Sjv9ym)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupthinking/eventrelay/pull/434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->