### PR TITLE
chore: untrack 3 stale build artifacts + Railway config (rebased remainder of #439)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,5 @@ docs/gemini_reference/
 data/audit/*.jsonl
 # TypeScript incremental build cache
 *.tsbuildinfo
+# Stale full-tree snapshot
+full-tree.txt

--- a/full-tree.txt
+++ b/full-tree.txt
@@ -1,8 +1,0 @@
-# Full recursive tree for groupthinking/EventRelay at commit 2e331451a376fe7b6f65150f6dffe11bb1b1b3f6
-
-This file contains the authoritative recursive `git tree` JSON returned by the GitHub REST API at the requested commit SHA. Use this as the canonical source to verify the repository layout used to generate ARCHITECTURE.md.
-
-NOTE: The content below is the raw `tree` array as returned by the API (each entry has at least `path`, `mode`, `type`, `sha`, and `size` for blobs). If you need a different encoding (plain `ls -R` style, CSV, or other), tell me and I'll add it.
-
----
-


### PR DESCRIPTION
## Summary

This is the **conflict-free, rebased remainder of #439**, opened in-scope on `claude/determined-maxwell-ldvlx6` because I can only push to my designated branch (not #439's `claude/evaluate-unused-folders`).

#439 was `dirty` (a merge conflict from the `main` force-push). On investigation the conflict was a **single benign file** — both `main` and #439 appended "regenerable artifacts" rules to `.gitignore`. Resolved as a deduplicated union.

**Most of #439's original value has already landed on `main`:** the ~992-file `dataconnect/.dataconnect/` PGlite cache and `coverage.json` are already untracked on `main` (verified: `0` `.dataconnect/` paths tracked). What remained after rebasing onto current `main` (`24120fc`) is a trivial 4-file hygiene cleanup:

| File | Change | Why |
|------|--------|-----|
| `railway.toml` | delete | Dead infra — prod is Cloud Run + Vercel; no workflow/config references it |
| `full-tree.txt` | delete | Stale tree snapshot |
| `tsconfig.tsbuildinfo` | delete | TypeScript incremental build cache (regenerable) |
| `.gitignore` | +4 lines | Adds `*.tsbuildinfo` and `full-tree.txt` rules (union with `main`'s existing block); `dataconnect/.dataconnect/` and `coverage.json` were already present on `main` |

Net: **4 files changed, +4 / −19**. All three deleted files are confirmed still tracked on `main`, so the deletions are meaningful. Zero source files modified.

## Verification

- Rebased `7ce8ce0` onto `origin/main` (`24120fc`); only `.gitignore` conflicted; resolved as union.
- No conflict markers remain; working tree clean.
- `git diff --stat origin/main`: 4 files, +4/−19.

## Relationship to #439

Supersedes #439. Recommended: **merge this and close #439** (its bulk deletion already merged; this carries the clean remainder). Alternatively, grant permission to force-update `claude/evaluate-unused-folders` and I'll push the rebase there instead.

Draft — not auto-merged; `main` is protected and this is an unattended remediation run, so the merge stays on human sign-off per the runbook's publish gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFW9N4vBmMKYxNRSSEdscT

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFW9N4vBmMKYxNRSSEdscT)_