### PR TITLE
fix(youtube): complete youtube-transcript-api >=1.0 migration across remaining call sites

### DIFF
--- a/shared/libs/youtube_proxy.py
+++ b/shared/libs/youtube_proxy.py
@@ -364,12 +364,12 @@ class YouTubeAPIProxy:
         """Get video transcript with retry logic and fallback methods"""
 
         async def _transcript_operation():
-            transcript_data = []
             proxy_url = _get_webshare_proxy_url()
             proxy_config = _get_transcript_proxy_config()
             # youtube-transcript-api is synchronous/blocking network I/O; run it
-            # in an executor so it doesn't stall the event loop.
-            loop = asyncio.get_running_loop()
+            # in an executor so it doesn't stall the event loop. (get_event_loop
+            # matches the convention used across the rest of this codebase.)
+            loop = asyncio.get_event_loop()
 
             # Method 1: Direct transcript API
             # youtube-transcript-api >=1.0 replaced the ``get_transcript`` class

--- a/shared/libs/youtube_proxy.py
+++ b/shared/libs/youtube_proxy.py
@@ -29,9 +29,11 @@ try:
         CouldNotRetrieveTranscript,
         NoTranscriptFound,
     )
+    from youtube_transcript_api.proxies import GenericProxyConfig
     YOUTUBE_DEPS_AVAILABLE = True
 except ImportError as e:
     YOUTUBE_DEPS_AVAILABLE = False
+    GenericProxyConfig = None  # type: ignore[assignment,misc]
     logging.warning(f"YouTube dependencies not available: {e}")
 
 logger = logging.getLogger("youtube_api_proxy")
@@ -49,6 +51,25 @@ def _get_webshare_proxy_url() -> str | None:
         )
         return None
     return url
+
+
+def _get_transcript_proxy_config():
+    """Return a youtube-transcript-api proxy config object, or None.
+
+    youtube-transcript-api >=1.0 replaced the ``proxies=`` keyword with a
+    ``proxy_config`` constructor argument accepting a proxy config object.
+    """
+    url = _get_webshare_proxy_url()
+    if not url:
+        return None
+    if GenericProxyConfig is None:
+        logger.warning(
+            "WEBSHARE_PROXY_URL is set but youtube-transcript-api proxy support "
+            "is unavailable (requires youtube-transcript-api>=1.0) — falling back "
+            "to direct connection"
+        )
+        return None
+    return GenericProxyConfig(http_url=url, https_url=url)
 
 
 def _redact_proxy_credentials(text: str) -> str:
@@ -345,11 +366,17 @@ class YouTubeAPIProxy:
         async def _transcript_operation():
             transcript_data = []
             proxy_url = _get_webshare_proxy_url()
-            proxies = {"http": proxy_url, "https": proxy_url} if proxy_url else None
+            proxy_config = _get_transcript_proxy_config()
 
             # Method 1: Direct transcript API
+            # youtube-transcript-api >=1.0 replaced the ``get_transcript`` class
+            # method with an instance ``fetch`` that returns a FetchedTranscript;
+            # ``to_raw_data`` yields the list-of-dicts shape the rest of the
+            # pipeline expects. The ``proxies=`` kwarg was replaced by a
+            # ``proxy_config`` constructor argument.
             try:
-                transcript = YouTubeTranscriptApi.get_transcript(video_id, proxies=proxies)
+                yt_api = YouTubeTranscriptApi(proxy_config=proxy_config)
+                transcript = yt_api.fetch(video_id).to_raw_data()
                 if transcript:
                     logger.info(f"✅ Direct transcript extraction: {len(transcript)} segments")
                     return transcript
@@ -357,10 +384,14 @@ class YouTubeAPIProxy:
                 logger.debug(f"Direct transcript failed: {e}")
 
             # Method 2: Alternative language codes
+            # ``list_transcripts`` class method is now the instance ``list``;
+            # each Transcript's ``fetch`` returns a FetchedTranscript, so
+            # ``to_raw_data`` restores the list-of-dicts.
             try:
-                transcript_list = YouTubeTranscriptApi.list_transcripts(video_id, proxies=proxies)
+                yt_api = YouTubeTranscriptApi(proxy_config=proxy_config)
+                transcript_list = yt_api.list(video_id)
                 for transcript_item in transcript_list:
-                    transcript = transcript_item.fetch()
+                    transcript = transcript_item.fetch().to_raw_data()
                     if transcript:
                         logger.info(f"✅ Alternative language transcript: {len(transcript)} segments")
                         return transcript

--- a/shared/libs/youtube_proxy.py
+++ b/shared/libs/youtube_proxy.py
@@ -53,7 +53,7 @@ def _get_webshare_proxy_url() -> str | None:
     return url
 
 
-def _get_transcript_proxy_config():
+def _get_transcript_proxy_config() -> GenericProxyConfig | None:
     """Return a youtube-transcript-api proxy config object, or None.
 
     youtube-transcript-api >=1.0 replaced the ``proxies=`` keyword with a
@@ -367,6 +367,9 @@ class YouTubeAPIProxy:
             transcript_data = []
             proxy_url = _get_webshare_proxy_url()
             proxy_config = _get_transcript_proxy_config()
+            # youtube-transcript-api is synchronous/blocking network I/O; run it
+            # in an executor so it doesn't stall the event loop.
+            loop = asyncio.get_running_loop()
 
             # Method 1: Direct transcript API
             # youtube-transcript-api >=1.0 replaced the ``get_transcript`` class
@@ -376,7 +379,9 @@ class YouTubeAPIProxy:
             # ``proxy_config`` constructor argument.
             try:
                 yt_api = YouTubeTranscriptApi(proxy_config=proxy_config)
-                transcript = yt_api.fetch(video_id).to_raw_data()
+                transcript = await loop.run_in_executor(
+                    None, lambda: yt_api.fetch(video_id).to_raw_data()
+                )
                 if transcript:
                     logger.info(f"✅ Direct transcript extraction: {len(transcript)} segments")
                     return transcript
@@ -389,9 +394,20 @@ class YouTubeAPIProxy:
             # ``to_raw_data`` restores the list-of-dicts.
             try:
                 yt_api = YouTubeTranscriptApi(proxy_config=proxy_config)
-                transcript_list = yt_api.list(video_id)
+                transcript_list = await loop.run_in_executor(
+                    None, lambda: yt_api.list(video_id)
+                )
                 for transcript_item in transcript_list:
-                    transcript = transcript_item.fetch().to_raw_data()
+                    # A single language failing (disabled/blocked) must not abort
+                    # the whole loop — try the next available transcript.
+                    try:
+                        transcript = await loop.run_in_executor(
+                            None,
+                            lambda item=transcript_item: item.fetch().to_raw_data(),
+                        )
+                    except Exception as item_e:
+                        logger.debug(f"Alternative language item failed: {item_e}")
+                        continue
                     if transcript:
                         logger.info(f"✅ Alternative language transcript: {len(transcript)} segments")
                         return transcript

--- a/shared/libs/youtube_proxy.py
+++ b/shared/libs/youtube_proxy.py
@@ -423,7 +423,9 @@ class YouTubeAPIProxy:
             except Exception as e:
                 logger.debug(f"yt-dlp extraction failed: {e}")
 
-            raise CouldNotRetrieveTranscript(f"All transcript extraction methods failed for {video_id}")
+            # CouldNotRetrieveTranscript(>=1.0) takes a bare video_id and builds
+            # its own message/URL; passing a sentence corrupts the generated URL.
+            raise CouldNotRetrieveTranscript(video_id)
 
         return await self._execute_with_retry(_transcript_operation, "transcript")
 

--- a/src/agents/interactive_metadata_extractor.py
+++ b/src/agents/interactive_metadata_extractor.py
@@ -79,8 +79,13 @@ class InteractiveMetadataExtractor:
 
         try:
             # Try YouTube's auto-generated captions (youtube-transcript-api >=1.0
-            # instance API; to_raw_data restores the list-of-dicts shape).
-            transcript = YouTubeTranscriptApi().fetch(video_id).to_raw_data()
+            # instance API; to_raw_data restores the list-of-dicts shape). The
+            # call is blocking network I/O, so run it in an executor to keep the
+            # event loop free.
+            loop = asyncio.get_event_loop()
+            transcript = await loop.run_in_executor(
+                None, lambda: YouTubeTranscriptApi().fetch(video_id).to_raw_data()
+            )
 
             for i, entry in enumerate(transcript):
                 transcript_lines.append({

--- a/src/agents/interactive_metadata_extractor.py
+++ b/src/agents/interactive_metadata_extractor.py
@@ -78,8 +78,9 @@ class InteractiveMetadataExtractor:
         transcript_lines = []
 
         try:
-            # Try YouTube's auto-generated captions
-            transcript = YouTubeTranscriptApi.get_transcript(video_id)
+            # Try YouTube's auto-generated captions (youtube-transcript-api >=1.0
+            # instance API; to_raw_data restores the list-of-dicts shape).
+            transcript = YouTubeTranscriptApi().fetch(video_id).to_raw_data()
 
             for i, entry in enumerate(transcript):
                 transcript_lines.append({

--- a/src/agents/process_video_with_mcp.py
+++ b/src/agents/process_video_with_mcp.py
@@ -210,11 +210,17 @@ class RealVideoProcessor:
 
     # ---------- Core async ops ----------
     async def _extract_transcript_with_rotation(self, video_id: str) -> list[dict[str, Any]]:
+        # youtube_transcript_api is synchronous/blocking network I/O; run it in
+        # an executor so it doesn't stall the event loop for other coroutines.
+        loop = asyncio.get_event_loop()
+
         # 1) Direct transcript
         try:
             if YouTubeTranscriptApi is not None:
                 # youtube-transcript-api >=1.0 instance API
-                transcript = YouTubeTranscriptApi().fetch(video_id).to_raw_data()
+                transcript = await loop.run_in_executor(
+                    None, lambda: YouTubeTranscriptApi().fetch(video_id).to_raw_data()
+                )
                 if transcript:
                     return transcript
         except Exception:
@@ -223,9 +229,14 @@ class RealVideoProcessor:
         # 2) List transcripts and fetch
         try:
             if YouTubeTranscriptApi is not None:
-                for t in YouTubeTranscriptApi().list(video_id):  # type: ignore[union-attr]
+                transcript_list = await loop.run_in_executor(
+                    None, lambda: YouTubeTranscriptApi().list(video_id)  # type: ignore[union-attr]
+                )
+                for t in transcript_list:
                     try:
-                        data = t.fetch().to_raw_data()
+                        data = await loop.run_in_executor(
+                            None, lambda t=t: t.fetch().to_raw_data()
+                        )
                         if data:
                             return data
                     except Exception:

--- a/src/agents/process_video_with_mcp.py
+++ b/src/agents/process_video_with_mcp.py
@@ -213,7 +213,8 @@ class RealVideoProcessor:
         # 1) Direct transcript
         try:
             if YouTubeTranscriptApi is not None:
-                transcript = YouTubeTranscriptApi.get_transcript(video_id)
+                # youtube-transcript-api >=1.0 instance API
+                transcript = YouTubeTranscriptApi().fetch(video_id).to_raw_data()
                 if transcript:
                     return transcript
         except Exception:
@@ -222,9 +223,9 @@ class RealVideoProcessor:
         # 2) List transcripts and fetch
         try:
             if YouTubeTranscriptApi is not None:
-                for t in YouTubeTranscriptApi.list_transcripts(video_id):  # type: ignore[union-attr]
+                for t in YouTubeTranscriptApi().list(video_id):  # type: ignore[union-attr]
                     try:
-                        data = t.fetch()
+                        data = t.fetch().to_raw_data()
                         if data:
                             return data
                     except Exception:

--- a/src/integration/youtube_api.py
+++ b/src/integration/youtube_api.py
@@ -96,7 +96,7 @@ class YouTubeAPIService:
         loop = asyncio.get_event_loop()
         transcript = await loop.run_in_executor(
             None,
-            lambda: YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
+            lambda: YouTubeTranscriptApi().fetch(video_id, languages=languages).to_raw_data()
         )
 
         return [

--- a/src/mcp/mcp_video_processor.py
+++ b/src/mcp/mcp_video_processor.py
@@ -674,9 +674,14 @@ class MCPVideoProcessor:
 
         async def _direct_extraction():
             """Direct API extraction with timeout"""
-            transcript = YouTubeTranscriptApi.get_transcript(
+            # youtube-transcript-api >=1.0 replaced the ``get_transcript`` class
+            # method with an instance ``fetch`` that returns a FetchedTranscript;
+            # ``to_raw_data`` yields the list-of-dicts shape the rest of the
+            # pipeline expects.
+            yt_api = YouTubeTranscriptApi()
+            transcript = yt_api.fetch(
                 video_id, languages=["en", "en-US", "en-GB"]
-            )
+            ).to_raw_data()
             if transcript and len(transcript) > 0:
                 self.mcp_logger.info(
                     "✅ Direct MCP extraction successful",
@@ -688,10 +693,14 @@ class MCPVideoProcessor:
 
         async def _routed_extraction():
             """MCP-routed extraction with timeout"""
-            transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+            # youtube-transcript-api >=1.0: ``list_transcripts`` class method is
+            # now the instance ``list``; each Transcript's ``fetch`` returns a
+            # FetchedTranscript, so ``to_raw_data`` restores the list-of-dicts.
+            yt_api = YouTubeTranscriptApi()
+            transcript_list = yt_api.list(video_id)
             for transcript_item in transcript_list:
                 try:
-                    transcript = transcript_item.fetch()
+                    transcript = transcript_item.fetch().to_raw_data()
                     if transcript and len(transcript) > 0:
                         self.mcp_logger.info(
                             "✅ MCP-routed extraction successful",

--- a/src/mcp/mcp_video_processor.py
+++ b/src/mcp/mcp_video_processor.py
@@ -677,11 +677,17 @@ class MCPVideoProcessor:
             # youtube-transcript-api >=1.0 replaced the ``get_transcript`` class
             # method with an instance ``fetch`` that returns a FetchedTranscript;
             # ``to_raw_data`` yields the list-of-dicts shape the rest of the
-            # pipeline expects.
+            # pipeline expects. The call is synchronous/blocking, so run it in an
+            # executor — otherwise it stalls the event loop and defeats the
+            # @timeout_protection / circuit-breaker hanging protection.
+            loop = asyncio.get_event_loop()
             yt_api = YouTubeTranscriptApi()
-            transcript = yt_api.fetch(
-                video_id, languages=["en", "en-US", "en-GB"]
-            ).to_raw_data()
+            transcript = await loop.run_in_executor(
+                None,
+                lambda: yt_api.fetch(
+                    video_id, languages=["en", "en-US", "en-GB"]
+                ).to_raw_data(),
+            )
             if transcript and len(transcript) > 0:
                 self.mcp_logger.info(
                     "✅ Direct MCP extraction successful",
@@ -696,11 +702,18 @@ class MCPVideoProcessor:
             # youtube-transcript-api >=1.0: ``list_transcripts`` class method is
             # now the instance ``list``; each Transcript's ``fetch`` returns a
             # FetchedTranscript, so ``to_raw_data`` restores the list-of-dicts.
+            # These are blocking network calls — run them in an executor to keep
+            # the event loop free and let the timeout protection work.
+            loop = asyncio.get_event_loop()
             yt_api = YouTubeTranscriptApi()
-            transcript_list = yt_api.list(video_id)
+            transcript_list = await loop.run_in_executor(
+                None, lambda: yt_api.list(video_id)
+            )
             for transcript_item in transcript_list:
                 try:
-                    transcript = transcript_item.fetch().to_raw_data()
+                    transcript = await loop.run_in_executor(
+                        None, lambda item=transcript_item: item.fetch().to_raw_data()
+                    )
                     if transcript and len(transcript) > 0:
                         self.mcp_logger.info(
                             "✅ MCP-routed extraction successful",

--- a/src/youtube_extension/backend/services/youtube/adapters/robust.py
+++ b/src/youtube_extension/backend/services/youtube/adapters/robust.py
@@ -444,22 +444,31 @@ class RobustYouTubeService:
         """Check if transcript is available and count segments"""
         try:
             if HAS_TRANSCRIPT_API:
-                # Use high-level API to list and fetch transcripts
+                # youtube-transcript-api is synchronous/blocking network I/O; run
+                # it in an executor so it doesn't stall the event loop.
+                loop = asyncio.get_event_loop()
                 try:
                     yt_api = YouTubeTranscriptApi(
                         proxy_config=get_transcript_proxy_config()
                     )
-                    transcript = yt_api.fetch(video_id)
+                    transcript = await loop.run_in_executor(
+                        None, lambda: yt_api.fetch(video_id)
+                    )
                 except Exception:
-                    # If object API fails, try the instance list() as fallback.
-                    # youtube-transcript-api >=1.0: ``list`` is an instance
-                    # method, and it must reuse the same proxy config as the
-                    # primary fetch above.
-                    try:
-                        list_api = YouTubeTranscriptApi(
+                    # Fallback: list() returns per-language metadata, not
+                    # segments, so fetch an actual transcript to keep the count
+                    # meaningful (segments, not language count). Reuse the same
+                    # proxy config as the primary fetch.
+                    def _list_and_fetch() -> Any:
+                        transcript_list = YouTubeTranscriptApi(
                             proxy_config=get_transcript_proxy_config()
                         ).list(video_id)
-                        transcript = list_api
+                        return transcript_list.find_transcript(["en"]).fetch()
+
+                    try:
+                        transcript = await loop.run_in_executor(
+                            None, _list_and_fetch
+                        )
                     except Exception:
                         transcript = []
                 return True, len(transcript)
@@ -488,12 +497,18 @@ class RobustYouTubeService:
                 transcript = None
                 api_error = None
 
+                # youtube-transcript-api is synchronous/blocking network I/O; run
+                # it in an executor so it doesn't stall the event loop.
+                loop = asyncio.get_event_loop()
+
                 # Try instance-based fetch first
                 try:
                     yt_api = YouTubeTranscriptApi(
                         proxy_config=get_transcript_proxy_config()
                     )
-                    transcript = yt_api.fetch(video_id, languages=[language, "en"])
+                    transcript = await loop.run_in_executor(
+                        None, lambda: yt_api.fetch(video_id, languages=[language, "en"])
+                    )
                     logger.info(
                         f"YouTubeTranscriptApi.fetch() returned {len(transcript) if transcript else 0} segments"
                     )
@@ -504,13 +519,18 @@ class RobustYouTubeService:
                     # Try instance list() as fallback — reuse the same proxy
                     # config as the primary fetch so a proxy-required environment
                     # doesn't bypass the proxy (or leak the origin IP).
-                    try:
+                    def _list_fallback() -> Any:
                         transcript_list = YouTubeTranscriptApi(
                             proxy_config=get_transcript_proxy_config()
                         ).list(video_id)
-                        transcript = transcript_list.find_transcript(
+                        return transcript_list.find_transcript(
                             [language, "en"]
                         ).fetch()
+
+                    try:
+                        transcript = await loop.run_in_executor(
+                            None, _list_fallback
+                        )
                         logger.info(
                             f"YouTubeTranscriptApi.list() returned {len(transcript) if transcript else 0} segments"
                         )

--- a/src/youtube_extension/backend/services/youtube/adapters/robust.py
+++ b/src/youtube_extension/backend/services/youtube/adapters/robust.py
@@ -471,6 +471,11 @@ class RobustYouTubeService:
                         )
                     except Exception:
                         transcript = []
+                # Both the primary fetch and the list() fallback failed if
+                # transcript is empty — report unavailable rather than a
+                # contradictory (available, 0 segments).
+                if not transcript:
+                    return False, 0
                 return True, len(transcript)
             elif HAS_YOUTUBE_SEARCH:
                 transcript_data = await asyncio.get_event_loop().run_in_executor(

--- a/src/youtube_extension/backend/services/youtube/adapters/robust.py
+++ b/src/youtube_extension/backend/services/youtube/adapters/robust.py
@@ -451,9 +451,14 @@ class RobustYouTubeService:
                     )
                     transcript = yt_api.fetch(video_id)
                 except Exception:
-                    # If object API fails, try module-level list() as fallback pattern
+                    # If object API fails, try the instance list() as fallback.
+                    # youtube-transcript-api >=1.0: ``list`` is an instance
+                    # method, and it must reuse the same proxy config as the
+                    # primary fetch above.
                     try:
-                        list_api = YouTubeTranscriptApi.list(video_id)
+                        list_api = YouTubeTranscriptApi(
+                            proxy_config=get_transcript_proxy_config()
+                        ).list(video_id)
                         transcript = list_api
                     except Exception:
                         transcript = []
@@ -496,9 +501,13 @@ class RobustYouTubeService:
                     api_error = f"YouTubeTranscriptApi.fetch failed: {type(fetch_err).__name__}: {fetch_err}"
                     logger.warning(api_error)
                     transcript_errors.append(api_error)
-                    # Try module-level list() as fallback
+                    # Try instance list() as fallback — reuse the same proxy
+                    # config as the primary fetch so a proxy-required environment
+                    # doesn't bypass the proxy (or leak the origin IP).
                     try:
-                        transcript_list = YouTubeTranscriptApi().list(video_id)
+                        transcript_list = YouTubeTranscriptApi(
+                            proxy_config=get_transcript_proxy_config()
+                        ).list(video_id)
                         transcript = transcript_list.find_transcript(
                             [language, "en"]
                         ).fetch()

--- a/src/youtube_extension/backend/services/youtube/adapters/robust.py
+++ b/src/youtube_extension/backend/services/youtube/adapters/robust.py
@@ -498,17 +498,15 @@ class RobustYouTubeService:
                     transcript_errors.append(api_error)
                     # Try module-level list() as fallback
                     try:
-                        transcript_list = YouTubeTranscriptApi.list_transcripts(
-                            video_id
-                        )
+                        transcript_list = YouTubeTranscriptApi().list(video_id)
                         transcript = transcript_list.find_transcript(
                             [language, "en"]
                         ).fetch()
                         logger.info(
-                            f"YouTubeTranscriptApi.list_transcripts() returned {len(transcript) if transcript else 0} segments"
+                            f"YouTubeTranscriptApi.list() returned {len(transcript) if transcript else 0} segments"
                         )
                     except Exception as list_err:
-                        api_error = f"YouTubeTranscriptApi.list_transcripts failed: {type(list_err).__name__}: {list_err}"
+                        api_error = f"YouTubeTranscriptApi.list() fallback failed: {type(list_err).__name__}: {list_err}"
                         logger.warning(api_error)
                         transcript_errors.append(api_error)
                         transcript = []

--- a/tests/unit/test_robust_youtube_service.py
+++ b/tests/unit/test_robust_youtube_service.py
@@ -888,7 +888,8 @@ class TestCheckTranscriptAvailability:
         mock_api_instance = MagicMock()
         mock_api_instance.fetch.side_effect = Exception("fetch failed")
         mock_api_cls = MagicMock(return_value=mock_api_instance)
-        mock_api_cls.list.return_value = mock_transcript
+        # youtube-transcript-api >=1.0: fallback calls the instance ``list``
+        mock_api_instance.list.return_value = mock_transcript
 
         with (
             patch(f"{_ROBUST_MODULE}.HAS_TRANSCRIPT_API", True),

--- a/tests/unit/test_robust_youtube_service.py
+++ b/tests/unit/test_robust_youtube_service.py
@@ -1030,7 +1030,8 @@ class TestGetTranscript:
         mock_transcript_list.find_transcript.return_value = mock_transcript_obj
 
         mock_api_cls = MagicMock(return_value=mock_api_instance)
-        mock_api_cls.list_transcripts = MagicMock(return_value=mock_transcript_list)
+        # youtube-transcript-api >=1.0: fallback uses the instance ``list``
+        mock_api_instance.list = MagicMock(return_value=mock_transcript_list)
 
         with (
             patch(f"{_ROBUST_MODULE}.HAS_TRANSCRIPT_API", True),
@@ -1272,7 +1273,8 @@ class TestGetTranscript:
         mock_api_instance = MagicMock()
         mock_api_instance.fetch.side_effect = Exception("fetch fail")
         mock_api_cls = MagicMock(return_value=mock_api_instance)
-        mock_api_cls.list_transcripts.side_effect = Exception("list fail")
+        # youtube-transcript-api >=1.0: fallback uses the instance ``list``
+        mock_api_instance.list.side_effect = Exception("list fail")
 
         innertube_segs = [CaptionSegment(text="Hi", start=0.0, duration=1.0)]
 

--- a/tests/unit/test_robust_youtube_service.py
+++ b/tests/unit/test_robust_youtube_service.py
@@ -888,8 +888,11 @@ class TestCheckTranscriptAvailability:
         mock_api_instance = MagicMock()
         mock_api_instance.fetch.side_effect = Exception("fetch failed")
         mock_api_cls = MagicMock(return_value=mock_api_instance)
-        # youtube-transcript-api >=1.0: fallback calls the instance ``list``
-        mock_api_instance.list.return_value = mock_transcript
+        # youtube-transcript-api >=1.0: fallback calls the instance ``list`` then
+        # fetches an actual transcript to count real segments (not languages).
+        mock_list = MagicMock()
+        mock_list.find_transcript.return_value.fetch.return_value = mock_transcript
+        mock_api_instance.list.return_value = mock_list
 
         with (
             patch(f"{_ROBUST_MODULE}.HAS_TRANSCRIPT_API", True),
@@ -925,7 +928,9 @@ class TestCheckTranscriptAvailability:
         mock_api_instance = MagicMock()
         mock_api_instance.fetch.side_effect = Exception("boom")
         mock_api_cls = MagicMock(return_value=mock_api_instance)
-        mock_api_cls.list.side_effect = Exception("boom2")
+        # >=1.0: the fallback calls the instance ``list``; make it fail too so
+        # the "both inner tries fail" path is actually exercised.
+        mock_api_instance.list.side_effect = Exception("boom2")
 
         # When both fetch and list() fail, transcript = [] and returns (True, 0)
         # OR the outer exception fires and returns (False, 0).

--- a/tests/unit/test_robust_youtube_service.py
+++ b/tests/unit/test_robust_youtube_service.py
@@ -922,8 +922,10 @@ class TestCheckTranscriptAvailability:
         assert available is True
         assert count == 2
 
-    async def test_all_inner_fail_still_returns_true_with_empty_list(self):
-        """When both inner tries fail, list() returns [], so returns (True, 0)."""
+    async def test_all_inner_fail_returns_false_zero(self):
+        """When both the fetch and the list() fallback fail, no transcript was
+        obtained, so the method reports (False, 0) — not a contradictory
+        (True, 0)."""
         svc = RobustYouTubeService()
         mock_api_instance = MagicMock()
         mock_api_instance.fetch.side_effect = Exception("boom")
@@ -932,19 +934,14 @@ class TestCheckTranscriptAvailability:
         # the "both inner tries fail" path is actually exercised.
         mock_api_instance.list.side_effect = Exception("boom2")
 
-        # When both fetch and list() fail, transcript = [] and returns (True, 0)
-        # OR the outer exception fires and returns (False, 0).
-        # The actual behavior: the except catches at the inner level and sets transcript=[],
-        # then returns (True, 0).
         with (
             patch(f"{_ROBUST_MODULE}.HAS_TRANSCRIPT_API", True),
             patch(f"{_ROBUST_MODULE}.YouTubeTranscriptApi", mock_api_cls, create=True),
         ):
             available, count = await svc._check_transcript_availability(VIDEO_ID)
 
-        # Verifying the function returns without raising regardless of outcome
-        assert isinstance(available, bool)
-        assert isinstance(count, int)
+        assert available is False
+        assert count == 0
 
     async def test_outer_exception_returns_false_zero(self):
         """Outer try/except around the whole body catches unexpected errors."""


### PR DESCRIPTION
## Problem

`pyproject.toml` on `main` pins `youtube-transcript-api>=1.0.0`. Version 1.0 **removed** the `YouTubeTranscriptApi.get_transcript()` and `.list_transcripts()` class methods in favour of the instance API (`YouTubeTranscriptApi().fetch()` / `.list()`).

Several production call sites were never migrated and still called the removed class methods, so each raises `AttributeError` (or, for the stray `.list()` class call, `TypeError`) the moment its transcript path executes — a latent runtime break already live on `main`. #493 migrated only `shared/libs/youtube_proxy.py`; a repo-wide scan found the bug across every transcript entry point.

## Changes

Completes the `>=1.0` migration across **all** production call sites (instance `fetch()`/`.list()`, `to_raw_data()` to preserve the list-of-dicts shape downstream code indexes):

- `src/mcp/mcp_video_processor.py` — direct + routed extraction
- `src/agents/interactive_metadata_extractor.py`
- `src/agents/process_video_with_mcp.py` — direct + list fallback
- `src/integration/youtube_api.py`
- `src/youtube_extension/backend/services/youtube/adapters/robust.py` — `list()` fallback + `_check_transcript_availability`
- `shared/libs/youtube_proxy.py` — proxy transcript path (`proxies=` kwarg → `proxy_config` constructor arg)

### Review-driven fixes (CodeRabbit / Devin / Copilot)
- **robust.py `_check_transcript_availability`**: `YouTubeTranscriptApi.list()` was a *class* call (instance method in >=1.0) — always `TypeError`, returning a misleading `(True, 0)`. Now an instance with the shared proxy config.
- **robust.py `get_transcript` fallback**: the `.list()` fallback dropped the proxy config the primary fetch uses (proxy bypass / origin-IP leak). Now reuses `get_transcript_proxy_config()`.
- **youtube_proxy.py**: `CouldNotRetrieveTranscript` now receives a bare `video_id` (the >=1.0 constructor builds its own URL; a sentence corrupts it).
- **process_video_with_mcp.py / mcp_video_processor.py**: the synchronous transcript calls ran directly inside `async` functions, blocking the event loop (and defeating `mcp_video_processor`'s own `@timeout_protection` / circuit-breaker). Wrapped in `run_in_executor`, matching `integration/youtube_api.py`.

Test mocks in `tests/unit/test_robust_youtube_service.py` updated to the instance `list` API.

## Relationship to #493
This PR now also migrates `shared/libs/youtube_proxy.py` (added by the Vercel review bot and refined here), so it is a **superset of #493** — #493 becomes redundant and can be closed once this merges. Only one of the two should land to avoid a merge conflict on that file.

## Verification
- `youtube-transcript-api 1.2.4` confirms instance `fetch()`/`list()` exist, class `get_transcript()`/`list_transcripts()` are removed, and `FetchedTranscript.to_raw_data()` / `CouldNotRetrieveTranscript(video_id)` behave as relied on.
- `py_compile` clean on all touched files; **zero** new `ruff` findings on edited lines.
- **125 unit tests pass** across the touched modules; **E2E 17/17** green against the live deployment.

> Note: the `Coverage` and `trivy` CI jobs fail on a GitHub-Action input-validation error (`qlty-action` / `INPUT_PATH`) unrelated to this diff — a pre-existing workflow/infra issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)