### PR TITLE
fix(api): pagination empty-page guard + test-stub imports (supersedes #430)

### DIFF
--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -874,6 +874,14 @@ async def list_videos_v1(
     """Get paginated list of processed videos"""
     try:
         total = data_service.count_videos()
+        if offset >= total:
+            return {
+                "videos": [],
+                "total": total,
+                "limit": limit,
+                "offset": offset,
+                "has_more": False,
+            }
         paginated_videos = data_service.get_videos_summary(limit=limit, offset=offset)
 
         return {

--- a/tests/unit/test_v1_router_extended.py
+++ b/tests/unit/test_v1_router_extended.py
@@ -39,6 +39,8 @@ _STUBS = [
     "youtube_extension.services.ai.gemini_service",
     "youtube_extension.services.cloud",
     "youtube_extension.services.cloud.cloud_tasks_queue",
+    "youtube_extension.services.pipeline_audit_store",
+    "youtube_extension.services.pipeline_job_store",
     "youtube_extension.services.workflows",
     "youtube_extension.services.workflows.transcript_action_workflow",
     "youtube_extension.integration",


### PR DESCRIPTION
## Summary

Triggered by the `review_requested` webhook on **#430**. That PR was `dirty` (merge conflict) with a **failing `build`** job. On investigation, its React‑version work is **now redundant** — `main` already carries `react: ^19` / `@types/react: ^19` (independently landed), and that redundancy was the *sole* cause of both the conflict and the webpack build failure. Its stale lockfile no longer matched main.

This branch rebases **only the two still‑valuable, unmerged changes** from #430 onto current `main`, dropping the redundant React churn. Both are Python‑only and auto‑merge cleanly.

## Changes

| File | Change |
|------|--------|
| `src/youtube_extension/backend/api/v1/router.py` | `list_videos_v1`: short‑circuit to an empty page when `offset >= total` instead of unconditionally calling `get_videos_summary`. Return shape matches the normal path (`has_more=False`). Not present on `main`. |
| `tests/unit/test_v1_router_extended.py` | Add `pipeline_audit_store` and `pipeline_job_store` to `_STUBS`. The router imports both at module load (`router.py:34‑35`); without the stubs the test module fails to **collect** with `ModuleNotFoundError` in any non‑editable‑install environment. |

## Verification

- `test_list_videos_pagination` (`offset=100` against a 1‑video store → `[]`) **passes**.
- Confirmed the stub gap is real: on pristine `main`, the test file fails to collect in a non‑editable env (`ModuleNotFoundError: pipeline_audit_store`) — exactly what the `_STUBS` addition fixes. With it, the module collects and **112 pass** locally.
- Residual local failures are partial‑install artifacts on endpoints this diff does not touch (e.g. `/videos/{id}/status`); **#430's own `test` CI job was green** with these identical Python changes.

## Relationship to #430

Supersedes #430. Once this is green, **#430 can be closed** — its unique value is carried here, conflict‑free and rebased, and its React changes are already on `main`.

Opened as **draft** — not auto‑merged (protected `main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJnsx7FSGbi4uE3sDkGAZn)_