### PR TITLE
ci: make Cloud Run deploy health check authoritative

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -102,13 +102,23 @@ jobs:
 
       - name: Test deployment
         run: |
-          # Wait a few seconds for service to be ready
-          sleep 10
-          
-          # Test health endpoint
-          curl -f ${{ steps.url.outputs.url }}/api/v1/health || \
-          curl -f ${{ steps.url.outputs.url }}/health || \
-          echo "Health check endpoint not responding"
+          # Authoritatively verify the API is actually up. /api/v1/health only
+          # returns 200 when the v1 router (health + agent dispatch) loaded — a
+          # broken import silently 404s it, so a passing check here is the real
+          # signal that the deploy is usable. Retry to absorb cold start, then
+          # FAIL the job if it never comes healthy (do not swallow the error).
+          URL="${{ steps.url.outputs.url }}/api/v1/health"
+          for i in $(seq 1 12); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "$URL" || echo 000)
+            echo "attempt $i: GET /api/v1/health -> $code"
+            if [ "$code" = "200" ]; then
+              echo "✅ Backend healthy"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::Backend never returned 200 from /api/v1/health after ~2m — deploy is not usable."
+          exit 1
 
       - name: Create deployment summary
         run: |


### PR DESCRIPTION
## Summary

Hardens the backend Cloud Run deploy so a broken-but-listening deploy can't pass as green — directly de-risks the deploy prepped in #451.

**Problem:** the `Test deployment` step ran `curl -f .../api/v1/health || curl -f .../health || echo "…not responding"`. The trailing `|| echo` means the step **always exits 0**, even if the API is completely down.

**Why it matters:** `/api/v1/health` only returns 200 when the v1 router (health **and agent dispatch**) actually loaded. A broken import silently 404s it while the container still listens on the port — so Cloud Run's default TCP probe passes and the old check "succeeds" on a non-functional API. (This is exactly the `shared.youtube` failure mode documented in `BACKEND_DEPLOY.md`.)

**Fix:** poll `/api/v1/health` up to 12× with 10s backoff (~2 min, absorbs cold start); exit 0 on the first 200, otherwise emit a `::error::` and **fail the job**.

Scope: single step in `.github/workflows/deploy-cloud-run.yml`. No behavior change on a healthy deploy; only surfaces a genuinely broken one. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hxv4YkvPSKcpAzKASDSpPY)_