### PR TITLE
fix(security): harden SQL identifier validation in database_cleanup_service

### DIFF
--- a/src/youtube_extension/backend/services/database_cleanup_service.py
+++ b/src/youtube_extension/backend/services/database_cleanup_service.py
@@ -60,6 +60,25 @@ class CleanupResult:
     success: bool
     error_message: Optional[str] = None
 
+_ALLOWED_TIME_COLUMNS = frozenset({"timestamp", "created_at", "createdAt", "ts"})
+"""Allowlist of timestamp column names that cleanup_table may reference."""
+
+_TABLE_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,127}$")
+"""Regex for safe SQLite identifier: starts with letter/underscore, alphanumeric+underscore only, max 128 chars."""
+
+
+def _validate_identifier(name: str) -> str:
+    """Validate and quote a SQL identifier (table/column name).
+
+    Only alphanumeric characters and underscores are allowed.
+    Returns the name quoted with double-quotes for safe interpolation.
+    Raises ValueError if the name is invalid.
+    """
+    if not _TABLE_NAME_RE.match(name):
+        raise ValueError(f"Invalid SQL identifier: {name!r}")
+    return f'"{name}"'
+
+
 class DatabaseCleanupService:
     """
     Automated cleanup service for SQLite monitoring databases
@@ -202,8 +221,12 @@ class DatabaseCleanupService:
         records_deleted = 0
         initial_size = self.get_database_size_mb(db_path)
 
-        # Validate table name to prevent SQL injection
-        if not re.match(r"^[a-zA-Z0-9_]+$", policy.table_name):
+        # Validate table name to prevent SQL injection.
+        # SQLite does not support parameterized identifiers (table/column names),
+        # so we validate against a strict allowlist regex and quote the identifier.
+        try:
+            safe_table_name = _validate_identifier(policy.table_name)
+        except ValueError:
             return CleanupResult(
                 database_path=db_path,
                 table_name=policy.table_name,
@@ -214,8 +237,6 @@ class DatabaseCleanupService:
                 success=False,
                 error_message=f"Invalid table name format: {policy.table_name}"
             )
-
-        safe_table_name = f'"{policy.table_name}"'
 
         try:
             if not os.path.exists(db_path):
@@ -233,9 +254,11 @@ class DatabaseCleanupService:
             with sqlite3.connect(db_path) as conn:
                 cursor = conn.cursor()
 
-                # Verify table exists
-                cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-                             (policy.table_name,))
+                # Verify table exists using parameterized query
+                cursor.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                    (policy.table_name,),
+                )
                 if not cursor.fetchone():
                     return CleanupResult(
                         database_path=db_path,
@@ -251,11 +274,15 @@ class DatabaseCleanupService:
                 # Calculate cutoff date
                 cutoff_date = datetime.now(timezone.utc) - timedelta(days=policy.retention_days)
 
-                # Determine a valid timestamp column for retention checks
-                cursor.execute(f"PRAGMA table_info({safe_table_name})")
+                # Determine a valid timestamp column for retention checks.
+                # PRAGMA table_info requires an identifier, not a parameter —
+                # safe_table_name is validated above via _validate_identifier.
+                cursor.execute(  # nosec B608 — identifier validated via _validate_identifier
+                    f"PRAGMA table_info({safe_table_name})"
+                )
                 columns = [row[1] for row in cursor.fetchall()]
                 time_col = None
-                for candidate in ("timestamp", "created_at", "createdAt", "ts"):
+                for candidate in _ALLOWED_TIME_COLUMNS:
                     if candidate in columns:
                         time_col = candidate
                         break
@@ -263,7 +290,8 @@ class DatabaseCleanupService:
                 if not time_col:
                     # No recognizable time column; skip with a warning
                     logger.warning(
-                        f"Skipping cleanup for {db_path}.{policy.table_name}: no timestamp-like column found"
+                        f"Skipping cleanup for {db_path}.{policy.table_name}: "
+                        "no timestamp-like column found"
                     )
                     return CleanupResult(
                         database_path=db_path,
@@ -276,17 +304,27 @@ class DatabaseCleanupService:
                         error_message="time column not found"
                     )
 
-                # Delete old records in batches (SQLite-compatible; DELETE ... LIMIT is not portable)
+                # Validate time_col against the allowlist (defense-in-depth).
+                # This assertion should never fail because time_col comes from
+                # _ALLOWED_TIME_COLUMNS, but guards against future code changes.
+                assert time_col in _ALLOWED_TIME_COLUMNS, (
+                    f"time_col {time_col!r} not in allowlist"
+                )
+                safe_time_col = _validate_identifier(time_col)
+
+                # Delete old records in batches using parameterized values.
+                # Table/column identifiers are validated above; only values use ? placeholders.
+                # (SQLite does not support parameterized identifiers.)
+                delete_sql = (
+                    f"DELETE FROM {safe_table_name} "  # nosec B608
+                    f"WHERE rowid IN ("
+                    f"SELECT rowid FROM {safe_table_name} "  # nosec B608
+                    f"WHERE {safe_time_col} < ? LIMIT ?"
+                    f")"
+                )
                 while True:
                     cursor.execute(
-                        f"""
-                        DELETE FROM {safe_table_name}
-                        WHERE rowid IN (
-                            SELECT rowid FROM {safe_table_name}
-                            WHERE {time_col} < ?
-                            LIMIT ?
-                        )
-                        """,
+                        delete_sql,
                         (cutoff_date.isoformat(), policy.batch_size),
                     )
 

--- a/src/youtube_extension/backend/services/database_cleanup_service.py
+++ b/src/youtube_extension/backend/services/database_cleanup_service.py
@@ -63,6 +63,9 @@ class CleanupResult:
 _ALLOWED_TIME_COLUMNS = frozenset({"timestamp", "created_at", "createdAt", "ts"})
 """Allowlist of timestamp column names that cleanup_table may reference."""
 
+_TIME_COLUMN_PRIORITY = ("timestamp", "created_at", "createdAt", "ts")
+"""Ordered sequence defining preference when multiple time columns exist."""
+
 _TABLE_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,127}$")
 """Regex for safe SQLite identifier: starts with letter/underscore, alphanumeric+underscore only, max 128 chars."""
 
@@ -282,7 +285,7 @@ class DatabaseCleanupService:
                 )
                 columns = [row[1] for row in cursor.fetchall()]
                 time_col = None
-                for candidate in _ALLOWED_TIME_COLUMNS:
+                for candidate in _TIME_COLUMN_PRIORITY:
                     if candidate in columns:
                         time_col = candidate
                         break
@@ -305,11 +308,12 @@ class DatabaseCleanupService:
                     )
 
                 # Validate time_col against the allowlist (defense-in-depth).
-                # This assertion should never fail because time_col comes from
-                # _ALLOWED_TIME_COLUMNS, but guards against future code changes.
-                assert time_col in _ALLOWED_TIME_COLUMNS, (
-                    f"time_col {time_col!r} not in allowlist"
-                )
+                # This check should never fail because time_col comes from
+                # _TIME_COLUMN_PRIORITY, but guards against future code changes.
+                if time_col not in _ALLOWED_TIME_COLUMNS:
+                    raise ValueError(
+                        f"time_col {time_col!r} not in allowlist"
+                    )
                 safe_time_col = _validate_identifier(time_col)
 
                 # Delete old records in batches using parameterized values.

--- a/tests/unit/test_database_cleanup_security.py
+++ b/tests/unit/test_database_cleanup_security.py
@@ -11,6 +11,7 @@ from youtube_extension.backend.services.database_cleanup_service import (
     RetentionPolicy,
     _ALLOWED_TIME_COLUMNS,
     _TABLE_NAME_RE,
+    _TIME_COLUMN_PRIORITY,
     _validate_identifier,
 )
 
@@ -239,6 +240,14 @@ class TestAllowedTimeColumns:
             # Should not raise
             result = _validate_identifier(col)
             assert result == f'"{col}"'
+
+    def test_priority_tuple_matches_allowlist(self):
+        """Ensure the ordered priority tuple has the same elements as the frozenset."""
+        assert set(_TIME_COLUMN_PRIORITY) == _ALLOWED_TIME_COLUMNS
+
+    def test_priority_has_deterministic_order(self):
+        """Verify timestamp is preferred over other time columns."""
+        assert _TIME_COLUMN_PRIORITY[0] == "timestamp"
 
 
 # ===========================================================================

--- a/tests/unit/test_database_cleanup_security.py
+++ b/tests/unit/test_database_cleanup_security.py
@@ -9,6 +9,9 @@ from youtube_extension.backend.services.database_cleanup_service import (
     CleanupResult,
     DatabaseCleanupService,
     RetentionPolicy,
+    _ALLOWED_TIME_COLUMNS,
+    _TABLE_NAME_RE,
+    _validate_identifier,
 )
 
 
@@ -71,3 +74,194 @@ def test_table_intact_after_rejected_injection(temp_db):
     count = cursor.fetchone()[0]
     conn.close()
     assert count == 2
+
+
+# ===========================================================================
+# _validate_identifier — unit tests
+# ===========================================================================
+
+
+class TestValidateIdentifier:
+    """Tests for the _validate_identifier security function."""
+
+    def test_valid_simple_name(self):
+        assert _validate_identifier("metrics") == '"metrics"'
+
+    def test_valid_underscore_prefix(self):
+        assert _validate_identifier("_internal") == '"_internal"'
+
+    def test_valid_mixed_case(self):
+        assert _validate_identifier("ApiUsage") == '"ApiUsage"'
+
+    def test_valid_with_numbers(self):
+        assert _validate_identifier("table_v2") == '"table_v2"'
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            _validate_identifier("")
+
+    def test_rejects_semicolon(self):
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            _validate_identifier("table; DROP TABLE users")
+
+    def test_rejects_dash(self):
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            _validate_identifier("my-table")
+
+    def test_rejects_space(self):
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            _validate_identifier("my table")
+
+    def test_rejects_quotes(self):
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            _validate_identifier('table"name')
+
+    def test_rejects_starts_with_number(self):
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            _validate_identifier("0_invalid")
+
+    def test_rejects_too_long(self):
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            _validate_identifier("a" * 129)
+
+    def test_accepts_max_length(self):
+        name = "a" * 128
+        assert _validate_identifier(name) == f'"{name}"'
+
+    def test_rejects_sql_comment(self):
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            _validate_identifier("table--comment")
+
+    def test_rejects_backtick(self):
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            _validate_identifier("`table`")
+
+    def test_rejects_parentheses(self):
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            _validate_identifier("table()")
+
+    def test_rejects_newline(self):
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            _validate_identifier("table\nname")
+
+
+# ===========================================================================
+# SQL injection attack vectors — regression tests
+# ===========================================================================
+
+
+class TestSQLInjectionVectors:
+    """Ensure various SQL injection attack patterns are all rejected."""
+
+    @pytest.fixture
+    def service(self):
+        return DatabaseCleanupService()
+
+    @pytest.fixture
+    def db_with_data(self, tmp_path):
+        db_path = str(tmp_path / "target.db")
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, timestamp TEXT)"
+        )
+        ts = datetime.now(timezone.utc).isoformat()
+        conn.execute("INSERT INTO users (name, timestamp) VALUES (?, ?)", ("alice", ts))
+        conn.commit()
+        conn.close()
+        return db_path
+
+    @pytest.mark.parametrize(
+        "malicious_name",
+        [
+            "users; DROP TABLE users;--",
+            "users UNION SELECT * FROM sqlite_master--",
+            "users; INSERT INTO users VALUES(99,'hacked','now');--",
+            "users WHERE 1=1;--",
+            "users\"; DROP TABLE users;--",
+            "users' OR '1'='1",
+            "users/**/UNION/**/SELECT/**/1,2,3--",
+        ],
+    )
+    def test_injection_in_table_name_rejected(
+        self, service, db_with_data, malicious_name
+    ):
+        policy = RetentionPolicy(table_name=malicious_name, retention_days=1)
+        result = service.cleanup_table(db_with_data, policy)
+        assert result.success is False
+        assert "Invalid table name" in result.error_message
+
+    @pytest.mark.parametrize(
+        "malicious_name",
+        [
+            "users; DROP TABLE users;--",
+            "users UNION SELECT * FROM sqlite_master--",
+            "users; INSERT INTO users VALUES(99,'hacked','now');--",
+        ],
+    )
+    def test_data_intact_after_injection_attempt(
+        self, service, db_with_data, malicious_name
+    ):
+        policy = RetentionPolicy(table_name=malicious_name, retention_days=1)
+        service.cleanup_table(db_with_data, policy)
+
+        # Verify data is untouched
+        conn = sqlite3.connect(db_with_data)
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM users")
+        count = cursor.fetchone()[0]
+        conn.close()
+        assert count == 1
+
+
+# ===========================================================================
+# Allowed time columns allowlist tests
+# ===========================================================================
+
+
+class TestAllowedTimeColumns:
+    """Verify the time column allowlist is correctly enforced."""
+
+    def test_allowlist_is_frozenset(self):
+        assert isinstance(_ALLOWED_TIME_COLUMNS, frozenset)
+
+    def test_expected_columns_present(self):
+        assert "timestamp" in _ALLOWED_TIME_COLUMNS
+        assert "created_at" in _ALLOWED_TIME_COLUMNS
+        assert "createdAt" in _ALLOWED_TIME_COLUMNS
+        assert "ts" in _ALLOWED_TIME_COLUMNS
+
+    def test_arbitrary_column_not_in_allowlist(self):
+        assert "user_input" not in _ALLOWED_TIME_COLUMNS
+        assert "DROP TABLE" not in _ALLOWED_TIME_COLUMNS
+
+    def test_all_allowlisted_columns_pass_identifier_validation(self):
+        for col in _ALLOWED_TIME_COLUMNS:
+            # Should not raise
+            result = _validate_identifier(col)
+            assert result == f'"{col}"'
+
+
+# ===========================================================================
+# Table name regex tests
+# ===========================================================================
+
+
+class TestTableNameRegex:
+    """Verify the _TABLE_NAME_RE regex catches all dangerous patterns."""
+
+    def test_rejects_empty(self):
+        assert not _TABLE_NAME_RE.match("")
+
+    def test_accepts_simple_alpha(self):
+        assert _TABLE_NAME_RE.match("metrics")
+
+    def test_accepts_underscore_start(self):
+        assert _TABLE_NAME_RE.match("_private")
+
+    def test_rejects_number_start(self):
+        assert not _TABLE_NAME_RE.match("123table")
+
+    def test_rejects_special_chars(self):
+        for char in [";", " ", "-", "'", '"', "(", ")", ".", ",", "/", "\\"]:
+            assert not _TABLE_NAME_RE.match(f"table{char}name")
+


### PR DESCRIPTION
## Summary

Hardens SQL-identifier handling in `DatabaseCleanupService.cleanup_table` to close SQL-injection vectors via table/column names, and adds a dedicated security test suite.

Changes to `src/youtube_extension/backend/services/database_cleanup_service.py`:
- Add a strict `_TABLE_NAME_RE` (`^[a-zA-Z_][a-zA-Z0-9_]{0,127}$`) and a `_validate_identifier()` helper that validates **and** double-quotes identifiers before any interpolation. SQLite cannot parameterize identifiers, so validate-then-quote is the correct pattern.
- Add `_ALLOWED_TIME_COLUMNS` (frozenset) + ordered `_TIME_COLUMN_PRIORITY` tuple. The chosen `time_col` is re-checked against the allowlist as defense-in-depth before it reaches SQL.
- Keep all **values** on `?` placeholders (cutoff date, batch size); only validated identifiers are interpolated, each annotated `# nosec B608` with justification.
- Verify table existence with a parameterized `sqlite_master` query.

Adds `tests/unit/test_database_cleanup_security.py` (40 tests): injection-vector rejection (`DROP TABLE`, `UNION SELECT`, comment/`;` payloads), data-integrity-after-attack checks, allowlist invariants, and regex boundary cases.

## Verification
- `pytest tests/unit/test_database_cleanup_security.py` → **40 passed**
- `pytest tests/unit/test_database_cleanup_service.py` → **33 passed** (no regression)

## Note on overlap
This targets the same file as the parallel efforts in **#547** (Copilot, draft) and **#548** (Claude, ready). They should be reconciled/de-duplicated before merge — surfacing here so a maintainer can pick one. Left as **draft** pending that decision.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DENrxcCeKbvdSjvqa5DRCM)_