### PR TITLE
fix(tests): avoid SIGPIPE abort and reduce key logging in test_gemini_api.sh

### DIFF
--- a/tests/testing/test_gemini_api.sh
+++ b/tests/testing/test_gemini_api.sh
@@ -12,10 +12,16 @@ if [ -z "${GEMINI_API_KEY:-}" ]; then
 fi
 
 echo "Testing Gemini API..."
-echo "API Key: ${GEMINI_API_KEY:0:15}..."
+# Report only that the key loaded (and its length) — never echo key material,
+# since this script may run in CI where stdout is captured.
+echo "API key loaded (${#GEMINI_API_KEY} chars)."
 echo ""
 
-curl -s "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent" \
+# Capture the full response first, then truncate for display. Piping
+# `... | python3 -m json.tool | head -30` directly would let `head` close the
+# pipe after 30 lines, sending SIGPIPE (exit 141) to python3; under `pipefail`
+# + `set -e` that aborts the script even on a successful API response.
+response=$(curl -s "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent" \
   -H "x-goog-api-key: ${GEMINI_API_KEY}" \
   -H 'Content-Type: application/json' \
   -X POST \
@@ -23,4 +29,6 @@ curl -s "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flas
     "contents": [{
       "parts": [{"text": "Respond with just SUCCESS if you receive this."}]
     }]
-  }' | python3 -m json.tool | head -30
+  }' | python3 -m json.tool)
+
+head -30 <<< "$response"


### PR DESCRIPTION
## Summary

Follow-up to **#522** (the hardcoded-Gemini-key scrub, now merged). #522 was squash-merged at its pre-fix head, so two review improvements flagged on that PR **did not make it onto `main`**. This PR lands them.

Both were caught by the automated reviewers on #522:

1. **SIGPIPE abort under `pipefail` (real bug).** `main`'s `test_gemini_api.sh` has `set -euo pipefail` followed by `curl ... | python3 -m json.tool | head -30`. When the pretty-printed JSON exceeds 30 lines, `head` closes the pipe, sending SIGPIPE (exit 141) to `python3`; `pipefail` propagates it and `set -e` aborts the script **even on a successful API call**. Fixed by capturing the response first, then truncating with a here-string (`head -30 <<< "$response"`) — no upstream producer to signal.
2. **Key material in logs.** The script echoed the first 15 characters of the key (`${GEMINI_API_KEY:0:15}`). Replaced with a length-only confirmation (`API key loaded (N chars)`) so no key prefix reaches CI/stdout logs.

The `${GEMINI_API_KEY:-}` unset-guard (confirmed correct by review) is unchanged.

## Verification

- `bash -n tests/testing/test_gemini_api.sh` → OK
- Behavioral check under `set -euo pipefail`: the capture-then-`head` form completes `exit 0`, where the piped `| head -30` form aborts — confirming the fix.
- No hardcoded key present (scrubbed in #522).

## Scope

Single file, manual smoke-test script (not run in CI). No application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpC1a89gvJBpeLfxA6epLg

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpC1a89gvJBpeLfxA6epLg)_