### PR TITLE
fix(jobs): make expire_before functional (created_at) + resolve #479 review findings

### DIFF
--- a/sdk/python/eventrelay_sdk/types.py
+++ b/sdk/python/eventrelay_sdk/types.py
@@ -8,7 +8,7 @@ with the backend models defined in:
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Optional
 
@@ -70,6 +70,10 @@ class VideoJobStatusResponse(BaseModel):
     error_reason: Optional[str] = Field(
         None,
         description="Machine-readable slug describing why a job failed (e.g. 'gemini_api_timeout')",
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="UTC creation timestamp; used by job-store retention (expire_before).",
     )
 
 
@@ -164,7 +168,7 @@ class TranscriptActionRequest(BaseModel):
 
     video_url: str = Field(..., description="YouTube video URL to process")
     language: Optional[str] = Field(
-        None,
+        "en",
         description="Optional language code for transcript processing",
     )
     transcript_text: Optional[str] = Field(

--- a/src/youtube_extension/backend/api/v1/models.py
+++ b/src/youtube_extension/backend/api/v1/models.py
@@ -9,7 +9,7 @@ Provides data validation and serialization for all API endpoints.
 
 import re
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Generic, Optional, TypeVar, Union
 
@@ -100,6 +100,10 @@ class VideoJobStatusResponse(BaseModel):
     error_reason: Optional[str] = Field(
         None,
         description="Machine-readable slug describing why a job failed (e.g. 'gemini_api_timeout')",
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="UTC creation timestamp; used by job-store retention (expire_before).",
     )
 
 

--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -1251,7 +1251,7 @@ _dispatches: _TTLDict = _TTLDict(ttl=_JOB_TTL, max_size=_JOB_MAX_SIZE)
 def _persist_video_job(job: VideoJobStatusResponse) -> None:
     _video_jobs[job.job_id] = job
     try:
-        get_job_store().save(job.job_id, job.model_dump())
+        get_job_store().save(job.job_id, job.model_dump(mode="json"))
     except Exception as exc:
         logger.warning("Job persist failed for %s: %s", job.job_id, exc)
 

--- a/src/youtube_extension/services/pipeline_job_store.py
+++ b/src/youtube_extension/services/pipeline_job_store.py
@@ -55,6 +55,11 @@ class PipelineJobStore:
         Jobs that lack a ``created_at`` field are left untouched so that legacy
         records created before this field existed are not inadvertently removed.
 
+        Naive (timezone-unaware) values — both the *cutoff* argument and any
+        stored ``created_at`` — are interpreted as UTC. Records persisted by the
+        current codebase are timezone-aware (``datetime.now(timezone.utc)``), so
+        the naive fallback only applies to legacy data.
+
         Returns the number of files deleted.
         """
         if cutoff.tzinfo is None:

--- a/tests/unit/test_master_roadmap_fixes.py
+++ b/tests/unit/test_master_roadmap_fixes.py
@@ -103,6 +103,36 @@ def test_job_store_expire_before_skips_missing_created_at(tmp_path):
     assert store.load("no_ts_job") is not None
 
 
+def test_persisted_video_job_is_expirable(tmp_path):
+    """A real VideoJobStatusResponse persisted like production must be expirable.
+
+    Regression for the CodeRabbit/Copilot finding on #479: expire_before() was a
+    no-op because VideoJobStatusResponse carried no created_at, so its persisted
+    model_dump() never matched. The model now supplies a UTC created_at at
+    construction, and persistence uses model_dump(mode="json") so it serialises to
+    an ISO string that expire_before() can parse.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from youtube_extension.backend.api.v1.models import (
+        JobStatus,
+        VideoJobStatusResponse,
+    )
+
+    job = VideoJobStatusResponse(job_id="real_job", status=JobStatus.pending)
+    assert job.created_at.tzinfo is not None  # tz-aware UTC by default
+
+    payload = job.model_dump(mode="json")
+    assert isinstance(payload["created_at"], str)  # JSON-serialisable
+
+    store = PipelineJobStore(tmp_path)
+    store.save("real_job", payload)
+
+    cutoff = datetime.now(timezone.utc) + timedelta(hours=1)
+    assert store.expire_before(cutoff) == 1
+    assert store.load("real_job") is None
+
+
 def test_vera_pre_check_gateway_exception_does_not_crash():
     from agents.pipeline_orchestrator import VideoPipelineOrchestrator
 


### PR DESCRIPTION
## What

Focused follow-up to **#479** (now **merged** into `main`). #479 shipped the phase 1–4 work (`error_reason`, `expire_before`, audit token counts, a11y), but its automated reviews surfaced findings that landed unaddressed. This PR fixes them on top of merged `main` — the diff is **Python-only, 5 files, +47/−4**.

## Review findings resolved

| Source | Finding | Resolution |
|---|---|---|
| **Copilot** | `expire_before()` was a **production no-op** — `VideoJobStatusResponse.model_dump()` had no `created_at`, so no persisted record ever matched the cutoff | Added a UTC `created_at` (`default_factory`) to the backend model **and** its SDK mirror; persist via `model_dump(mode="json")` so the datetime serialises to an ISO string the store can parse. `created_at` is set once at construction and preserved across in-place status updates and disk round-trips. |
| **Devin** | SDK↔backend drift: `TranscriptActionRequest.language` defaulted `None` in SDK vs `"en"` in backend | Aligned SDK default to `"en"` (backend is source of truth per `CLAUDE.md`). |
| **Devin** (info) | `expire_before()` UTC-naive assumption undocumented | Documented in the docstring. |
| **Devin** (info) | `aria-controls` → conditionally-rendered panel | No change — Devin explicitly notes this is industry-standard, not a bug. |
| **Devin / Copilot** | `SESSION_HANDOFF.md` doc inaccuracies | Moot — file was deleted in `main`. |

## Changes

- `backend/api/v1/models.py`, `sdk/.../types.py` — add `created_at` to `VideoJobStatusResponse` (kept in sync); SDK `language` default → `"en"`.
- `backend/api/v1/router.py` — `_persist_video_job` uses `model_dump(mode="json")`.
- `services/pipeline_job_store.py` — `expire_before` docstring documents UTC handling.
- `tests/unit/test_master_roadmap_fixes.py` — regression test asserting a real persisted job is now expirable.

## Verification

End-to-end run against current `main`: `created_at` is tz-aware & JSON-serialisable, preserved across mutation + disk reconstruct; a real persisted `VideoJobStatusResponse` is now removed by `expire_before` (previously a no-op); SDK↔backend contract confirmed in sync. Store/model unit tests green; `black --check` clean. (Pre-existing repo-wide `ruff UP045`/`E402` untouched.)

## Follow-up (out of scope)

`expire_before()` is now functional but still needs wiring into a scheduled cleanup path to run in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KFaqY1eSgBeeznCwTMnYh