### PR TITLE
test(pipeline-store): port #494 edge-case coverage for expire_before + audit store

### DIFF
--- a/tests/unit/test_master_roadmap_fixes.py
+++ b/tests/unit/test_master_roadmap_fixes.py
@@ -72,6 +72,29 @@ def test_audit_store_token_counts_default_to_none(tmp_path):
     assert entries[0]["output_tokens"] is None
 
 
+def test_audit_store_token_counts_persist_to_disk(tmp_path):
+    """Token counts survive a reload from the JSONL file, not just the in-memory buffer."""
+    store = PipelineAuditStore(tmp_path)
+    store.append(
+        "run_disk_test",
+        agent_id="gemini-agent",
+        action="analyze",
+        success=True,
+        duration_ms=42.0,
+        input_tokens=10,
+        output_tokens=20,
+    )
+
+    # A brand-new instance has an empty in-memory buffer, forcing get_run() to
+    # read the persisted JSONL file from disk.
+    fresh_store = PipelineAuditStore(tmp_path)
+    entries = fresh_store.get_run("run_disk_test")
+
+    assert len(entries) == 1
+    assert entries[0]["input_tokens"] == 10
+    assert entries[0]["output_tokens"] == 20
+
+
 def test_job_store_expire_before_removes_old_jobs(tmp_path):
     """expire_before() should delete jobs whose created_at is before the cutoff."""
     from datetime import datetime, timedelta, timezone
@@ -103,6 +126,104 @@ def test_job_store_expire_before_skips_missing_created_at(tmp_path):
     assert store.load("no_ts_job") is not None
 
 
+def test_job_store_expire_before_skips_empty_created_at(tmp_path):
+    """An empty-string created_at is treated the same as a missing field."""
+    from datetime import datetime, timezone
+
+    store = PipelineJobStore(tmp_path)
+    store.save("blank_ts_job", {"job_id": "blank_ts_job", "status": "pending", "created_at": ""})
+
+    removed = store.expire_before(datetime.now(timezone.utc))
+
+    assert removed == 0
+    assert store.load("blank_ts_job") is not None
+
+
+def test_job_store_expire_before_skips_unparseable_created_at(tmp_path):
+    """A created_at value that isn't a valid ISO timestamp is left alone rather than raising."""
+    from datetime import datetime, timezone
+
+    store = PipelineJobStore(tmp_path)
+    store.save(
+        "bad_ts_job",
+        {"job_id": "bad_ts_job", "status": "pending", "created_at": "not-a-timestamp"},
+    )
+
+    removed = store.expire_before(datetime.now(timezone.utc))
+
+    assert removed == 0
+    assert store.load("bad_ts_job") is not None
+
+
+def test_job_store_expire_before_ignores_corrupt_json_file(tmp_path):
+    """A job file with invalid JSON is skipped instead of raising."""
+    from datetime import datetime, timezone
+
+    store = PipelineJobStore(tmp_path)
+    corrupt_path = tmp_path / "corrupt_job.json"
+    corrupt_path.write_text("{not valid json", encoding="utf-8")
+
+    removed = store.expire_before(datetime.now(timezone.utc))
+
+    assert removed == 0
+    assert corrupt_path.exists()
+
+
+def test_job_store_expire_before_boundary_not_removed(tmp_path):
+    """A job created exactly at the cutoff instant is not removed (strict less-than)."""
+    from datetime import datetime, timezone
+
+    store = PipelineJobStore(tmp_path)
+    cutoff = datetime.now(timezone.utc)
+    store.save(
+        "boundary_job",
+        {"job_id": "boundary_job", "status": "complete", "created_at": cutoff.isoformat()},
+    )
+
+    removed = store.expire_before(cutoff)
+
+    assert removed == 0
+    assert store.load("boundary_job") is not None
+
+
+def test_job_store_expire_before_accepts_naive_cutoff(tmp_path):
+    """A naive (tzinfo-less) cutoff is coerced to UTC instead of raising."""
+    from datetime import datetime, timedelta, timezone
+
+    store = PipelineJobStore(tmp_path)
+    old_ts = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    store.save("old_job_naive_cutoff", {"job_id": "old_job_naive_cutoff", "status": "complete", "created_at": old_ts})
+
+    # Anchor the naive cutoff to a UTC base so the test is timezone-independent:
+    # expire_before() reinterprets a naive cutoff as UTC, so building it from a
+    # local now() would drift the cutoff earlier than old_ts west of UTC.
+    naive_cutoff = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(tzinfo=None)
+    removed = store.expire_before(naive_cutoff)
+
+    assert removed == 1
+    assert store.load("old_job_naive_cutoff") is None
+
+
+def test_job_store_expire_before_removes_multiple_matching_jobs(tmp_path):
+    """expire_before() removes every job older than the cutoff, not just the first match."""
+    from datetime import datetime, timedelta, timezone
+
+    store = PipelineJobStore(tmp_path)
+    old_ts = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat()
+    for job_id in ("old_a", "old_b", "old_c"):
+        store.save(job_id, {"job_id": job_id, "status": "complete", "created_at": old_ts})
+    new_ts = datetime.now(timezone.utc).isoformat()
+    store.save("new_job", {"job_id": "new_job", "status": "pending", "created_at": new_ts})
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+    removed = store.expire_before(cutoff)
+
+    assert removed == 3
+    for job_id in ("old_a", "old_b", "old_c"):
+        assert store.load(job_id) is None
+    assert store.load("new_job") is not None
+
+
 def test_persisted_video_job_is_expirable(tmp_path):
     """A real VideoJobStatusResponse persisted like production must be expirable.
 
@@ -131,6 +252,32 @@ def test_persisted_video_job_is_expirable(tmp_path):
     cutoff = datetime.now(timezone.utc) + timedelta(hours=1)
     assert store.expire_before(cutoff) == 1
     assert store.load("real_job") is None
+
+
+def test_persist_video_job_stamps_stable_created_at(tmp_path, monkeypatch):
+    """Persisted job records carry a created_at (so expire_before() works on real
+    data), and it stays stable across the many status-transition re-persists."""
+    from youtube_extension.backend.api.v1 import router as router_module
+    from youtube_extension.backend.api.v1.models import (
+        JobStatus,
+        VideoJobStatusResponse,
+    )
+    from youtube_extension.services.pipeline_job_store import PipelineJobStore
+
+    store = PipelineJobStore(tmp_path)
+    monkeypatch.setattr(router_module, "get_job_store", lambda: store)
+
+    job = VideoJobStatusResponse(job_id="job_persist_1", status=JobStatus.pending)
+    router_module._persist_video_job(job)
+    first = store.load("job_persist_1")
+    assert isinstance(first, dict)
+    assert isinstance(first.get("created_at"), str) and first["created_at"]
+
+    # A later status update must not overwrite the original created_at.
+    job.status = JobStatus.complete
+    router_module._persist_video_job(job)
+    second = store.load("job_persist_1")
+    assert second["created_at"] == first["created_at"]
 
 
 def test_vera_pre_check_gateway_exception_does_not_crash():

--- a/tests/unit/test_master_roadmap_fixes.py
+++ b/tests/unit/test_master_roadmap_fixes.py
@@ -266,12 +266,17 @@ def test_persist_video_job_stamps_stable_created_at(tmp_path, monkeypatch):
 
     store = PipelineJobStore(tmp_path)
     monkeypatch.setattr(router_module, "get_job_store", lambda: store)
+    # Isolate the module-level in-memory job cache: _persist_video_job also writes
+    # into router._video_jobs, so patch it to a throwaway dict (auto-restored by
+    # monkeypatch) to avoid leaking this job into other tests.
+    monkeypatch.setattr(router_module, "_video_jobs", {})
 
     job = VideoJobStatusResponse(job_id="job_persist_1", status=JobStatus.pending)
     router_module._persist_video_job(job)
     first = store.load("job_persist_1")
     assert isinstance(first, dict)
-    assert isinstance(first.get("created_at"), str) and first["created_at"]
+    assert isinstance(first.get("created_at"), str)
+    assert first["created_at"]
 
     # A later status update must not overwrite the original created_at.
     job.status = JobStatus.complete


### PR DESCRIPTION
## Summary

`main` already carries the `PipelineJobStore.expire_before()` and `PipelineAuditStore` implementations (landed via #495), but it lacks the robustness/edge-case tests that were written and reviewed on the now-superseded **#494**. This PR ports **only that unique test residue** onto current `main` — nothing else from #494 (its implementation is fully duplicated on `main` and would conflict/regress if merged).

This is the "reduce #494 to a clean add-extra-edge-case-test-coverage branch" outcome the #494 triage thread recommended, so **#494 can be closed without losing coverage.**

## What's added

8 regression tests in `tests/unit/test_master_roadmap_fixes.py` (all additive, all already pass against `main`'s code):

**`expire_before()` edge cases**
- empty-string `created_at` treated as missing (no removal)
- unparseable `created_at` left alone rather than raising
- corrupt JSON job file skipped, not raised
- boundary instant not removed (strict less-than)
- naive (tz-less) cutoff coerced to UTC
- removes *every* matching job, not just the first

**Audit store**
- token counts survive a reload from the JSONL file (fresh instance, empty in-memory buffer)

**Router**
- `_persist_video_job` stamps a `created_at` that stays stable across status-transition re-persists

## Targeting the current tree, not #494's

The tests import from the refactored `youtube_extension.services.*` layout on `main` (not #494's stale `backend/services/` tree). The naive-cutoff test is anchored to a UTC base rather than local `now()`, so it is timezone-independent.

## Verification

- 13/13 service-layer tests pass (`PYTHONPATH=src pytest tests/unit/test_master_roadmap_fixes.py -k "expire_before or audit_store or job_store_roundtrip"`), including the 7 new stdlib-only tests.
- The timezone-sensitive naive-cutoff test verified passing under `America/New_York`, `Pacific/Honolulu`, `Asia/Tokyo`, and `UTC`.
- The 8th test (`test_persist_video_job_stamps_stable_created_at`) exercises FastAPI-dependent code not installed in the authoring sandbox; its monkeypatch target (`get_job_store`, imported into the router namespace) and `_persist_video_job`'s use of `model_dump(mode="json")` were verified by reading `main`'s `router.py`. It runs under full CI deps.
- Tests-only change; adds zero new lint findings (the 3 pre-existing `E402`s are identical to `main`, and CI lints `src/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019i6mZMCLtYtQENZsT8Yc6G)_