### PR TITLE
fix(web): report React render errors to Sentry + migrate client config to instrumentation-client.ts

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,0 +1,13 @@
+// Client-side Sentry initialization. Next.js loads this file for every
+// browser session (replaces the deprecated sentry.client.config.ts, which
+// Turbopack does not support).
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN ?? process.env.SENTRY_DSN,
+  tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? '0.1'),
+  debug: false,
+});
+
+// Instruments App Router navigations for Sentry tracing.
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -1,7 +1,0 @@
-import * as Sentry from '@sentry/nextjs';
-
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN ?? process.env.SENTRY_DSN,
-  tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? '0.1'),
-  debug: false,
-});

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { useEffect } from 'react';
+
+// Catches React rendering errors that escape every route-level error
+// boundary (including errors thrown in the root layout) and reports them
+// to Sentry. Must render its own <html>/<body> because it replaces the
+// root layout when active.
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          display: 'flex',
+          minHeight: '100vh',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'system-ui, sans-serif',
+          background: '#0a0a0a',
+          color: '#fafafa',
+        }}
+      >
+        <div style={{ textAlign: 'center', padding: '2rem' }}>
+          <h1 style={{ fontSize: '1.5rem', marginBottom: '0.75rem' }}>
+            Something went wrong
+          </h1>
+          <p style={{ opacity: 0.7, marginBottom: '1.5rem' }}>
+            The error has been reported. Please try again.
+          </p>
+          <button
+            onClick={reset}
+            style={{
+              padding: '0.5rem 1.25rem',
+              borderRadius: '0.5rem',
+              border: '1px solid #333',
+              background: '#1a1a1a',
+              color: '#fafafa',
+              cursor: 'pointer',
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary

Resolves the two `@sentry/nextjs` code-level warnings from the Vercel production build:

1. **`It seems like you don't have a global error handler set up`** — added `apps/web/src/app/global-error.tsx` with `Sentry.captureException`, so React rendering errors that escape every route-level error boundary (including root-layout errors) are actually reported. Previously only Next's builtin global-error ran, which reports nothing.
2. **`DEPRECATION WARNING: … renaming your sentry.client.config.ts … to instrumentation-client.ts`** — moved the client init to `apps/web/instrumentation-client.ts` (the current Next.js convention; the old filename is silently ignored under Turbopack) and deleted `sentry.client.config.ts`. Also exports `onRouterTransitionStart` for App Router navigation tracing.

Not addressed here (not a code change): the `No auth token provided` warnings require setting `SENTRY_AUTH_TOKEN` in the Vercel project env to enable release creation + source-map upload.

## Verification

- `npx tsc --noEmit` in `apps/web`: clean
- Full `next build`: succeeds with **zero** Sentry warnings (both warnings previously printed at build start)
- ESLint crashes on all files in this workspace (pre-existing `eslint-plugin-react` / ESLint 10 incompatibility, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TuMQyqr1ipBBZRFoErENJZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuMQyqr1ipBBZRFoErENJZ)_