### PR TITLE
fix: wire deploy to existing GCP secrets + auth the agent-dispatch proxy

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -89,7 +89,7 @@ jobs:
             --max-instances 10 \
             --port 8080 \
             --set-env-vars "ENVIRONMENT=production,DEBUG=false,LOG_LEVEL=INFO,LOG_FORMAT=json,PYTHONPATH=/app/src" \
-            --set-secrets "GEMINI_API_KEY=gemini-api-key:latest,OPENAI_API_KEY=openai-api-key:latest"
+            --set-secrets "GEMINI_API_KEY=GEMINI_API_KEY:latest,OPENAI_API_KEY=OPENAI_API_KEY:latest,YOUTUBE_API_KEY=YOUTUBE_API_KEY:latest,EVENTRELAY_API_KEY=EVENTRELAY_API_KEY:latest"
 
       - name: Get service URL
         id: url

--- a/apps/web/src/app/api/agents/dispatch/route.ts
+++ b/apps/web/src/app/api/agents/dispatch/route.ts
@@ -61,7 +61,10 @@ export async function POST(request: Request) {
   try {
     const res = await fetch(`${base}/api/v1/agents/dispatch`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(process.env.EVENTRELAY_API_KEY ? { 'X-API-Key': process.env.EVENTRELAY_API_KEY } : {}),
+      },
       body: JSON.stringify({
         job_id: body.job_id,
         events: body.events ?? [],


### PR DESCRIPTION
## Summary
Two launch-path fixes found while provisioning GCP project `uvai-730bb` for the backend deploy:

1. **Deploy workflow referenced nonexistent secrets.** Secret Manager in `uvai-730bb` already holds `GEMINI_API_KEY`/`OPENAI_API_KEY`/`YOUTUBE_API_KEY`/`EVENTRELAY_API_KEY` (uppercase, from the previous backend), but the workflow mounted lowercase `gemini-api-key`/`openai-api-key` — the deploy would have failed at secret resolution. Now references the real names and also mounts `YOUTUBE_API_KEY` (server-side transcript capture) and `EVENTRELAY_API_KEY` (API-key auth middleware).

2. **Agent-dispatch proxy sent no auth header.** Every other backend proxy route (`chat`, `video`, `dashboard`, transcription) sends `X-API-Key` from `EVENTRELAY_API_KEY`; `agents/dispatch/route.ts` did not — so a production backend with auth enabled would 401 the headline Pro feature while everything else worked. Applies the same conditional-spread pattern.

## Verification
- Workflow YAML parses (`yaml.safe_load`)
- `apps/web` `tsc --noEmit` exits clean
- GCP side verified live: secrets exist, deployer SA (`eventrelay-deployer@uvai-730bb`) has run.admin/artifactregistry.writer/serviceAccountUser/secretAccessor, runtime compute SA has secretAccessor

## Reminder for deploy
Vercel env also needs `EVENTRELAY_API_KEY` set (same value as the GCP secret) so the frontend proxies can authenticate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)