### PR TITLE
fix(web): retry malformed Gemini JSON + index analyses into Upstash Search

### DIFF
--- a/apps/web/src/app/api/pipeline/stream/route.ts
+++ b/apps/web/src/app/api/pipeline/stream/route.ts
@@ -630,6 +630,18 @@ export async function POST(request: Request) {
                 console.warn(`[CloudEvent] Background task failed (non-fatal):`, err);
               }),
             );
+
+            // Durable cross-video search index (Upstash) — unlike the local-disk
+            // stores above, this persists on Vercel's read-only filesystem.
+            // Skips honestly when UPSTASH_SEARCH_* env is absent.
+            waitUntil(
+              (async () => {
+                const { indexVideoAnalysis } = await import('@/lib/search-indexer');
+                await indexVideoAnalysis(videoUrl, analysis);
+              })().catch((err) => {
+                console.warn(`[SearchIndex] Background task failed (non-fatal):`, err);
+              }),
+            );
           };
 
           if (useBackend && backendUrl) {

--- a/apps/web/src/lib/__tests__/gemini-video-analyzer.test.ts
+++ b/apps/web/src/lib/__tests__/gemini-video-analyzer.test.ts
@@ -48,6 +48,11 @@ describe('parseAnalysisResult', () => {
     expect(parseAnalysisResult('```json\n' + VALID_JSON + '\n```').title).toBe('T');
   });
 
+  it('parses pretty-printed multi-line fenced JSON', () => {
+    const pretty = JSON.stringify(VALID_ANALYSIS, null, 2);
+    expect(parseAnalysisResult('```json\n' + pretty + '\n```').title).toBe('T');
+  });
+
   it('salvages a JSON object wrapped in prose', () => {
     const noisy = `Here is the analysis you asked for:\n${VALID_JSON}\nLet me know if you need more.`;
     expect(parseAnalysisResult(noisy).summary).toBe('S');

--- a/apps/web/src/lib/__tests__/gemini-video-analyzer.test.ts
+++ b/apps/web/src/lib/__tests__/gemini-video-analyzer.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+const { gatewayChatMock } = vi.hoisted(() => ({ gatewayChatMock: vi.fn() }));
+
+vi.mock('@/lib/vercel-ai-gateway', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/vercel-ai-gateway')>();
+  return {
+    ...actual,
+    hasAiGatewayKey: () => true,
+    gatewayChat: gatewayChatMock,
+  };
+});
+
+vi.mock('@/lib/transcription-service', () => ({
+  fetchTranscript: vi.fn(async () => ({ success: false, error: 'unavailable in tests' })),
+}));
+
+import {
+  AnalysisParseError,
+  analyzeVideoWithGemini,
+  parseAnalysisResult,
+} from '@/lib/gemini-video-analyzer';
+
+const VALID_ANALYSIS = {
+  title: 'T',
+  summary: 'S',
+  transcript: [{ start: 0, duration: 5, text: 'hello' }],
+  events: [],
+  actions: [],
+  topics: ['a'],
+  architectureCode: '',
+  ingestScript: '',
+  e22Snippets: [],
+};
+const VALID_JSON = JSON.stringify(VALID_ANALYSIS);
+
+afterEach(() => {
+  gatewayChatMock.mockReset();
+  vi.useRealTimers();
+});
+
+describe('parseAnalysisResult', () => {
+  it('parses clean JSON', () => {
+    expect(parseAnalysisResult(VALID_JSON).title).toBe('T');
+  });
+
+  it('parses fenced JSON', () => {
+    expect(parseAnalysisResult('```json\n' + VALID_JSON + '\n```').title).toBe('T');
+  });
+
+  it('salvages a JSON object wrapped in prose', () => {
+    const noisy = `Here is the analysis you asked for:\n${VALID_JSON}\nLet me know if you need more.`;
+    expect(parseAnalysisResult(noisy).summary).toBe('S');
+  });
+
+  it('throws AnalysisParseError on unsalvageable output', () => {
+    expect(() => parseAnalysisResult("{'title': 'single quotes are not JSON'}")).toThrow(
+      AnalysisParseError,
+    );
+  });
+
+  it('throws AnalysisParseError on truncated JSON (unterminated string)', () => {
+    expect(() => parseAnalysisResult(VALID_JSON.slice(0, VALID_JSON.length / 2))).toThrow(
+      AnalysisParseError,
+    );
+  });
+});
+
+describe('analyzeVideoWithGemini retry on parse failure', () => {
+  it('retries when the model returns malformed JSON and succeeds on the next attempt', async () => {
+    vi.useFakeTimers();
+    gatewayChatMock
+      .mockResolvedValueOnce({ content: "{'not': 'json'}" })
+      .mockResolvedValueOnce({ content: VALID_JSON });
+
+    const promise = analyzeVideoWithGemini('https://www.youtube.com/watch?v=abc123');
+    await vi.advanceTimersByTimeAsync(5_000); // cover the 2s backoff after attempt 1
+    const result = await promise;
+
+    expect(result.title).toBe('T');
+    expect(gatewayChatMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up after max retries of malformed JSON', async () => {
+    vi.useFakeTimers();
+    gatewayChatMock.mockResolvedValue({ content: 'not json at all' });
+
+    const promise = analyzeVideoWithGemini('https://www.youtube.com/watch?v=abc123');
+    const assertion = expect(promise).rejects.toThrow(/failed after 3 attempts/);
+    await vi.advanceTimersByTimeAsync(20_000); // cover 2s + 4s backoffs
+    await assertion;
+    expect(gatewayChatMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/web/src/lib/__tests__/search-indexer.test.ts
+++ b/apps/web/src/lib/__tests__/search-indexer.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+const upsertMock = vi.fn();
+
+vi.mock('@upstash/search', () => ({
+  Search: class {
+    index() {
+      return { upsert: upsertMock, search: vi.fn() };
+    }
+  },
+}));
+
+import {
+  buildVideoDocuments,
+  extractVideoId,
+  indexVideoAnalysis,
+} from '@/lib/search-indexer';
+import type { VideoAnalysisResult } from '@/lib/gemini-video-analyzer';
+
+const ENV_KEYS = ['UPSTASH_SEARCH_REST_URL', 'UPSTASH_SEARCH_REST_TOKEN'] as const;
+const ORIGINAL_ENV = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+
+function analysis(overrides: Partial<VideoAnalysisResult> = {}): VideoAnalysisResult {
+  return {
+    title: 'Deploying with E22',
+    summary: 'A walkthrough of cloud deployment.',
+    transcript: [
+      { start: 0, duration: 30, text: 'Welcome to the video.' },
+      { start: 30, duration: 30, text: 'Today we deploy to the cloud.' },
+    ],
+    events: [
+      {
+        timestamp: 10,
+        label: 'Setup CLI',
+        description: 'Install the CLI',
+        codeMapping: 'npm i -g cli',
+        cloudService: 'E22',
+      },
+    ],
+    actions: [],
+    topics: ['deployment', 'cloud'],
+    architectureCode: '',
+    ingestScript: '',
+    e22Snippets: [],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const original = ORIGINAL_ENV[key];
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
+  upsertMock.mockReset();
+});
+
+describe('extractVideoId', () => {
+  it('pulls the v= param from a watch URL', () => {
+    expect(extractVideoId('https://www.youtube.com/watch?v=abc-123&t=5')).toBe('abc-123');
+  });
+
+  it('sanitizes non-watch URLs into a safe id', () => {
+    expect(extractVideoId('https://youtu.be/xyz')).toBe('https___youtu_be_xyz');
+  });
+});
+
+describe('buildVideoDocuments', () => {
+  it('emits a summary document plus transcript chunks with string content', () => {
+    const docs = buildVideoDocuments('https://www.youtube.com/watch?v=vid1', analysis());
+    expect(docs[0].id).toBe('video:vid1');
+    expect(docs[0].content.topics).toBe('deployment, cloud');
+    expect(docs[0].content.events).toBe('Setup CLI');
+    expect(docs[0].metadata?.type).toBe('video_summary');
+
+    const chunkDocs = docs.slice(1);
+    expect(chunkDocs.length).toBeGreaterThan(0);
+    expect(chunkDocs[0].id).toBe('video:vid1:t0');
+    expect(chunkDocs[0].content.text).toContain('Welcome to the video.');
+    expect(chunkDocs[0].metadata?.type).toBe('transcript_chunk');
+    expect(chunkDocs[0].metadata?.startSeconds).toBe(0);
+  });
+
+  it('caps transcript documents at 40 chunks', () => {
+    const longTranscript = Array.from({ length: 60 }, (_, i) => ({
+      start: i * 30,
+      duration: 30,
+      text: 'x'.repeat(1600),
+    }));
+    const docs = buildVideoDocuments(
+      'https://www.youtube.com/watch?v=long1',
+      analysis({ transcript: longTranscript }),
+    );
+    expect(docs).toHaveLength(41); // 1 summary + 40 capped chunks
+  });
+
+  it('skips empty transcript segments', () => {
+    const docs = buildVideoDocuments(
+      'https://www.youtube.com/watch?v=vid2',
+      analysis({ transcript: [{ start: 0, duration: 10, text: '   ' }] }),
+    );
+    expect(docs).toHaveLength(1); // summary only
+  });
+});
+
+describe('indexVideoAnalysis', () => {
+  it('returns null and does not upsert when Upstash Search is unconfigured', async () => {
+    delete process.env.UPSTASH_SEARCH_REST_URL;
+    delete process.env.UPSTASH_SEARCH_REST_TOKEN;
+    const result = await indexVideoAnalysis('https://www.youtube.com/watch?v=vid1', analysis());
+    expect(result).toBeNull();
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  it('upserts the built documents and returns the count when configured', async () => {
+    process.env.UPSTASH_SEARCH_REST_URL = 'https://example-search.upstash.io';
+    process.env.UPSTASH_SEARCH_REST_TOKEN = 'test-token';
+    const result = await indexVideoAnalysis('https://www.youtube.com/watch?v=vid1', analysis());
+    expect(result).toBeGreaterThanOrEqual(2);
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+    const docs = upsertMock.mock.calls[0][0];
+    expect(docs[0].id).toBe('video:vid1');
+  });
+});

--- a/apps/web/src/lib/__tests__/vercel-ai-gateway.test.ts
+++ b/apps/web/src/lib/__tests__/vercel-ai-gateway.test.ts
@@ -36,6 +36,12 @@ describe('vercel-ai-gateway', () => {
     expect(stripJsonCodeFence('```json\n{"ok":true}\n```')).toBe('{"ok":true}');
   });
 
+  it('keeps every line of multi-line (pretty-printed) fenced JSON', () => {
+    const pretty = '{\n  "ok": true,\n  "n": 1\n}';
+    expect(stripJsonCodeFence('```json\n' + pretty + '\n```')).toBe(pretty);
+    expect(JSON.parse(stripJsonCodeFence('```json\n' + pretty + '\n```'))).toEqual({ ok: true, n: 1 });
+  });
+
   it('chunks text using embeddings-demo sentence split', () => {
     expect(chunkTextForEmbedding('First idea. Second idea.')).toEqual([
       'First idea',

--- a/apps/web/src/lib/gemini-video-analyzer.ts
+++ b/apps/web/src/lib/gemini-video-analyzer.ts
@@ -194,15 +194,18 @@ export function parseAnalysisResult(raw: string): VideoAnalysisResult {
   try {
     return JSON.parse(cleaned) as VideoAnalysisResult;
   } catch (parseError) {
-    const start = cleaned.indexOf('{');
-    const end = cleaned.lastIndexOf('}');
-    if (start !== -1 && end > start) {
+    // Salvage the outermost {...} span — from the fence-stripped string first,
+    // then from the raw response in case fence stripping mangled the payload.
+    for (const source of [cleaned, raw]) {
+      const start = source.indexOf('{');
+      const end = source.lastIndexOf('}');
+      if (start === -1 || end <= start) continue;
       try {
-        const salvaged = JSON.parse(cleaned.slice(start, end + 1)) as VideoAnalysisResult;
+        const salvaged = JSON.parse(source.slice(start, end + 1)) as VideoAnalysisResult;
         console.warn('[Video Analyzer] Salvaged analysis JSON from a noisy model response.');
         return salvaged;
       } catch {
-        // fall through to the typed error below
+        // try the next source, then fall through to the typed error below
       }
     }
     const message = parseError instanceof Error ? parseError.message : String(parseError);

--- a/apps/web/src/lib/gemini-video-analyzer.ts
+++ b/apps/web/src/lib/gemini-video-analyzer.ts
@@ -168,6 +168,52 @@ ${actualTranscript ? actualTranscript : "(No transcript available, you MUST use 
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 /**
+ * Raised when the model's response cannot be parsed as the analysis JSON.
+ * Distinct from API errors so the retry loop can treat malformed output as
+ * retryable — production logs show Gemini intermittently emitting invalid or
+ * truncated JSON that a fresh attempt resolves.
+ */
+export class AnalysisParseError extends Error {
+  constructor(
+    message: string,
+    readonly rawSnippet: string,
+  ) {
+    super(message);
+    this.name = 'AnalysisParseError';
+  }
+}
+
+/**
+ * Parses a model response into a VideoAnalysisResult. Strips markdown fences,
+ * and on failure salvages the outermost {...} span (models occasionally wrap
+ * the object in prose or emit trailing garbage). Throws AnalysisParseError
+ * when no valid JSON object can be recovered.
+ */
+export function parseAnalysisResult(raw: string): VideoAnalysisResult {
+  const cleaned = stripJsonCodeFence(raw);
+  try {
+    return JSON.parse(cleaned) as VideoAnalysisResult;
+  } catch (parseError) {
+    const start = cleaned.indexOf('{');
+    const end = cleaned.lastIndexOf('}');
+    if (start !== -1 && end > start) {
+      try {
+        const salvaged = JSON.parse(cleaned.slice(start, end + 1)) as VideoAnalysisResult;
+        console.warn('[Video Analyzer] Salvaged analysis JSON from a noisy model response.');
+        return salvaged;
+      } catch {
+        // fall through to the typed error below
+      }
+    }
+    const message = parseError instanceof Error ? parseError.message : String(parseError);
+    throw new AnalysisParseError(
+      `Model returned unparseable analysis JSON: ${message}`,
+      cleaned.slice(0, 200),
+    );
+  }
+}
+
+/**
  * Executes a deep agentic analysis of a YouTube video using Gemini + Google Search.
  * Performs exponential backoff for 503 overload and 429 quota errors.
  */
@@ -187,11 +233,13 @@ async function analyzeVideoWithGateway(
           'Return ONLY a single JSON object matching the required schema. No markdown fences.',
       },
     ],
-    max_tokens: 8192,
+    // 16k cap: production logs showed 8k truncating long analyses mid-string,
+    // which surfaced as "Unterminated string in JSON" parse failures.
+    max_tokens: 16_384,
     temperature: 0.2,
     timeoutMs: 55_000,
   });
-  return JSON.parse(stripJsonCodeFence(result.content)) as VideoAnalysisResult;
+  return parseAnalysisResult(result.content);
 }
 
 export async function analyzeVideoWithGemini(
@@ -244,10 +292,11 @@ export async function analyzeVideoWithGemini(
       });
 
       const resultText = response.text || '{}';
-      return JSON.parse(resultText) as VideoAnalysisResult;
+      return parseAnalysisResult(resultText);
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       const retryable =
+        error instanceof AnalysisParseError ||
         errorMessage.includes('503') ||
         errorMessage.toLowerCase().includes('high traffic') ||
         errorMessage.includes('overloaded') ||
@@ -258,7 +307,7 @@ export async function analyzeVideoWithGemini(
         attempt++;
         if (attempt >= MAX_RETRIES) {
           throw new Error(
-            `Gemini API unavailable after ${MAX_RETRIES} attempts. Original error: ${errorMessage}`,
+            `Gemini analysis failed after ${MAX_RETRIES} attempts. Original error: ${errorMessage}`,
           );
         }
 

--- a/apps/web/src/lib/search-indexer.ts
+++ b/apps/web/src/lib/search-indexer.ts
@@ -1,0 +1,117 @@
+import 'server-only';
+
+/**
+ * Indexes completed video analyses into the durable Upstash Search index so
+ * cross-video search (/api/search) fills organically from the pipeline.
+ *
+ * This is the durable complement to the local-disk stores (`training-store`,
+ * `embedding-store`), whose writes fail on Vercel's read-only filesystem
+ * (ENOENT /var/task/apps/web/data in production logs). Indexing is ancillary:
+ * callers run it via waitUntil after the SSE stream completes, and a missing
+ * Upstash config results in an honest skip — never fabricated success.
+ */
+
+import { getSearchIndex, resolveSearchIndexName } from './upstash-search';
+import type { SearchDocument } from './upstash-search';
+import type { VideoAnalysisResult } from './gemini-video-analyzer';
+
+/** Target size of one transcript document's text (~400 tokens). */
+const CHUNK_CHAR_TARGET = 1600;
+/** Bound the per-video batch well under the /api/search upsert cap of 100. */
+const MAX_TRANSCRIPT_DOCS = 40;
+
+export function extractVideoId(videoUrl: string): string {
+  return (
+    videoUrl.match(/[?&]v=([^&]+)/)?.[1] || videoUrl.replace(/[^a-zA-Z0-9_-]/g, '_')
+  );
+}
+
+/** Merge transcript segments into ~CHUNK_CHAR_TARGET-sized texts, keeping the start offset of each chunk. */
+function chunkTranscriptText(
+  transcript: VideoAnalysisResult['transcript'],
+): { start: number; text: string }[] {
+  const chunks: { start: number; text: string }[] = [];
+  let current = '';
+  let currentStart = 0;
+  for (const segment of transcript) {
+    const text = segment.text?.trim();
+    if (!text) continue;
+    if (!current) currentStart = segment.start;
+    current = current ? `${current} ${text}` : text;
+    if (current.length >= CHUNK_CHAR_TARGET) {
+      chunks.push({ start: currentStart, text: current });
+      current = '';
+    }
+  }
+  if (current) chunks.push({ start: currentStart, text: current });
+  return chunks;
+}
+
+export function buildVideoDocuments(
+  videoUrl: string,
+  analysis: VideoAnalysisResult,
+): SearchDocument[] {
+  const videoId = extractVideoId(videoUrl);
+  const indexedAt = new Date().toISOString();
+
+  const documents: SearchDocument[] = [
+    {
+      id: `video:${videoId}`,
+      content: {
+        title: analysis.title || videoId,
+        summary: analysis.summary || '',
+        topics: (analysis.topics || []).join(', '),
+        events: (analysis.events || []).map((e) => e.label).join('; '),
+      },
+      metadata: { url: videoUrl, videoId, type: 'video_summary', indexedAt },
+    },
+  ];
+
+  const chunks = chunkTranscriptText(analysis.transcript || []);
+  const dropped = Math.max(0, chunks.length - MAX_TRANSCRIPT_DOCS);
+  for (const [i, chunk] of chunks.slice(0, MAX_TRANSCRIPT_DOCS).entries()) {
+    documents.push({
+      id: `video:${videoId}:t${i}`,
+      content: {
+        title: analysis.title || videoId,
+        text: chunk.text,
+      },
+      metadata: {
+        url: videoUrl,
+        videoId,
+        type: 'transcript_chunk',
+        startSeconds: chunk.start,
+        indexedAt,
+      },
+    });
+  }
+  if (dropped > 0) {
+    console.warn(
+      `[SearchIndex] Transcript for ${videoId} exceeds ${MAX_TRANSCRIPT_DOCS} chunks; dropped ${dropped} tail chunks.`,
+    );
+  }
+
+  return documents;
+}
+
+/**
+ * Upserts the analysis into the Upstash Search index. Returns the number of
+ * documents indexed, or null when Upstash Search is not configured (skip is
+ * logged once per call; this path must never fail the pipeline).
+ */
+export async function indexVideoAnalysis(
+  videoUrl: string,
+  analysis: VideoAnalysisResult,
+): Promise<number | null> {
+  const index = getSearchIndex();
+  if (!index) {
+    console.log('[SearchIndex] Skipped: UPSTASH_SEARCH_REST_URL/TOKEN not configured.');
+    return null;
+  }
+  const documents = buildVideoDocuments(videoUrl, analysis);
+  await index.upsert(documents);
+  console.log(
+    `[SearchIndex] Upserted ${documents.length} documents for ${extractVideoId(videoUrl)} into "${resolveSearchIndexName()}".`,
+  );
+  return documents.length;
+}

--- a/apps/web/src/lib/vercel-ai-gateway.ts
+++ b/apps/web/src/lib/vercel-ai-gateway.ts
@@ -169,7 +169,10 @@ export async function gatewayEmbedOne(text: string, model?: string): Promise<num
 export function stripJsonCodeFence(text: string): string {
   const trimmed = text.trim();
   if (!trimmed.startsWith('```')) return trimmed;
-  const withoutOpening = trimmed.split('\n', 2)[1] ?? trimmed;
+  // Keep everything after the opening fence line — split('\n', 2)[1] here
+  // would keep only the first content line and mangle pretty-printed JSON.
+  const firstNewline = trimmed.indexOf('\n');
+  const withoutOpening = firstNewline === -1 ? '' : trimmed.slice(firstNewline + 1);
   return withoutOpening.replace(/```\s*$/u, '').trim();
 }
 


### PR DESCRIPTION
## Summary

Fixes the two recurring production failures surfaced by the Vercel log export (production `main`, 20:39–21:01 UTC, 1,119 rows):

**1. Gemini JSON parse failures → user-facing pipeline errors (18× in 21 min)**
Every error was `Pipeline stream processing error: SyntaxError` from parsing the model's analysis output. Two shapes: malformed output right after the opening brace, and truncation mid-string (`Unterminated string in JSON at position ~10–12k`, consistent with the 8k `max_tokens` cap). The analyzer's retry loop only covered 503/429, so parse failures were never retried.

- `parseAnalysisResult()` (new, exported): strips markdown fences, salvages the outermost `{...}` span from prose-wrapped responses, and throws a typed `AnalysisParseError` when unrecoverable.
- The retry loop now treats `AnalysisParseError` as retryable (same 3-attempt exponential backoff).
- Gateway `max_tokens` doubled 8,192 → 16,384 to stop truncation-induced unterminated strings.

**2. Production persistence writes always fail on Vercel (59× ENOENT in 21 min)**
`training-store` / `embedding-store` write to `path.join(process.cwd(), 'data', ...)` — read-only (`/var/task`) on Vercel, so no analysis was ever durably persisted from production.

- New `lib/search-indexer.ts`: builds a summary document (title/summary/topics/event labels) plus ~1,600-char transcript chunk documents (capped at 40, logged when the tail is dropped) and upserts them into the Upstash Search index from #482.
- Wired into `schedulePostProcessing` in the SSE route via `waitUntil`, alongside the existing training/embeddings/CloudEvent tasks — non-blocking, honest skip (logged) when `UPSTASH_SEARCH_*` env is absent, per REAL_MODE_ONLY.
- This is the pipeline→index follow-up anticipated in #482: cross-video search now fills organically as videos are analyzed.

Not addressed here (needs Vercel env config, not code): rate limiting fail-open (`UPSTASH_REDIS_*` unset in production) and the backend-proxy timeouts falling through to Gemini.

## Verification

- 14 new vitest cases: `parseAnalysisResult` (clean/fenced/prose-wrapped/unsalvageable/truncated), retry-then-succeed and retry-exhaustion via mocked gateway with fake timers; search-indexer document shapes, chunk cap, empty-segment handling, unconfigured skip, and upsert.
- Full `apps/web` suite: 200/200 across 36 files.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RNTu9aPfBegZdmzqkBRCU

---
_Generated by [Claude Code](https://claude.ai/code/session_018RNTu9aPfBegZdmzqkBRCU)_