### PR TITLE
fix(cloud-ai): unblock event loop in async OCR + timeout-branch tests

### DIFF
--- a/src/youtube_extension/integrations/cloud_ai/providers/azure_vision.py
+++ b/src/youtube_extension/integrations/cloud_ai/providers/azure_vision.py
@@ -263,17 +263,21 @@ class AzureVision(BaseCloudAI):
             OperationStatusCodes,
         )
 
-        # Start OCR operation
+        # Start OCR operation (offload blocking SDK calls so the event loop is
+        # never stalled by a slow Azure response).
         if image_stream:
             # Use stream for local files
             import io
-            read_response = self._vision_client.read_in_stream(
+            read_response = await asyncio.to_thread(
+                self._vision_client.read_in_stream,
                 io.BytesIO(image_stream),
-                raw=True
+                raw=True,
             )
         else:
             # Use URL for remote images
-            read_response = self._vision_client.read(image_url, raw=True)
+            read_response = await asyncio.to_thread(
+                self._vision_client.read, image_url, raw=True
+            )
 
         # Get operation location
         operation_location = read_response.headers["Operation-Location"]
@@ -283,7 +287,7 @@ class AzureVision(BaseCloudAI):
         max_wait_time = 30  # seconds
         elapsed = 0
         while elapsed < max_wait_time:
-            result = self._vision_client.get_read_result(operation_id)
+            result = await asyncio.to_thread(self._vision_client.get_read_result, operation_id)
             if result.status not in [OperationStatusCodes.running, OperationStatusCodes.not_started]:
                 break
             await asyncio.sleep(1)
@@ -302,17 +306,25 @@ class AzureVision(BaseCloudAI):
             OperationStatusCodes,
         )
 
-        read_response = self._vision_client.read_in_stream(image_stream, raw=True)
+        read_response = await asyncio.to_thread(
+            self._vision_client.read_in_stream, image_stream, raw=True
+        )
 
         operation_location = read_response.headers["Operation-Location"]
         operation_id = operation_location.split("/")[-1]
 
-        # Wait for completion
-        while True:
-            result = self._vision_client.get_read_result(operation_id)
+        # Wait for completion (bounded so a stuck operation cannot hang forever)
+        max_wait_time = 30  # seconds
+        elapsed = 0
+        while elapsed < max_wait_time:
+            result = await asyncio.to_thread(self._vision_client.get_read_result, operation_id)
             if result.status not in [OperationStatusCodes.running, OperationStatusCodes.not_started]:
                 break
             await asyncio.sleep(1)
+            elapsed += 1
+
+        if result.status != OperationStatusCodes.succeeded:
+            raise CloudAIError(f"OCR stream operation failed with status: {result.status}")
 
         return {"read_result": result.analyze_result}
 

--- a/src/youtube_extension/integrations/cloud_ai/providers/azure_vision.py
+++ b/src/youtube_extension/integrations/cloud_ai/providers/azure_vision.py
@@ -257,7 +257,7 @@ class AzureVision(BaseCloudAI):
 
     async def _perform_ocr(self, image_url: str, image_stream: Optional[bytes]) -> dict[str, Any]:
         """Perform OCR using Azure Read API."""
-        import time
+        import asyncio
 
         from azure.cognitiveservices.vision.computervision.models import (
             OperationStatusCodes,
@@ -286,7 +286,7 @@ class AzureVision(BaseCloudAI):
             result = self._vision_client.get_read_result(operation_id)
             if result.status not in [OperationStatusCodes.running, OperationStatusCodes.not_started]:
                 break
-            time.sleep(1)
+            await asyncio.sleep(1)
             elapsed += 1
 
         if result.status == OperationStatusCodes.succeeded:
@@ -296,7 +296,7 @@ class AzureVision(BaseCloudAI):
 
     async def _perform_ocr_stream(self, image_stream) -> dict[str, Any]:
         """Perform OCR on image stream."""
-        import time
+        import asyncio
 
         from azure.cognitiveservices.vision.computervision.models import (
             OperationStatusCodes,
@@ -312,7 +312,7 @@ class AzureVision(BaseCloudAI):
             result = self._vision_client.get_read_result(operation_id)
             if result.status not in [OperationStatusCodes.running, OperationStatusCodes.not_started]:
                 break
-            time.sleep(1)
+            await asyncio.sleep(1)
 
         return {"read_result": result.analyze_result}
 

--- a/src/youtube_extension/integrations/cloud_ai/providers/azure_vision.py
+++ b/src/youtube_extension/integrations/cloud_ai/providers/azure_vision.py
@@ -255,6 +255,26 @@ class AzureVision(BaseCloudAI):
             with open(image_url, 'rb') as image_file:
                 return image_file.read()
 
+    async def _await_ocr_call(self, deadline: float, func: Any, *args: Any, **kwargs: Any) -> Any:
+        """Run a blocking Azure SDK call in a worker thread, bounded by a
+        monotonic wall-clock ``deadline`` (seconds, ``loop.time()`` scale).
+
+        Offloading via ``asyncio.to_thread`` keeps the event loop responsive, and
+        ``asyncio.wait_for`` enforces the remaining budget so neither a slow read
+        nor a slow poll can run past the OCR timeout. Raises ``CloudAIError`` on
+        expiry."""
+        import asyncio
+
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            raise CloudAIError("Azure OCR operation timed out")
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(func, *args, **kwargs), timeout=remaining
+            )
+        except asyncio.TimeoutError as exc:
+            raise CloudAIError("Azure OCR operation timed out") from exc
+
     async def _perform_ocr(self, image_url: str, image_stream: Optional[bytes]) -> dict[str, Any]:
         """Perform OCR using Azure Read API."""
         import asyncio
@@ -263,35 +283,37 @@ class AzureVision(BaseCloudAI):
             OperationStatusCodes,
         )
 
-        # Start OCR operation (offload blocking SDK calls so the event loop is
-        # never stalled by a slow Azure response).
+        # Bound the whole operation by a monotonic wall-clock deadline so neither
+        # the blocking SDK calls nor the poll loop can exceed the timeout budget.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 30  # seconds
+
+        # Start OCR operation (blocking SDK calls offloaded to a worker thread).
         if image_stream:
             # Use stream for local files
             import io
-            read_response = await asyncio.to_thread(
-                self._vision_client.read_in_stream,
-                io.BytesIO(image_stream),
-                raw=True,
+            read_response = await self._await_ocr_call(
+                deadline, self._vision_client.read_in_stream,
+                io.BytesIO(image_stream), raw=True,
             )
         else:
             # Use URL for remote images
-            read_response = await asyncio.to_thread(
-                self._vision_client.read, image_url, raw=True
+            read_response = await self._await_ocr_call(
+                deadline, self._vision_client.read, image_url, raw=True,
             )
 
         # Get operation location
         operation_location = read_response.headers["Operation-Location"]
         operation_id = operation_location.split("/")[-1]
 
-        # Wait for operation completion
-        max_wait_time = 30  # seconds
-        elapsed = 0
-        while elapsed < max_wait_time:
-            result = await asyncio.to_thread(self._vision_client.get_read_result, operation_id)
+        # Poll for completion within the remaining time budget.
+        while True:
+            result = await self._await_ocr_call(
+                deadline, self._vision_client.get_read_result, operation_id,
+            )
             if result.status not in [OperationStatusCodes.running, OperationStatusCodes.not_started]:
                 break
-            await asyncio.sleep(1)
-            elapsed += 1
+            await asyncio.sleep(min(1, max(0, deadline - loop.time())))
 
         if result.status == OperationStatusCodes.succeeded:
             return {"read_result": result.analyze_result}
@@ -306,22 +328,26 @@ class AzureVision(BaseCloudAI):
             OperationStatusCodes,
         )
 
-        read_response = await asyncio.to_thread(
-            self._vision_client.read_in_stream, image_stream, raw=True
+        # Bound the whole operation by a monotonic wall-clock deadline so a stuck
+        # operation cannot hang the coroutine forever.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 30  # seconds
+
+        read_response = await self._await_ocr_call(
+            deadline, self._vision_client.read_in_stream, image_stream, raw=True,
         )
 
         operation_location = read_response.headers["Operation-Location"]
         operation_id = operation_location.split("/")[-1]
 
-        # Wait for completion (bounded so a stuck operation cannot hang forever)
-        max_wait_time = 30  # seconds
-        elapsed = 0
-        while elapsed < max_wait_time:
-            result = await asyncio.to_thread(self._vision_client.get_read_result, operation_id)
+        # Poll for completion within the remaining time budget.
+        while True:
+            result = await self._await_ocr_call(
+                deadline, self._vision_client.get_read_result, operation_id,
+            )
             if result.status not in [OperationStatusCodes.running, OperationStatusCodes.not_started]:
                 break
-            await asyncio.sleep(1)
-            elapsed += 1
+            await asyncio.sleep(min(1, max(0, deadline - loop.time())))
 
         if result.status != OperationStatusCodes.succeeded:
             raise CloudAIError(f"OCR stream operation failed with status: {result.status}")

--- a/tests/unit/test_azure_vision_provider.py
+++ b/tests/unit/test_azure_vision_provider.py
@@ -1020,6 +1020,51 @@ class TestAzureVisionPerformOCRStream:
 
 
 # ===========================================================================
+# _await_ocr_call (wall-clock deadline enforcement)
+# ===========================================================================
+
+
+class TestAzureVisionAwaitOcrCall:
+    """Cover the timeout-enforcement branches of ``_await_ocr_call``.
+
+    These guard the OCR wall-clock budget: the ``remaining <= 0`` pre-check and
+    the ``asyncio.TimeoutError`` path are the core behaviour the deadline fix
+    introduced, so they get explicit coverage here.
+    """
+
+    async def test_await_ocr_call_returns_value_within_budget(self):
+        import asyncio
+        provider = _make_provider()
+        deadline = asyncio.get_running_loop().time() + 10
+        result = await provider._await_ocr_call(deadline, lambda x: x * 2, 21)
+        assert result == 42
+
+    async def test_await_ocr_call_past_deadline_raises(self):
+        import asyncio
+        provider = _make_provider()
+        # Deadline already in the past -> remaining <= 0 branch, never invokes func.
+        past_deadline = asyncio.get_running_loop().time() - 1
+
+        def _should_not_run():  # pragma: no cover - asserted never called
+            raise AssertionError("func must not run once the deadline has passed")
+
+        with pytest.raises(CloudAIError) as exc_info:
+            await provider._await_ocr_call(past_deadline, _should_not_run)
+        assert "timed out" in str(exc_info.value).lower()
+
+    async def test_await_ocr_call_slow_call_times_out(self):
+        import asyncio
+        import time
+        provider = _make_provider()
+        # Tiny remaining budget against a call that blocks well past it ->
+        # asyncio.wait_for raises TimeoutError, mapped to CloudAIError.
+        deadline = asyncio.get_running_loop().time() + 0.05
+        with pytest.raises(CloudAIError) as exc_info:
+            await provider._await_ocr_call(deadline, time.sleep, 0.5)
+        assert "timed out" in str(exc_info.value).lower()
+
+
+# ===========================================================================
 # _analyze_image_content
 # ===========================================================================
 

--- a/tests/unit/test_azure_vision_provider.py
+++ b/tests/unit/test_azure_vision_provider.py
@@ -1000,6 +1000,24 @@ class TestAzureVisionPerformOCRStream:
 
         assert "read_result" in result
 
+    async def test_perform_ocr_stream_failed_status_raises(self):
+        import io
+        provider = _make_provider()
+        mock_client = MagicMock()
+        mock_read_resp = MagicMock()
+        mock_read_resp.headers = {"Operation-Location": "https://api/v1/operations/op-stream-fail"}
+        mock_client.read_in_stream.return_value = mock_read_resp
+        result_obj = MagicMock()
+        result_obj.status = "failed"
+        mock_client.get_read_result.return_value = result_obj
+        provider._vision_client = mock_client
+
+        mocks = _azure_sdk_mocks()
+        with patch.dict("sys.modules", mocks):
+            with pytest.raises(CloudAIError) as exc_info:
+                await provider._perform_ocr_stream(io.BytesIO(b"\xff\xd8\xff"))
+        assert "failed" in str(exc_info.value).lower()
+
 
 # ===========================================================================
 # _analyze_image_content


### PR DESCRIPTION
## Summary

This branch carries the **complete** Azure OCR event-loop fix **plus** the test coverage requested in review — it is a strict superset of #438 (same three fix commits `7270c90`, `a321e94`, `a64b362`) with one additional test commit on top.

> **Relationship to #438:** #438's branch (`claude/determined-maxwell-j64glo`) holds the identical three fix commits but is missing the timeout-path test that `copilot-pull-request-reviewer` flagged there. I couldn't push that test onto #438's branch from this session (branch-scope restriction), so it lands here instead. **Recommendation: merge this PR in place of #438, or cherry-pick `609985b` onto #438 — then close the other.** Only one should merge; they touch the same lines.

## Code change (commits `7270c90` → `a64b362`)

`AzureVision._perform_ocr` / `_perform_ocr_stream` are `async def` but performed blocking work on the event loop:

- `time.sleep(1)` in the Read poll loops → replaced with `await asyncio.sleep(...)`.
- Synchronous Azure SDK calls (`read` / `read_in_stream` / `get_read_result`) ran inline → offloaded via `asyncio.to_thread(...)`.
- The 30s cap only counted sleep intervals, so time inside the offloaded calls escaped the budget → introduced `_await_ocr_call`, which runs each blocking call under a monotonic `loop.time()` deadline via `asyncio.wait_for` and raises `CloudAIError` on expiry. The stream path also now raises on non-success status.

Resolves the **Gate 4: Async Pattern Check** failure flagged on #414 (the violation was on `main`, so this is a repo-wide fix). CodeRabbit confirmed the timeout finding is addressed.

## Test change (commit `609985b`)

Adds `TestAzureVisionAwaitOcrCall`, covering the previously-untested deadline branches of `_await_ocr_call`:
- `remaining <= 0` pre-check raises `CloudAIError` without invoking the call;
- a slow offloaded call trips `asyncio.wait_for` → `TimeoutError`, mapped to `CloudAIError`;
- the within-budget happy path returns the call's value.

This addresses the open `copilot-pull-request-reviewer` thread on #438.

## Verification

- `pytest tests/unit/test_azure_vision_provider.py` → **100/100 pass**.
- Coverage of `azure_vision.py` → **96%**; `_await_ocr_call` branches fully covered.
- Repo-wide AST scan → **zero** `time.sleep` inside any `async def` in `src/`.
- `ruff check src/` → no new findings (pre-existing `B904`/`F401` on `main` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwAYSDRWoBTmxkLDKatHqz)_