### PR TITLE
docs: align CLAUDE.md anthropic SDK floor with pyproject.toml (0.105.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ grep -A 30 "class TranscriptActionResponse" sdk/python/eventrelay_sdk/types.py
 
 ## Anthropic SDK Version
 
-The project requires `anthropic>=0.78.0`. This floor guarantees:
+The project requires `anthropic>=0.105.0` (see `pyproject.toml`). This floor guarantees:
 - `thinking={"type": "adaptive"}` (adaptive thinking, no `budget_tokens`) — introduced in 0.78.0
 - `output_config={"effort": "..."}` (GA effort control, no beta header) — introduced in 0.75.0
 - Current model string: `claude-opus-4-8` (no date suffix)


### PR DESCRIPTION
## Summary

`CLAUDE.md` stated the Anthropic SDK floor as `anthropic>=0.78.0`, but `pyproject.toml:133` actually requires `anthropic>=0.105.0`. Because `CLAUDE.md` is an authoritative rule file that agents and tooling rely on, the stale floor could mislead an agent into believing 0.78.0 is sufficient. This aligns the stated floor to the real constraint.

## Change

- `CLAUDE.md` — update the stated floor from `>=0.78.0` to `>=0.105.0` (with a pointer to `pyproject.toml` as the source of truth). The feature-introduction notes (adaptive thinking → 0.78.0, effort control → 0.75.0) are kept as historical context; those are the versions the features first shipped in, not the project floor.

## Context

This resolves the version-drift item surfaced by the vendor capabilities audit (PR #554) and the corresponding Devin review comment on that PR, which noted the `CLAUDE.md` / `pyproject.toml` inconsistency but left it as a follow-up. This PR is that focused follow-up — docs only, one line changed, no code or behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8sLsneQz1JiC4LmtFmTJ4)_