### PR TITLE
feat(web): /api/search — durable cross-video search via Upstash Search

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -46,3 +46,9 @@ XAI_API_KEY=
 # Backend API
 BACKEND_URL=http://localhost:8000
 NEXT_PUBLIC_BACKEND_URL=http://localhost:8000
+
+# Upstash Search (optional) — durable cross-video search for /api/search.
+# Create a Search index at console.upstash.com; distinct from Upstash REDIS above.
+UPSTASH_SEARCH_REST_URL=https://your-index.upstash.io
+UPSTASH_SEARCH_REST_TOKEN=your-admin-token
+# UPSTASH_SEARCH_INDEX=videos

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "@stripe/stripe-js": "^9.8.0",
     "@supabase/supabase-js": "^2.39.0",
     "@upstash/redis": "^1.38.0",
+    "@upstash/search": "^0.1.7",
     "@vercel/analytics": "^2.0.1",
     "@vercel/functions": "^3.7.4",
     "@vercel/speed-insights": "^2.0.0",

--- a/apps/web/src/app/api/__tests__/search-route.test.ts
+++ b/apps/web/src/app/api/__tests__/search-route.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+const searchMock = vi.fn();
+const upsertMock = vi.fn();
+
+vi.mock('@upstash/search', () => ({
+  Search: class {
+    index() {
+      return { search: searchMock, upsert: upsertMock };
+    }
+  },
+}));
+
+import { POST, PUT } from '@/app/api/search/route';
+import { NextRequest } from 'next/server';
+
+const ENV_KEYS = [
+  'UPSTASH_SEARCH_REST_URL',
+  'UPSTASH_SEARCH_REST_TOKEN',
+  'UPSTASH_SEARCH_INDEX',
+  'INTERNAL_REQUEST_TOKEN',
+] as const;
+const ORIGINAL_ENV = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+
+function configureSearch() {
+  process.env.UPSTASH_SEARCH_REST_URL = 'https://example-search.upstash.io';
+  process.env.UPSTASH_SEARCH_REST_TOKEN = 'test-token';
+}
+
+function postReq(body: unknown) {
+  return new NextRequest('http://localhost/api/search', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function putReq(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost/api/search', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const original = ORIGINAL_ENV[key];
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
+  searchMock.mockReset();
+  upsertMock.mockReset();
+});
+
+describe('POST /api/search', () => {
+  it('returns 503 when Upstash Search env is not configured', async () => {
+    delete process.env.UPSTASH_SEARCH_REST_URL;
+    delete process.env.UPSTASH_SEARCH_REST_TOKEN;
+    const res = await POST(postReq({ query: 'hello' }));
+    expect(res.status).toBe(503);
+    expect((await res.json()).error).toBe('search_not_configured');
+  });
+
+  it('returns 400 on a missing query', async () => {
+    configureSearch();
+    const res = await POST(postReq({}));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('missing_query');
+  });
+
+  it('returns results from the index', async () => {
+    configureSearch();
+    searchMock.mockResolvedValue([
+      { id: 'vid-1', content: { title: 'Hello world' }, score: 0.92 },
+    ]);
+    const res = await POST(postReq({ query: 'hello world', limit: 3 }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.results).toHaveLength(1);
+    expect(searchMock).toHaveBeenCalledWith({ query: 'hello world', limit: 3 });
+  });
+
+  it('clamps limit into [1, 25]', async () => {
+    configureSearch();
+    searchMock.mockResolvedValue([]);
+    await POST(postReq({ query: 'x', limit: 999 }));
+    expect(searchMock).toHaveBeenCalledWith({ query: 'x', limit: 25 });
+  });
+
+  it('surfaces index failures as 502 (no fabricated results)', async () => {
+    configureSearch();
+    searchMock.mockRejectedValue(new Error('index unavailable'));
+    const res = await POST(postReq({ query: 'x' }));
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).toBe('search_failed');
+  });
+});
+
+describe('PUT /api/search (internal upsert)', () => {
+  const DOC = { id: 'vid-1', content: { title: 'Hello' } };
+
+  it('fails closed with 503 when INTERNAL_REQUEST_TOKEN is unset', async () => {
+    configureSearch();
+    delete process.env.INTERNAL_REQUEST_TOKEN;
+    const res = await PUT(putReq({ documents: [DOC] }));
+    expect(res.status).toBe(503);
+  });
+
+  it('rejects a wrong internal token with 401', async () => {
+    configureSearch();
+    process.env.INTERNAL_REQUEST_TOKEN = 'secret';
+    const res = await PUT(putReq({ documents: [DOC] }, { 'x-eventrelay-internal': 'wrong' }));
+    expect(res.status).toBe(401);
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed documents with 400', async () => {
+    configureSearch();
+    process.env.INTERNAL_REQUEST_TOKEN = 'secret';
+    const res = await PUT(
+      putReq({ documents: [{ id: '', content: {} }] }, { 'x-eventrelay-internal': 'secret' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('upserts valid documents', async () => {
+    configureSearch();
+    process.env.INTERNAL_REQUEST_TOKEN = 'secret';
+    upsertMock.mockResolvedValue(undefined);
+    const res = await PUT(putReq({ documents: [DOC] }, { 'x-eventrelay-internal': 'secret' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.upserted).toBe(1);
+    expect(upsertMock).toHaveBeenCalledWith([DOC]);
+  });
+});

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSearchIndex, resolveSearchIndexName } from '@/lib/upstash-search';
+import type { SearchDocument } from '@/lib/upstash-search';
+
+const MAX_LIMIT = 25;
+const DEFAULT_LIMIT = 5;
+const MAX_UPSERT_BATCH = 100;
+
+/**
+ * POST /api/search — cross-video full-text/semantic search via Upstash Search.
+ * Body: { query: string, limit?: number }
+ */
+export async function POST(req: NextRequest) {
+  const index = getSearchIndex();
+  if (!index) {
+    return NextResponse.json(
+      { error: 'search_not_configured', detail: 'UPSTASH_SEARCH_REST_URL / UPSTASH_SEARCH_REST_TOKEN are not set.' },
+      { status: 503 },
+    );
+  }
+
+  let body: { query?: unknown; limit?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const query = typeof body.query === 'string' ? body.query.trim() : '';
+  if (!query) {
+    return NextResponse.json({ error: 'missing_query' }, { status: 400 });
+  }
+  const rawLimit = typeof body.limit === 'number' && Number.isFinite(body.limit) ? body.limit : DEFAULT_LIMIT;
+  const limit = Math.min(Math.max(Math.trunc(rawLimit), 1), MAX_LIMIT);
+
+  try {
+    const results = await index.search({ query, limit });
+    return NextResponse.json({
+      success: true,
+      index: resolveSearchIndexName(),
+      query,
+      results,
+    });
+  } catch (error) {
+    console.error('Upstash search error:', error);
+    return NextResponse.json(
+      { error: 'search_failed', detail: error instanceof Error ? error.message : String(error) },
+      { status: 502 },
+    );
+  }
+}
+
+/**
+ * PUT /api/search — upsert documents into the search index.
+ * Server-to-server only: requires the x-eventrelay-internal header to match
+ * INTERNAL_REQUEST_TOKEN (same trust mechanism as the middleware bypass).
+ * Body: { documents: Array<{ id: string, content: Record<string,string>, metadata? }> }
+ */
+export async function PUT(req: NextRequest) {
+  const internalToken = process.env.INTERNAL_REQUEST_TOKEN?.trim();
+  if (!internalToken) {
+    // Fail closed: without a configured token there is no legitimate caller.
+    return NextResponse.json({ error: 'ingest_not_configured' }, { status: 503 });
+  }
+  if (req.headers.get('x-eventrelay-internal') !== internalToken) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const index = getSearchIndex();
+  if (!index) {
+    return NextResponse.json(
+      { error: 'search_not_configured', detail: 'UPSTASH_SEARCH_REST_URL / UPSTASH_SEARCH_REST_TOKEN are not set.' },
+      { status: 503 },
+    );
+  }
+
+  let body: { documents?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const documents = Array.isArray(body.documents) ? (body.documents as SearchDocument[]) : [];
+  if (documents.length === 0 || documents.length > MAX_UPSERT_BATCH) {
+    return NextResponse.json(
+      { error: 'invalid_documents', detail: `Provide 1–${MAX_UPSERT_BATCH} documents.` },
+      { status: 400 },
+    );
+  }
+  const malformed = documents.find(
+    (d) => !d || typeof d.id !== 'string' || !d.id.trim() || typeof d.content !== 'object' || d.content === null,
+  );
+  if (malformed !== undefined) {
+    return NextResponse.json(
+      { error: 'invalid_documents', detail: 'Each document needs a non-empty string id and a content object.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await index.upsert(documents);
+    return NextResponse.json({
+      success: true,
+      index: resolveSearchIndexName(),
+      upserted: documents.length,
+    });
+  } catch (error) {
+    console.error('Upstash upsert error:', error);
+    return NextResponse.json(
+      { error: 'upsert_failed', detail: error instanceof Error ? error.message : String(error) },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/web/src/lib/upstash-search.ts
+++ b/apps/web/src/lib/upstash-search.ts
@@ -1,0 +1,51 @@
+/**
+ * Upstash Search client (full-text + semantic search over indexed documents).
+ *
+ * Complements the per-video vector search in `gemini-embedding.ts` /
+ * `embedding-store.ts` (which is scoped to one video's transcript chunks and
+ * backed by ephemeral storage) with a durable, cross-video index hosted on
+ * Upstash. Reads config at call time so a deploy picks up env changes without
+ * module-load ordering concerns — same pattern as `vercel-ai-gateway.ts`.
+ *
+ * Required env (Vercel project / apps/web/.env.local):
+ *   UPSTASH_SEARCH_REST_URL
+ *   UPSTASH_SEARCH_REST_TOKEN      (admin token — server-side only)
+ * Optional:
+ *   UPSTASH_SEARCH_INDEX           (default: "videos")
+ */
+
+import { Search } from '@upstash/search';
+
+export const DEFAULT_SEARCH_INDEX = 'videos';
+
+export type SearchDocument = {
+  id: string;
+  content: Record<string, string>;
+  metadata?: Record<string, unknown>;
+};
+
+export function resolveSearchConfig(): { url: string; token: string } | null {
+  const url = process.env.UPSTASH_SEARCH_REST_URL?.trim();
+  const token = process.env.UPSTASH_SEARCH_REST_TOKEN?.trim();
+  if (!url || !token) return null;
+  return { url, token };
+}
+
+export function hasUpstashSearch(): boolean {
+  return resolveSearchConfig() !== null;
+}
+
+export function resolveSearchIndexName(): string {
+  return process.env.UPSTASH_SEARCH_INDEX?.trim() || DEFAULT_SEARCH_INDEX;
+}
+
+/**
+ * Returns a handle to the configured Upstash Search index, or null when the
+ * env vars are absent (callers surface an honest 503 — never fake results).
+ */
+export function getSearchIndex() {
+  const config = resolveSearchConfig();
+  if (!config) return null;
+  const client = new Search({ url: config.url, token: config.token });
+  return client.index(resolveSearchIndexName());
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@stripe/stripe-js": "^9.8.0",
         "@supabase/supabase-js": "^2.39.0",
         "@upstash/redis": "^1.38.0",
+        "@upstash/search": "^0.1.7",
         "@vercel/analytics": "^2.0.1",
         "@vercel/functions": "^3.7.4",
         "@vercel/speed-insights": "^2.0.0",
@@ -4942,6 +4943,21 @@
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
+    },
+    "node_modules/@upstash/search": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@upstash/search/-/search-0.1.7.tgz",
+      "integrity": "sha512-rgJ52TP0eUPLFo4K6TZtiC7qICbJnEwkT+TqaDI1vN8/Hk6qidgNC9dpnUUXCiqfwogty1rlSyBhYfk6PRgXjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/vector": "^1.2.1"
+      }
+    },
+    "node_modules/@upstash/vector": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@upstash/vector/-/vector-1.2.3.tgz",
+      "integrity": "sha512-yXsWKeuHNYyH72BcSZd3bV5ZD5MybAoTvKxkMaeV2UzuGfNzbHBVh5eO+ysTWTFAf8I9XcOueF4tZfAGjCa4Iw==",
+      "license": "MIT"
     },
     "node_modules/@vercel/analytics": {
       "version": "2.0.1",
@@ -12559,6 +12575,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
## Summary

Wires the Upstash Search credentials (provisioned today) into a real endpoint, adapted to this repo's stack — the reference snippet was SvelteKit; EventRelay is Next.js App Router, so this uses `route.ts` + `NextResponse` and the repo's established patterns.

- **`lib/upstash-search.ts`** — lazy client reading `UPSTASH_SEARCH_REST_URL`/`TOKEN` at call time (same pattern as `vercel-ai-gateway.ts`); index defaults to `videos` (`UPSTASH_SEARCH_INDEX` overrides).
- **`POST /api/search`** — `{ query, limit? }` → index results. Honest degradation per REAL_MODE_ONLY: 503 `search_not_configured` when env is absent, 400 on bad input, 502 surfacing real index errors — never fabricated results.
- **`PUT /api/search`** — internal-only document upsert, gated by `x-eventrelay-internal` matching `INTERNAL_REQUEST_TOKEN` (fails closed 503 when unset; 401 on mismatch), batch cap 100.
- **Tests** — 9 vitest cases (config, auth, validation, success, error surfaces), mocking `@upstash/search`.
- `.env.example` documents placeholders; real tokens live in Vercel env only.

Complements (doesn't replace) the existing per-video embedding search at `/api/video/search`, which is single-video and ephemeral-storage-backed. Follow-up candidate: upsert transcripts/events into the index from the pipeline so cross-video search fills organically.

## Verification
- `apps/web` `tsc --noEmit` clean
- New tests 9/9 pass against the real SDK types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hxv4YkvPSKcpAzKASDSpPY)_