### PR TITLE
fix(web): send X-API-Key on remaining backend proxy routes (401 gap f…

### DIFF
--- a/apps/web/src/app/api/agents/status/route.ts
+++ b/apps/web/src/app/api/agents/status/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { backendHeaders } from '@/lib/pipeline-backend';
 
 /** Resolve the FastAPI backend base URL, or null if not configured. */
 function backendBaseUrl(): string | null {
@@ -25,6 +26,7 @@ export async function GET(request: Request) {
 
   try {
     const res = await fetch(`${base}/api/v1/agents/${encodeURIComponent(agentId)}/status`, {
+      headers: backendHeaders(),
       signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) {

--- a/apps/web/src/lib/__tests__/action-tools.test.ts
+++ b/apps/web/src/lib/__tests__/action-tools.test.ts
@@ -162,3 +162,53 @@ describe('resolveBackendBaseUrl', () => {
     expect(resolveBackendBaseUrl()).toBe('http://localhost:8000');
   });
 });
+
+describe('backend auth headers on tool calls', () => {
+  // Regression coverage for the #470 401 gap: the transcript action agent's
+  // dispatch/ingest tools call non-public FastAPI endpoints, so they must send
+  // X-API-Key (via backendHeaders) once EVENTRELAY_API_KEY is configured.
+  const original = process.env.EVENTRELAY_API_KEY;
+  afterEach(() => {
+    if (original === undefined) delete process.env.EVENTRELAY_API_KEY;
+    else process.env.EVENTRELAY_API_KEY = original;
+  });
+
+  it('dispatch_agent sends a trimmed X-API-Key when EVENTRELAY_API_KEY is set', async () => {
+    process.env.EVENTRELAY_API_KEY = '  secret-key  '; // padded to prove trimming
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ agent_id: 'a1' })));
+    await getTool('dispatch_agent')!.execute(
+      { agentType: 'researcher', instruction: 'x' },
+      { backendBaseUrl: 'http://backend', fetchImpl, jobId: 'job1' },
+    );
+    const headers = (fetchImpl.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect(headers['X-API-Key']).toBe('secret-key');
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('add_to_knowledge_base sends X-API-Key when EVENTRELAY_API_KEY is set', async () => {
+    process.env.EVENTRELAY_API_KEY = 'secret-key';
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(JSON.stringify({ stored: true })));
+    await getTool('add_to_knowledge_base')!.execute(
+      { insight: 'x', tags: ['a'] },
+      { backendBaseUrl: 'http://backend', fetchImpl },
+    );
+    const headers = (fetchImpl.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect(headers['X-API-Key']).toBe('secret-key');
+  });
+
+  it('omits X-API-Key when EVENTRELAY_API_KEY is unset', async () => {
+    delete process.env.EVENTRELAY_API_KEY;
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ agent_id: 'a1' })));
+    await getTool('dispatch_agent')!.execute(
+      { agentType: 'researcher', instruction: 'x' },
+      { backendBaseUrl: 'http://backend', fetchImpl, jobId: 'job1' },
+    );
+    const headers = (fetchImpl.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect(headers['X-API-Key']).toBeUndefined();
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+});

--- a/apps/web/src/lib/action-tools.ts
+++ b/apps/web/src/lib/action-tools.ts
@@ -13,6 +13,7 @@
  */
 
 import type { FunctionDeclaration } from '@google/genai';
+import { backendHeaders } from '@/lib/pipeline-backend';
 
 // ── JSON Schema (shared by OpenAI strict tools + Gemini declarations) ──
 
@@ -209,7 +210,7 @@ const dispatchAgent: ActionTool = {
     try {
       const res = await doFetch(`${ctx.backendBaseUrl}/api/v1/agents/dispatch`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: backendHeaders(),
         body: JSON.stringify({
           job_id: ctx.jobId,
           agent_types: [agentType],
@@ -256,7 +257,7 @@ const addToKnowledgeBase: ActionTool = {
     try {
       const res = await doFetch(`${ctx.backendBaseUrl}/api/v1/knowledge/ingest`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: backendHeaders(),
         body: JSON.stringify({ text: insight, tags: strArray(input, 'tags'), source: ctx.jobId }),
         signal: AbortSignal.timeout(30_000),
       });


### PR DESCRIPTION
…rom #470) (#473)

* fix(web): send X-API-Key on remaining backend proxy routes (401 gap from #470)

PR #470 wires EVENTRELAY_API_KEY into the Cloud Run deploy and adds the X-API-Key header to the agents/dispatch proxy route, but the same header was missing from other frontend routes that call non-public FastAPI endpoints. The backend's deny-by-default APIKeyAuthMiddleware rejects any non-public route without a valid X-API-Key once EVENTRELAY_API_KEY is set (src/youtube_extension/backend/middleware/api_key_auth.py:100-113; PUBLIC_PREFIXES only exempts /health, /docs, /redoc, /openapi.json).

Devin's review of #470 flagged the resulting 401s. This closes the remaining gaps so agent dispatch works end-to-end in production:

- api/agents/status: route status polling through the shared backendHeaders() helper (same pattern already used by jobs/[jobId] and the pipeline routes), so GET /api/v1/agents/{id}/status is authenticated.
- lib/action-tools: attach X-API-Key (trimmed, matching backendHeaders) to the dispatchAgent (/api/v1/agents/dispatch) and addToKnowledgeBase (/api/v1/knowledge/ingest) tool calls used by the transcript action agent.

The pipeline/jobs proxy routes Devin also mentioned already send the header via backendHeaders(); no change needed there.

Verified: apps/web `tsc --noEmit` clean; action-tools + pipeline-backend vitest suites pass (19/19).


Claude-Session: https://claude.ai/code/session_01Q25qQkUEurBXUnKuay8E1d

* refactor(web): reuse backendHeaders() in action-tools + add X-API-Key regression tests

Address CodeRabbit review on #473:

- action-tools.ts: replace the hand-rolled Content-Type + conditional X-API-Key blocks in dispatchAgent and addToKnowledgeBase with the shared backendHeaders() helper. Forking a second copy of the header logic reintroduced the same drift risk this PR fixes; the helper is the single source of truth. Verified safe: action-tools.ts is imported only by action-agent.ts (which already has `import 'server-only'`), so pulling in the server-only pipeline-backend helper adds no client-bundle risk.
- action-tools.test.ts: add regression coverage asserting X-API-Key is sent (and trimmed) on dispatch_agent / add_to_knowledge_base when EVENTRELAY_API_KEY is set, and omitted when unset — the specific 401 gap from #470 now has a guard.

Verified: apps/web `tsc --noEmit` clean; action-tools + pipeline-backend vitest 22/22 pass.


Claude-Session: https://claude.ai/code/session_01Q25qQkUEurBXUnKuay8E1d

---------
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupthinking/eventrelay/pull/475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->