### PR TITLE
fix(youtube): transcript-api >=1.0 migration + CodeRabbit review fixes

### DIFF
--- a/shared/libs/youtube_proxy.py
+++ b/shared/libs/youtube_proxy.py
@@ -29,9 +29,11 @@ try:
         CouldNotRetrieveTranscript,
         NoTranscriptFound,
     )
+    from youtube_transcript_api.proxies import GenericProxyConfig
     YOUTUBE_DEPS_AVAILABLE = True
 except ImportError as e:
     YOUTUBE_DEPS_AVAILABLE = False
+    GenericProxyConfig = None  # type: ignore[assignment,misc]
     logging.warning(f"YouTube dependencies not available: {e}")
 
 logger = logging.getLogger("youtube_api_proxy")
@@ -49,6 +51,25 @@ def _get_webshare_proxy_url() -> str | None:
         )
         return None
     return url
+
+
+def _get_transcript_proxy_config():
+    """Return a youtube-transcript-api proxy config object, or None.
+
+    youtube-transcript-api >=1.0 replaced the ``proxies=`` keyword with a
+    ``proxy_config`` constructor argument accepting a proxy config object.
+    """
+    url = _get_webshare_proxy_url()
+    if not url:
+        return None
+    if GenericProxyConfig is None:
+        logger.warning(
+            "WEBSHARE_PROXY_URL is set but youtube-transcript-api proxy support "
+            "is unavailable (requires youtube-transcript-api>=1.0) — falling back "
+            "to direct connection"
+        )
+        return None
+    return GenericProxyConfig(http_url=url, https_url=url)
 
 
 def _redact_proxy_credentials(text: str) -> str:
@@ -345,11 +366,17 @@ class YouTubeAPIProxy:
         async def _transcript_operation():
             transcript_data = []
             proxy_url = _get_webshare_proxy_url()
-            proxies = {"http": proxy_url, "https": proxy_url} if proxy_url else None
+            proxy_config = _get_transcript_proxy_config()
 
             # Method 1: Direct transcript API
+            # youtube-transcript-api >=1.0 replaced the ``get_transcript`` class
+            # method with an instance ``fetch`` that returns a FetchedTranscript;
+            # ``to_raw_data`` yields the list-of-dicts shape the rest of the
+            # pipeline expects. The ``proxies=`` kwarg was replaced by a
+            # ``proxy_config`` constructor argument.
             try:
-                transcript = YouTubeTranscriptApi.get_transcript(video_id, proxies=proxies)
+                yt_api = YouTubeTranscriptApi(proxy_config=proxy_config)
+                transcript = yt_api.fetch(video_id).to_raw_data()
                 if transcript:
                     logger.info(f"✅ Direct transcript extraction: {len(transcript)} segments")
                     return transcript
@@ -357,10 +384,14 @@ class YouTubeAPIProxy:
                 logger.debug(f"Direct transcript failed: {e}")
 
             # Method 2: Alternative language codes
+            # ``list_transcripts`` class method is now the instance ``list``;
+            # each Transcript's ``fetch`` returns a FetchedTranscript, so
+            # ``to_raw_data`` restores the list-of-dicts.
             try:
-                transcript_list = YouTubeTranscriptApi.list_transcripts(video_id, proxies=proxies)
+                yt_api = YouTubeTranscriptApi(proxy_config=proxy_config)
+                transcript_list = yt_api.list(video_id)
                 for transcript_item in transcript_list:
-                    transcript = transcript_item.fetch()
+                    transcript = transcript_item.fetch().to_raw_data()
                     if transcript:
                         logger.info(f"✅ Alternative language transcript: {len(transcript)} segments")
                         return transcript

--- a/src/agents/interactive_metadata_extractor.py
+++ b/src/agents/interactive_metadata_extractor.py
@@ -78,8 +78,9 @@ class InteractiveMetadataExtractor:
         transcript_lines = []
 
         try:
-            # Try YouTube's auto-generated captions
-            transcript = YouTubeTranscriptApi.get_transcript(video_id)
+            # Try YouTube's auto-generated captions (youtube-transcript-api >=1.0
+            # instance API; to_raw_data restores the list-of-dicts shape).
+            transcript = YouTubeTranscriptApi().fetch(video_id).to_raw_data()
 
             for i, entry in enumerate(transcript):
                 transcript_lines.append({

--- a/src/agents/process_video_with_mcp.py
+++ b/src/agents/process_video_with_mcp.py
@@ -213,7 +213,8 @@ class RealVideoProcessor:
         # 1) Direct transcript
         try:
             if YouTubeTranscriptApi is not None:
-                transcript = YouTubeTranscriptApi.get_transcript(video_id)
+                # youtube-transcript-api >=1.0 instance API
+                transcript = YouTubeTranscriptApi().fetch(video_id).to_raw_data()
                 if transcript:
                     return transcript
         except Exception:
@@ -222,9 +223,9 @@ class RealVideoProcessor:
         # 2) List transcripts and fetch
         try:
             if YouTubeTranscriptApi is not None:
-                for t in YouTubeTranscriptApi.list_transcripts(video_id):  # type: ignore[union-attr]
+                for t in YouTubeTranscriptApi().list(video_id):  # type: ignore[union-attr]
                     try:
-                        data = t.fetch()
+                        data = t.fetch().to_raw_data()
                         if data:
                             return data
                     except Exception:

--- a/src/agents/process_video_with_mcp.py
+++ b/src/agents/process_video_with_mcp.py
@@ -210,11 +210,17 @@ class RealVideoProcessor:
 
     # ---------- Core async ops ----------
     async def _extract_transcript_with_rotation(self, video_id: str) -> list[dict[str, Any]]:
+        loop = asyncio.get_event_loop()
         # 1) Direct transcript
         try:
             if YouTubeTranscriptApi is not None:
-                # youtube-transcript-api >=1.0 instance API
-                transcript = YouTubeTranscriptApi().fetch(video_id).to_raw_data()
+                # youtube-transcript-api >=1.0 instance API. The call is
+                # synchronous network I/O, so run it off the event loop to
+                # avoid blocking other coroutines on this thread.
+                transcript = await loop.run_in_executor(
+                    None,
+                    lambda: YouTubeTranscriptApi().fetch(video_id).to_raw_data(),
+                )
                 if transcript:
                     return transcript
         except Exception:
@@ -223,9 +229,14 @@ class RealVideoProcessor:
         # 2) List transcripts and fetch
         try:
             if YouTubeTranscriptApi is not None:
-                for t in YouTubeTranscriptApi().list(video_id):  # type: ignore[union-attr]
+                transcript_list = await loop.run_in_executor(
+                    None, lambda: YouTubeTranscriptApi().list(video_id)  # type: ignore[union-attr]
+                )
+                for t in transcript_list:
                     try:
-                        data = t.fetch().to_raw_data()
+                        data = await loop.run_in_executor(
+                            None, lambda t=t: t.fetch().to_raw_data()
+                        )
                         if data:
                             return data
                     except Exception:

--- a/src/integration/youtube_api.py
+++ b/src/integration/youtube_api.py
@@ -96,7 +96,7 @@ class YouTubeAPIService:
         loop = asyncio.get_event_loop()
         transcript = await loop.run_in_executor(
             None,
-            lambda: YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
+            lambda: YouTubeTranscriptApi().fetch(video_id, languages=languages).to_raw_data()
         )
 
         return [

--- a/src/mcp/mcp_video_processor.py
+++ b/src/mcp/mcp_video_processor.py
@@ -674,9 +674,14 @@ class MCPVideoProcessor:
 
         async def _direct_extraction():
             """Direct API extraction with timeout"""
-            transcript = YouTubeTranscriptApi.get_transcript(
+            # youtube-transcript-api >=1.0 replaced the ``get_transcript`` class
+            # method with an instance ``fetch`` that returns a FetchedTranscript;
+            # ``to_raw_data`` yields the list-of-dicts shape the rest of the
+            # pipeline expects.
+            yt_api = YouTubeTranscriptApi()
+            transcript = yt_api.fetch(
                 video_id, languages=["en", "en-US", "en-GB"]
-            )
+            ).to_raw_data()
             if transcript and len(transcript) > 0:
                 self.mcp_logger.info(
                     "✅ Direct MCP extraction successful",
@@ -688,10 +693,14 @@ class MCPVideoProcessor:
 
         async def _routed_extraction():
             """MCP-routed extraction with timeout"""
-            transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+            # youtube-transcript-api >=1.0: ``list_transcripts`` class method is
+            # now the instance ``list``; each Transcript's ``fetch`` returns a
+            # FetchedTranscript, so ``to_raw_data`` restores the list-of-dicts.
+            yt_api = YouTubeTranscriptApi()
+            transcript_list = yt_api.list(video_id)
             for transcript_item in transcript_list:
                 try:
-                    transcript = transcript_item.fetch()
+                    transcript = transcript_item.fetch().to_raw_data()
                     if transcript and len(transcript) > 0:
                         self.mcp_logger.info(
                             "✅ MCP-routed extraction successful",

--- a/src/mcp/mcp_video_processor.py
+++ b/src/mcp/mcp_video_processor.py
@@ -677,11 +677,17 @@ class MCPVideoProcessor:
             # youtube-transcript-api >=1.0 replaced the ``get_transcript`` class
             # method with an instance ``fetch`` that returns a FetchedTranscript;
             # ``to_raw_data`` yields the list-of-dicts shape the rest of the
-            # pipeline expects.
+            # pipeline expects. The call is blocking network I/O, so offload it
+            # to an executor — otherwise a hung request stalls the event loop and
+            # defeats this class's timeout/circuit-breaker hanging protection.
+            loop = asyncio.get_event_loop()
             yt_api = YouTubeTranscriptApi()
-            transcript = yt_api.fetch(
-                video_id, languages=["en", "en-US", "en-GB"]
-            ).to_raw_data()
+            transcript = await loop.run_in_executor(
+                None,
+                lambda: yt_api.fetch(
+                    video_id, languages=["en", "en-US", "en-GB"]
+                ).to_raw_data(),
+            )
             if transcript and len(transcript) > 0:
                 self.mcp_logger.info(
                     "✅ Direct MCP extraction successful",
@@ -696,11 +702,18 @@ class MCPVideoProcessor:
             # youtube-transcript-api >=1.0: ``list_transcripts`` class method is
             # now the instance ``list``; each Transcript's ``fetch`` returns a
             # FetchedTranscript, so ``to_raw_data`` restores the list-of-dicts.
+            # Both ``list`` and per-item ``fetch`` are blocking network I/O, so
+            # offload them to an executor to keep the hanging protection intact.
+            loop = asyncio.get_event_loop()
             yt_api = YouTubeTranscriptApi()
-            transcript_list = yt_api.list(video_id)
+            transcript_list = await loop.run_in_executor(
+                None, lambda: yt_api.list(video_id)
+            )
             for transcript_item in transcript_list:
                 try:
-                    transcript = transcript_item.fetch().to_raw_data()
+                    transcript = await loop.run_in_executor(
+                        None, lambda item=transcript_item: item.fetch().to_raw_data()
+                    )
                     if transcript and len(transcript) > 0:
                         self.mcp_logger.info(
                             "✅ MCP-routed extraction successful",

--- a/src/youtube_extension/backend/services/youtube/adapters/robust.py
+++ b/src/youtube_extension/backend/services/youtube/adapters/robust.py
@@ -498,17 +498,15 @@ class RobustYouTubeService:
                     transcript_errors.append(api_error)
                     # Try module-level list() as fallback
                     try:
-                        transcript_list = YouTubeTranscriptApi.list_transcripts(
-                            video_id
-                        )
+                        transcript_list = YouTubeTranscriptApi().list(video_id)
                         transcript = transcript_list.find_transcript(
                             [language, "en"]
                         ).fetch()
                         logger.info(
-                            f"YouTubeTranscriptApi.list_transcripts() returned {len(transcript) if transcript else 0} segments"
+                            f"YouTubeTranscriptApi.list() returned {len(transcript) if transcript else 0} segments"
                         )
                     except Exception as list_err:
-                        api_error = f"YouTubeTranscriptApi.list_transcripts failed: {type(list_err).__name__}: {list_err}"
+                        api_error = f"YouTubeTranscriptApi.list() fallback failed: {type(list_err).__name__}: {list_err}"
                         logger.warning(api_error)
                         transcript_errors.append(api_error)
                         transcript = []

--- a/src/youtube_extension/backend/services/youtube/adapters/robust.py
+++ b/src/youtube_extension/backend/services/youtube/adapters/robust.py
@@ -451,9 +451,14 @@ class RobustYouTubeService:
                     )
                     transcript = yt_api.fetch(video_id)
                 except Exception:
-                    # If object API fails, try module-level list() as fallback pattern
+                    # If object API fails, try instance-based list() as fallback.
+                    # youtube-transcript-api >=1.0 removed the class-method form,
+                    # so build an instance with the same proxy config as the
+                    # primary fetch (otherwise the retry hits the same block).
                     try:
-                        list_api = YouTubeTranscriptApi.list(video_id)
+                        list_api = YouTubeTranscriptApi(
+                            proxy_config=get_transcript_proxy_config()
+                        ).list(video_id)
                         transcript = list_api
                     except Exception:
                         transcript = []
@@ -496,9 +501,12 @@ class RobustYouTubeService:
                     api_error = f"YouTubeTranscriptApi.fetch failed: {type(fetch_err).__name__}: {fetch_err}"
                     logger.warning(api_error)
                     transcript_errors.append(api_error)
-                    # Try module-level list() as fallback
+                    # Try instance-based list() as fallback, reusing the proxy
+                    # config so it doesn't fail for the same reason fetch() did.
                     try:
-                        transcript_list = YouTubeTranscriptApi().list(video_id)
+                        transcript_list = YouTubeTranscriptApi(
+                            proxy_config=get_transcript_proxy_config()
+                        ).list(video_id)
                         transcript = transcript_list.find_transcript(
                             [language, "en"]
                         ).fetch()

--- a/tests/unit/test_robust_youtube_service.py
+++ b/tests/unit/test_robust_youtube_service.py
@@ -1030,7 +1030,8 @@ class TestGetTranscript:
         mock_transcript_list.find_transcript.return_value = mock_transcript_obj
 
         mock_api_cls = MagicMock(return_value=mock_api_instance)
-        mock_api_cls.list_transcripts = MagicMock(return_value=mock_transcript_list)
+        # youtube-transcript-api >=1.0: fallback uses the instance ``list``
+        mock_api_instance.list = MagicMock(return_value=mock_transcript_list)
 
         with (
             patch(f"{_ROBUST_MODULE}.HAS_TRANSCRIPT_API", True),
@@ -1272,7 +1273,8 @@ class TestGetTranscript:
         mock_api_instance = MagicMock()
         mock_api_instance.fetch.side_effect = Exception("fetch fail")
         mock_api_cls = MagicMock(return_value=mock_api_instance)
-        mock_api_cls.list_transcripts.side_effect = Exception("list fail")
+        # youtube-transcript-api >=1.0: fallback uses the instance ``list``
+        mock_api_instance.list.side_effect = Exception("list fail")
 
         innertube_segs = [CaptionSegment(text="Hi", start=0.0, duration=1.0)]
 

--- a/tests/unit/test_robust_youtube_service.py
+++ b/tests/unit/test_robust_youtube_service.py
@@ -887,8 +887,10 @@ class TestCheckTranscriptAvailability:
         mock_transcript = [{"text": "seg"}] * 3
         mock_api_instance = MagicMock()
         mock_api_instance.fetch.side_effect = Exception("fetch failed")
+        # youtube-transcript-api >=1.0 exposes ``list`` on the instance, not the
+        # class; the fallback builds a proxied instance and calls ``.list()``.
+        mock_api_instance.list.return_value = mock_transcript
         mock_api_cls = MagicMock(return_value=mock_api_instance)
-        mock_api_cls.list.return_value = mock_transcript
 
         with (
             patch(f"{_ROBUST_MODULE}.HAS_TRANSCRIPT_API", True),


### PR DESCRIPTION
## Summary

This PR carries the full `youtube-transcript-api >=1.0` migration (identical to #496) **plus** the four Major review findings CodeRabbit raised on that migration, already applied and verified. It is a strict superset of #496 — see note below.

## Background

`pyproject.toml` pins `youtube-transcript-api>=1.0.0`, which **removed** the `YouTubeTranscriptApi.get_transcript()` / `list_transcripts()` class methods in favour of the instance API (`YouTubeTranscriptApi().fetch()` / `.list()`). Several production call sites still called the removed class methods — a latent runtime break. The base migration switches every remaining site to the instance API.

## Review findings resolved (on top of the migration)

CodeRabbit's ASSERTIVE review flagged four Major issues; all are fixed here:

1. **`robust.py._check_transcript_availability`** — the `.list()` fallback used the removed class-method form (`YouTubeTranscriptApi.list(...)`), raising `AttributeError` on >=1.0 and silently returning `0` segments. Switched to the instance form and now reuses the primary fetch's proxy config.
2. **`robust.py.get_transcript`** — the `.list()` fallback built a bare instance, dropping the proxy config; if `fetch()` was blocked, the retry hit the same wall. Now reuses `get_transcript_proxy_config()`.
3. **`process_video_with_mcp.py._extract_transcript_with_rotation`** — synchronous transcript network I/O ran directly on the event loop. Offloaded via `run_in_executor`, matching the existing pattern in `integration/youtube_api.py`.
4. **`mcp_video_processor.py._direct_extraction` / `_routed_extraction`** — same blocking-in-async issue, which defeated the class's timeout / circuit-breaker hanging protection. Offloaded via `run_in_executor`.

The Vercel/VADE finding about `shared/libs/youtube_proxy.py` still using the removed API was already resolved by the migration commit (it now uses `YouTubeTranscriptApi(proxy_config=...).fetch()/.list()`).

## Verification

- `python -m py_compile` passes on all changed modules.
- `pytest tests/unit/test_robust_youtube_service.py` → **70 passed** (the `.list()` fallback test mock was updated to the instance API per CLAUDE.md — fix the mock to match the real API, don't weaken the code).
- `pytest tests/unit/test_security_fixes.py` → 7 passed, 5 skipped.
- Ruff introduces no new findings (pre-existing `F401`/`E402` on untouched lines only).

## Relationship to #496

#496 (`claude/determined-maxwell-joqg1f`) carries the same base migration but **without** these four review fixes. This branch is a superset. Suggest closing #496 in favour of this PR, or cherry-picking commit `4855637` onto #496 — maintainer's choice. Opened as **draft**; merge to `main` awaits human approval.


---
_Generated by [Claude Code](https://claude.ai/code/session_019XsGzakDy4iYaZqBd9gEEX)_