### PR TITLE
fix(types): mirror error_reason + created_at on VideoJobStatusResponse

### DIFF
--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -48,6 +48,10 @@ export interface VideoJobStatusResponse {
   transcript?: string;
   metadata?: Record<string, unknown>;
   error?: string;
+  /** Machine-readable slug describing why a job failed (e.g. 'gemini_api_timeout') */
+  error_reason?: string;
+  /** UTC creation timestamp (ISO 8601); used by job-store retention (expire_before). */
+  created_at: string;
 }
 
 // ── Event Extraction ──

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -48,6 +48,10 @@ export interface VideoJobStatusResponse {
   transcript?: string;
   metadata?: Record<string, unknown>;
   error?: string;
+  /** Machine-readable slug describing why a job failed (e.g. 'gemini_api_timeout') */
+  error_reason?: string;
+  /** UTC creation timestamp (ISO 8601); used by job-store retention (expire_before). */
+  created_at: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Completes the cross-language contract for the video job status model. The Python backend (`src/youtube_extension/backend/api/v1/models.py`) and the Python SDK (`sdk/python/eventrelay_sdk/types.py`) already expose `error_reason: Optional[str]` and a required `created_at` timestamp on `VideoJobStatusResponse`, but the TypeScript SDK and the frontend type were left out of sync — so TypeScript consumers of `GET /api/v1/videos/{job_id}/status` could not read these fields type-safely.

This adds the two missing fields to both TypeScript interfaces, mirroring the source-of-truth optionality per `CLAUDE.md`'s **SDK ↔ Backend Contract Alignment** rule:

- `error_reason?: string` — optional (backend: `Optional[str]`)
- `created_at: string` — required ISO 8601 timestamp (backend: `created_at: datetime` with a default factory, always stamped)

## Files

- `sdk/typescript/src/types.ts`
- `apps/web/src/lib/types.ts`

## Context

This is the one genuinely-missing piece flagged by the reviewer on #494. The rest of that PR's changes (backend `error_reason`/`created_at`, `expire_before`, Python SDK sync, tests) are **already merged to `main`** (via #495 and related), where `created_at` landed with stronger typing (`datetime` rather than `Optional[str]`). This branch was therefore restarted from the latest `main` and carries only the outstanding TS alignment, rather than re-introducing the superseded Python changes.

## Verification

- All existing usages of `VideoJobStatusResponse` in TS are API-response reads (`apiClient.get<...>` / casts), never object-literal constructions, so the newly-required `created_at` does not break any call site.
- Interface validated under `tsc --strict` (isolated compile): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uBUZEHzMb8YUcCLztJrhn

---
_Generated by [Claude Code](https://claude.ai/code/session_012uBUZEHzMb8YUcCLztJrhn)_