### PR TITLE
fix(web): report React render errors to Sentry + migrate client config

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,0 +1,13 @@
+// Client-side Sentry initialization. Next.js loads this file for every
+// browser session (replaces the deprecated sentry.client.config.ts, which
+// Turbopack does not support).
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN ?? process.env.SENTRY_DSN,
+  tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? '0.1'),
+  debug: false,
+});
+
+// Instruments App Router navigations for Sentry tracing.
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -1,7 +1,0 @@
-import * as Sentry from '@sentry/nextjs';
-
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN ?? process.env.SENTRY_DSN,
-  tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? '0.1'),
-  debug: false,
-});

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { useEffect } from 'react';
+
+// Catches React rendering errors that escape every route-level error
+// boundary (including errors thrown in the root layout) and reports them
+// to Sentry. Must render its own <html>/<body> because it replaces the
+// root layout when active.
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          display: 'flex',
+          minHeight: '100vh',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'system-ui, sans-serif',
+          background: '#0a0a0a',
+          color: '#fafafa',
+        }}
+      >
+        <div style={{ textAlign: 'center', padding: '2rem' }}>
+          <h1 style={{ fontSize: '1.5rem', marginBottom: '0.75rem' }}>
+            Something went wrong
+          </h1>
+          <p style={{ opacity: 0.7, marginBottom: '1.5rem' }}>
+            The error has been reported. Please try again.
+          </p>
+          <button
+            onClick={reset}
+            style={{
+              padding: '0.5rem 1.25rem',
+              borderRadius: '0.5rem',
+              border: '1px solid #333',
+              background: '#1a1a1a',
+              color: '#fafafa',
+              cursor: 'pointer',
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Why this PR

Two `@sentry/nextjs` build warnings surface on the Vercel deploy of `apps/web`. This PR resolves both, purely additively (+71 / −7, all under `apps/web`).

## What's included

| File | Change |
|------|--------|
| `apps/web/src/app/global-error.tsx` (new) | Reports React rendering errors that escape every route-level error boundary (including the root layout) to Sentry via `Sentry.captureException`. Renders its own `<html>/<body>` since it replaces the root layout when active. Previously only the framework's built-in global-error ran, which reports nothing. |
| `apps/web/instrumentation-client.ts` (new) | Client-side Sentry init using the current Next.js convention. Adds `onRouterTransitionStart` for App Router navigation tracing. |
| `apps/web/sentry.client.config.ts` (removed) | Deprecated filename — silently ignored under Turbopack. Content moved to `instrumentation-client.ts`. |

## Validation

- Purely additive frontend change under `apps/web`; no lockfile or backend churn.
- Environment variable handling (`NEXT_PUBLIC_SENTRY_DSN` / `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE`) preserved verbatim from the old config file.

## Next step (human gate)

Base `main` is protected — not auto-merging. Opened as draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3KErPBU7Fi7e5CUHj6PBq

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3KErPBU7Fi7e5CUHj6PBq)_