### PR TITLE
fix(cloud-ai): unblock event loop in async OCR + PR remediation scan

### DIFF
--- a/src/youtube_extension/integrations/cloud_ai/providers/azure_vision.py
+++ b/src/youtube_extension/integrations/cloud_ai/providers/azure_vision.py
@@ -263,17 +263,21 @@ class AzureVision(BaseCloudAI):
             OperationStatusCodes,
         )
 
-        # Start OCR operation
+        # Start OCR operation (offload blocking SDK calls so the event loop is
+        # never stalled by a slow Azure response).
         if image_stream:
             # Use stream for local files
             import io
-            read_response = self._vision_client.read_in_stream(
+            read_response = await asyncio.to_thread(
+                self._vision_client.read_in_stream,
                 io.BytesIO(image_stream),
-                raw=True
+                raw=True,
             )
         else:
             # Use URL for remote images
-            read_response = self._vision_client.read(image_url, raw=True)
+            read_response = await asyncio.to_thread(
+                self._vision_client.read, image_url, raw=True
+            )
 
         # Get operation location
         operation_location = read_response.headers["Operation-Location"]
@@ -283,7 +287,7 @@ class AzureVision(BaseCloudAI):
         max_wait_time = 30  # seconds
         elapsed = 0
         while elapsed < max_wait_time:
-            result = self._vision_client.get_read_result(operation_id)
+            result = await asyncio.to_thread(self._vision_client.get_read_result, operation_id)
             if result.status not in [OperationStatusCodes.running, OperationStatusCodes.not_started]:
                 break
             await asyncio.sleep(1)
@@ -302,17 +306,25 @@ class AzureVision(BaseCloudAI):
             OperationStatusCodes,
         )
 
-        read_response = self._vision_client.read_in_stream(image_stream, raw=True)
+        read_response = await asyncio.to_thread(
+            self._vision_client.read_in_stream, image_stream, raw=True
+        )
 
         operation_location = read_response.headers["Operation-Location"]
         operation_id = operation_location.split("/")[-1]
 
-        # Wait for completion
-        while True:
-            result = self._vision_client.get_read_result(operation_id)
+        # Wait for completion (bounded so a stuck operation cannot hang forever)
+        max_wait_time = 30  # seconds
+        elapsed = 0
+        while elapsed < max_wait_time:
+            result = await asyncio.to_thread(self._vision_client.get_read_result, operation_id)
             if result.status not in [OperationStatusCodes.running, OperationStatusCodes.not_started]:
                 break
             await asyncio.sleep(1)
+            elapsed += 1
+
+        if result.status != OperationStatusCodes.succeeded:
+            raise CloudAIError(f"OCR stream operation failed with status: {result.status}")
 
         return {"read_result": result.analyze_result}
 

--- a/src/youtube_extension/integrations/cloud_ai/providers/azure_vision.py
+++ b/src/youtube_extension/integrations/cloud_ai/providers/azure_vision.py
@@ -257,7 +257,7 @@ class AzureVision(BaseCloudAI):
 
     async def _perform_ocr(self, image_url: str, image_stream: Optional[bytes]) -> dict[str, Any]:
         """Perform OCR using Azure Read API."""
-        import time
+        import asyncio
 
         from azure.cognitiveservices.vision.computervision.models import (
             OperationStatusCodes,
@@ -286,7 +286,7 @@ class AzureVision(BaseCloudAI):
             result = self._vision_client.get_read_result(operation_id)
             if result.status not in [OperationStatusCodes.running, OperationStatusCodes.not_started]:
                 break
-            time.sleep(1)
+            await asyncio.sleep(1)
             elapsed += 1
 
         if result.status == OperationStatusCodes.succeeded:
@@ -296,7 +296,7 @@ class AzureVision(BaseCloudAI):
 
     async def _perform_ocr_stream(self, image_stream) -> dict[str, Any]:
         """Perform OCR on image stream."""
-        import time
+        import asyncio
 
         from azure.cognitiveservices.vision.computervision.models import (
             OperationStatusCodes,
@@ -312,7 +312,7 @@ class AzureVision(BaseCloudAI):
             result = self._vision_client.get_read_result(operation_id)
             if result.status not in [OperationStatusCodes.running, OperationStatusCodes.not_started]:
                 break
-            time.sleep(1)
+            await asyncio.sleep(1)
 
         return {"read_result": result.analyze_result}
 

--- a/src/youtube_extension/integrations/cloud_ai/providers/azure_vision.py
+++ b/src/youtube_extension/integrations/cloud_ai/providers/azure_vision.py
@@ -255,6 +255,26 @@ class AzureVision(BaseCloudAI):
             with open(image_url, 'rb') as image_file:
                 return image_file.read()
 
+    async def _await_ocr_call(self, deadline: float, func: Any, *args: Any, **kwargs: Any) -> Any:
+        """Run a blocking Azure SDK call in a worker thread, bounded by a
+        monotonic wall-clock ``deadline`` (seconds, ``loop.time()`` scale).
+
+        Offloading via ``asyncio.to_thread`` keeps the event loop responsive, and
+        ``asyncio.wait_for`` enforces the remaining budget so neither a slow read
+        nor a slow poll can run past the OCR timeout. Raises ``CloudAIError`` on
+        expiry."""
+        import asyncio
+
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            raise CloudAIError("Azure OCR operation timed out")
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(func, *args, **kwargs), timeout=remaining
+            )
+        except asyncio.TimeoutError as exc:
+            raise CloudAIError("Azure OCR operation timed out") from exc
+
     async def _perform_ocr(self, image_url: str, image_stream: Optional[bytes]) -> dict[str, Any]:
         """Perform OCR using Azure Read API."""
         import asyncio
@@ -263,35 +283,37 @@ class AzureVision(BaseCloudAI):
             OperationStatusCodes,
         )
 
-        # Start OCR operation (offload blocking SDK calls so the event loop is
-        # never stalled by a slow Azure response).
+        # Bound the whole operation by a monotonic wall-clock deadline so neither
+        # the blocking SDK calls nor the poll loop can exceed the timeout budget.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 30  # seconds
+
+        # Start OCR operation (blocking SDK calls offloaded to a worker thread).
         if image_stream:
             # Use stream for local files
             import io
-            read_response = await asyncio.to_thread(
-                self._vision_client.read_in_stream,
-                io.BytesIO(image_stream),
-                raw=True,
+            read_response = await self._await_ocr_call(
+                deadline, self._vision_client.read_in_stream,
+                io.BytesIO(image_stream), raw=True,
             )
         else:
             # Use URL for remote images
-            read_response = await asyncio.to_thread(
-                self._vision_client.read, image_url, raw=True
+            read_response = await self._await_ocr_call(
+                deadline, self._vision_client.read, image_url, raw=True,
             )
 
         # Get operation location
         operation_location = read_response.headers["Operation-Location"]
         operation_id = operation_location.split("/")[-1]
 
-        # Wait for operation completion
-        max_wait_time = 30  # seconds
-        elapsed = 0
-        while elapsed < max_wait_time:
-            result = await asyncio.to_thread(self._vision_client.get_read_result, operation_id)
+        # Poll for completion within the remaining time budget.
+        while True:
+            result = await self._await_ocr_call(
+                deadline, self._vision_client.get_read_result, operation_id,
+            )
             if result.status not in [OperationStatusCodes.running, OperationStatusCodes.not_started]:
                 break
-            await asyncio.sleep(1)
-            elapsed += 1
+            await asyncio.sleep(min(1, max(0, deadline - loop.time())))
 
         if result.status == OperationStatusCodes.succeeded:
             return {"read_result": result.analyze_result}
@@ -306,22 +328,26 @@ class AzureVision(BaseCloudAI):
             OperationStatusCodes,
         )
 
-        read_response = await asyncio.to_thread(
-            self._vision_client.read_in_stream, image_stream, raw=True
+        # Bound the whole operation by a monotonic wall-clock deadline so a stuck
+        # operation cannot hang the coroutine forever.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 30  # seconds
+
+        read_response = await self._await_ocr_call(
+            deadline, self._vision_client.read_in_stream, image_stream, raw=True,
         )
 
         operation_location = read_response.headers["Operation-Location"]
         operation_id = operation_location.split("/")[-1]
 
-        # Wait for completion (bounded so a stuck operation cannot hang forever)
-        max_wait_time = 30  # seconds
-        elapsed = 0
-        while elapsed < max_wait_time:
-            result = await asyncio.to_thread(self._vision_client.get_read_result, operation_id)
+        # Poll for completion within the remaining time budget.
+        while True:
+            result = await self._await_ocr_call(
+                deadline, self._vision_client.get_read_result, operation_id,
+            )
             if result.status not in [OperationStatusCodes.running, OperationStatusCodes.not_started]:
                 break
-            await asyncio.sleep(1)
-            elapsed += 1
+            await asyncio.sleep(min(1, max(0, deadline - loop.time())))
 
         if result.status != OperationStatusCodes.succeeded:
             raise CloudAIError(f"OCR stream operation failed with status: {result.status}")

--- a/tests/unit/test_azure_vision_provider.py
+++ b/tests/unit/test_azure_vision_provider.py
@@ -1020,6 +1020,42 @@ class TestAzureVisionPerformOCRStream:
 
 
 # ===========================================================================
+# _await_ocr_call (deadline / timeout enforcement)
+# ===========================================================================
+
+
+class TestAzureVisionAwaitOcrCall:
+    async def test_await_ocr_call_past_deadline_raises(self):
+        import asyncio
+
+        provider = _make_provider()
+        loop = asyncio.get_running_loop()
+        called = False
+
+        def _should_not_run():
+            nonlocal called
+            called = True
+            return "unused"
+
+        with pytest.raises(CloudAIError) as exc_info:
+            # Deadline already in the past -> remaining <= 0 branch.
+            await provider._await_ocr_call(loop.time() - 1, _should_not_run)
+        assert "timed out" in str(exc_info.value).lower()
+        assert called is False
+
+    async def test_await_ocr_call_slow_call_times_out(self):
+        import asyncio
+        import time as _time
+
+        provider = _make_provider()
+        loop = asyncio.get_running_loop()
+        # Tiny budget against a call that blocks longer -> wait_for TimeoutError branch.
+        with pytest.raises(CloudAIError) as exc_info:
+            await provider._await_ocr_call(loop.time() + 0.05, _time.sleep, 0.5)
+        assert "timed out" in str(exc_info.value).lower()
+
+
+# ===========================================================================
 # _analyze_image_content
 # ===========================================================================
 

--- a/tests/unit/test_azure_vision_provider.py
+++ b/tests/unit/test_azure_vision_provider.py
@@ -1000,6 +1000,24 @@ class TestAzureVisionPerformOCRStream:
 
         assert "read_result" in result
 
+    async def test_perform_ocr_stream_failed_status_raises(self):
+        import io
+        provider = _make_provider()
+        mock_client = MagicMock()
+        mock_read_resp = MagicMock()
+        mock_read_resp.headers = {"Operation-Location": "https://api/v1/operations/op-stream-fail"}
+        mock_client.read_in_stream.return_value = mock_read_resp
+        result_obj = MagicMock()
+        result_obj.status = "failed"
+        mock_client.get_read_result.return_value = result_obj
+        provider._vision_client = mock_client
+
+        mocks = _azure_sdk_mocks()
+        with patch.dict("sys.modules", mocks):
+            with pytest.raises(CloudAIError) as exc_info:
+                await provider._perform_ocr_stream(io.BytesIO(b"\xff\xd8\xff"))
+        assert "failed" in str(exc_info.value).lower()
+
 
 # ===========================================================================
 # _analyze_image_content


### PR DESCRIPTION
## Summary

This PR carries one concrete code fix produced while running the **PR Remediation & Publish Runbook** across all 18 open PRs, plus the full status report (below) so the decision-ready state is captured in one place.

### Code change
`AzureVisionProvider._perform_ocr` and `_perform_ocr_stream` are `async def` but used a blocking `time.sleep(1)` in their Azure Read polling loops, stalling the event loop on every poll. Swapped the local `import time` for `import asyncio` and used `await asyncio.sleep(1)`.

- Resolves the **Gate 4: Async Pattern Check** failure flagged on #414. The violation is present on `main`, so this is a repo-wide fix, not specific to that PR.
- An AST scan of `src/` confirms **zero** remaining `time.sleep` calls inside `async def` functions after this change (the other `time.sleep` calls in the repo are in synchronous / background-thread code and are correct).

---

## Open-PR remediation scan (oldest first)

Legend — CI = GitHub Actions checks only (Vercel deploy / CodeRabbit shown separately). Per the runbook PUBLISH GATE, **no PR was auto-merged**: none carry an `automerge` label and `main` is protected, so green PRs land in `HALTED(awaiting_merge_approval)` pending a human merge decision.

| PR | Title | Age | CI (Actions) | Conflicts | Terminal state |
|----|-------|-----|------|-----------|----------------|
| #316 | AST validation layer | 10d | ✅ all green | none | HALTED(awaiting_merge_approval) |
| #324 | Agent lock architecture overview | 10d | ⚠️ full CI did not run on head; Vercel deploy failed | unknown | HALTED(stale_no_ci) |
| #327 | Upgrade dev deps (security) | 10d | ⚠️ no CI on head; Vercel failed | unknown | HALTED(stale_no_ci) |
| #328 | Upgrade vitest/vite (security) | 10d | ⚠️ no CI on head; Vercel failed | unknown | HALTED(stale_no_ci) |
| #365 | Vercel AI Gateway (#269) | 8d | ❌ `build` (Sentry MODULE_NOT_FOUND) + E2E (token perm) | — | HALTED(ci_failing) |
| #412 | React 19 align (draft) | 5d | — | — | DEFERRED(draft) |
| #414 | Dockerfile rewrite for prod | 4d | ❌ Gate 1 Docker + Gate 3 Security + Gate 4 Async | — | HALTED(ci_failing) — Gate 4 fixed by this PR |
| #415 | Triage watermark (draft) | 4d | — | — | DEFERRED(draft) |
| #419 | bump ai 6→7 | 2d | ✅ green (fresh run) | none | HALTED(awaiting_merge_approval) |
| #421 | bump @ai-sdk/anthropic 3→4 | 2d | ✅ green (fresh run) | none | HALTED(awaiting_merge_approval) |
| #422 | bump zod 3→4 | 2d | ✅ green (fresh run) | none | HALTED(awaiting_merge_approval) |
| #426 | bump eslint 9→10 | 2d | ✅ green (fresh run) | none | HALTED(awaiting_merge_approval) |
| #430 | React 19 + pagination guard (draft) | 1d | — | — | DEFERRED(draft) |
| #432 | CI parallel lint + labeling | 1d | ✅ all green | none | HALTED(awaiting_merge_approval) |
| #433 | DatabaseOptimizer unit tests | 1d | ✅ all green | none | HALTED(awaiting_merge_approval) |
| #434 | Fix anthropic-wif-test (draft) | 1d | — | — | DEFERRED(draft) |
| #436 | DB schema extraction + PrismaAdapter | 0d | ✅ all green | none | HALTED(awaiting_merge_approval) |
| #437 | Cleanup non-working artifacts | 0d | ✅ all green | none | HALTED(awaiting_merge_approval) |

### Blockers needing a human / follow-up
- **#365** — `apps/web` `next build` fails with `MODULE_NOT_FOUND: @sentry/node-core` (Sentry dependency-resolution issue, surfaced via `apps/web/next.config.js`). The E2E "failure" is a separate `Resource not accessible by integration` token-permission error, not a code defect.
- **#414** — Gate 4 (async `time.sleep`) is fixed by this PR; **Gate 1 (Docker Build)** and **Gate 3 (Security Scan)** still fail and need investigation on that branch.
- **#324 / #327 / #328** — 10 days stale; full CI never ran on the head commit (only Vercel, which failed). Need a CI re-trigger / rebase before they can be assessed.

### Ready for merge decision (green, awaiting human sign-off)
#316, #419, #421, #422, #426, #432, #433, #436, #437 — all GitHub Actions checks passing, no conflicts. Staged action for each: merge to `main` per repo policy once approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01USCsrKBiF77ddURDFrWp3Q)_