### PR TITLE
ci: bump actions/setup-node v4 → v5 (Node 20 runtime deprecated)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
## Summary

The post-merge E2E run for #482 surfaced this runner warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/setup-node@v4.

This bumps `actions/setup-node` from v4 to v5 everywhere it appears — `ci.yml` (×2), `e2e-tests.yml`, and `security.yml`. v5 runs on the Node 24 action runtime natively; its inputs (`node-version`, `cache`) are unchanged, so no other workflow edits are needed.

## Verification

- `grep setup-node .github/workflows/*.yml` shows all four uses now on `@v5`; no other actions in the repo were flagged by the deprecation warning.
- Behavior is validated by CI on this PR itself — the warning should no longer appear in job annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNTu9aPfBegZdmzqkBRCU

---
_Generated by [Claude Code](https://claude.ai/code/session_018RNTu9aPfBegZdmzqkBRCU)_