### PR TITLE
fix(video): stream gateway bytes — repair post-merge payload bug from #572

### DIFF
--- a/apps/web/src/app/api/__tests__/video-generate-route.test.ts
+++ b/apps/web/src/app/api/__tests__/video-generate-route.test.ts
@@ -20,8 +20,21 @@ function gatewayOk(json: unknown) {
 function gatewayErr(status: number) {
   return { ok: false, status, json: async () => ({}), text: async () => 'gateway error' };
 }
-function videoBytesOk() {
-  return { ok: true, status: 200, arrayBuffer: async () => new TextEncoder().encode('FAKEVIDEO').buffer };
+function streamOf(text: string) {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+}
+function videoBytesOk(text = 'FAKEVIDEO') {
+  return {
+    ok: true,
+    status: 200,
+    body: streamOf(text),
+    headers: new Headers({ 'content-type': 'video/mp4', 'content-length': String(text.length) }),
+  };
 }
 
 const validBody = { prompt: 'a calm ocean at sunset', aspectRatio: '16:9', duration: 5 };
@@ -95,18 +108,19 @@ describe('POST /api/video/generate', () => {
     expect(res.status).toBe(502);
   });
 
-  it('returns base64 directly when the gateway provides it', async () => {
+  it('streams the decoded bytes when the gateway provides base64 inline', async () => {
+    // 'QkFTRTY0' is base64 for 'BASE64'
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
       gatewayOk({ data: [{ b64_json: 'QkFTRTY0' }] }) as unknown as Response
     );
     const res = await POST(postReq(validBody, '10.0.0.10'));
     expect(res.status).toBe(200);
-    const json = await res.json();
-    expect(json.videoBase64).toBe('QkFTRTY0');
-    expect(json.video).toBeNull();
+    expect(res.headers.get('content-type')).toBe('video/mp4');
+    const buf = Buffer.from(await res.arrayBuffer());
+    expect(buf.toString()).toBe('BASE64');
   });
 
-  it('inlines a remote signed URL as base64 (CSP-safe, no client-controlled proxy)', async () => {
+  it('streams a remote signed URL through without base64-in-JSON (CSP-safe, no client proxy)', async () => {
     const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
     fetchMock
       .mockResolvedValueOnce(gatewayOk({ data: [{ url: 'https://cdn.example/signed.mp4' }] }) as unknown as Response)
@@ -114,11 +128,10 @@ describe('POST /api/video/generate', () => {
 
     const res = await POST(postReq(validBody, '10.0.0.11'));
     expect(res.status).toBe(200);
-    const json = await res.json();
-    expect(json.video).toBeNull();
-    // 'FAKEVIDEO' base64-encoded
-    expect(json.videoBase64).toBe(Buffer.from('FAKEVIDEO').toString('base64'));
-    // second fetch was the server-side inline of the gateway-provided URL
+    expect(res.headers.get('content-type')).toBe('video/mp4');
+    const buf = Buffer.from(await res.arrayBuffer());
+    expect(buf.toString()).toBe('FAKEVIDEO');
+    // second fetch was the server-side retrieval of the gateway-provided URL
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[0][0]).toBe(GATEWAY_URL);
     expect(fetchMock.mock.calls[1][0]).toBe('https://cdn.example/signed.mp4');
@@ -128,7 +141,7 @@ describe('POST /api/video/generate', () => {
     const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
     fetchMock
       .mockResolvedValueOnce(gatewayOk({ data: [{ url: 'https://cdn.example/signed.mp4' }] }) as unknown as Response)
-      .mockResolvedValueOnce({ ok: false, status: 404 } as unknown as Response);
+      .mockResolvedValueOnce({ ok: false, status: 404, body: null, headers: new Headers() } as unknown as Response);
 
     const res = await POST(postReq(validBody, '10.0.0.12'));
     expect(res.status).toBe(502);

--- a/apps/web/src/app/api/video/generate/route.ts
+++ b/apps/web/src/app/api/video/generate/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-export const runtime = 'nodejs'; // needs Buffer to inline the signed video URL
+export const runtime = 'nodejs'; // streams/buffers the gateway video bytes through
 export const maxDuration = 300; // 5 minutes — video generation takes time
 
 /** Simple in-memory rate limiter: max 3 requests per IP per 10 minutes */
@@ -132,9 +132,9 @@ export async function POST(request: Request) {
     // AI Gateway returns video as a signed URL or base64 depending on the response.
     // Validate the shape so we never send a 200 with no usable video payload.
     const remoteUrl: string | null = data?.data?.[0]?.url ?? data?.url ?? null;
-    let videoBase64: string | null = data?.data?.[0]?.b64_json ?? null;
+    const inlineBase64: string | null = data?.data?.[0]?.b64_json ?? null;
 
-    if (!remoteUrl && !videoBase64) {
+    if (!remoteUrl && !inlineBase64) {
       console.error(
         '[video/generate] Unexpected gateway response shape:',
         JSON.stringify(data)?.slice(0, 500)
@@ -145,39 +145,63 @@ export async function POST(request: Request) {
       );
     }
 
-    // The app's CSP is `media-src 'self' blob: data:`, so a cross-origin signed
-    // URL would be blocked by the browser and the <video> would never load. The
-    // URL here comes from the trusted gateway response (NOT client input), so we
-    // can safely fetch it server-side and inline it as base64 — a `data:` source
-    // the CSP permits — without exposing a client-controllable proxy (no SSRF).
-    if (!videoBase64 && remoteUrl) {
-      try {
-        const videoResp = await fetch(remoteUrl, { signal: AbortSignal.timeout(45_000) });
-        if (videoResp.ok) {
-          const buf = Buffer.from(await videoResp.arrayBuffer());
-          videoBase64 = buf.toString('base64');
-        } else {
-          console.error('[video/generate] Failed to fetch signed video URL:', videoResp.status);
-        }
-      } catch (fetchErr) {
-        console.error('[video/generate] Error inlining signed video URL:', fetchErr);
-      }
+    // Return the raw video bytes as the response body (never base64-in-JSON): a
+    // realistically-sized Veo clip base64-encoded inside NextResponse.json would
+    // exceed Vercel's ~4.5 MB serverless response limit and fail with
+    // FUNCTION_PAYLOAD_TOO_LARGE. The client wraps the bytes in a `blob:` URL,
+    // which the app's `media-src 'self' blob: data:` CSP permits.
+    const baseHeaders: Record<string, string> = {
+      'Cache-Control': 'no-store',
+      'X-Video-Model': 'google/veo-3.1-generate-001',
+    };
+
+    // Case 1: gateway already returned the bytes inline as base64. Decode once
+    // and stream them back as binary — small enough to hold, but sent outside a
+    // JSON envelope so the response never trips the buffered-body size limit.
+    if (inlineBase64) {
+      const buf = Buffer.from(inlineBase64, 'base64');
+      return new Response(buf, {
+        status: 200,
+        headers: {
+          ...baseHeaders,
+          'Content-Type': 'video/mp4',
+          'Content-Length': String(buf.byteLength),
+        },
+      });
     }
 
-    if (!videoBase64) {
+    // Case 2: gateway returned a signed URL. The URL comes from the trusted
+    // gateway response (NOT client input — no SSRF), so we fetch it server-side
+    // and STREAM the body straight through to the client. Streaming means we
+    // never buffer the whole file in memory (no OOM on large clips) and never
+    // hit the buffered-response size limit.
+    let videoResp: Response;
+    try {
+      videoResp = await fetch(remoteUrl as string, { signal: AbortSignal.timeout(120_000) });
+    } catch (fetchErr) {
+      console.error('[video/generate] Error fetching signed video URL:', fetchErr);
       return NextResponse.json(
         { error: 'Video was generated but could not be retrieved for playback.' },
         { status: 502 }
       );
     }
 
-    return NextResponse.json({
-      // `video` is intentionally null: the client renders the base64 `data:` URL,
-      // which is the only cross-origin-safe source under the app's media-src CSP.
-      video: null,
-      videoBase64,
-      model: 'google/veo-3.1-generate-001',
-      prompt: prompt.trim(),
+    if (!videoResp.ok || !videoResp.body) {
+      console.error('[video/generate] Failed to fetch signed video URL:', videoResp.status);
+      return NextResponse.json(
+        { error: 'Video was generated but could not be retrieved for playback.' },
+        { status: 502 }
+      );
+    }
+
+    const upstreamLength = videoResp.headers.get('content-length');
+    return new Response(videoResp.body, {
+      status: 200,
+      headers: {
+        ...baseHeaders,
+        'Content-Type': videoResp.headers.get('content-type') ?? 'video/mp4',
+        ...(upstreamLength ? { 'Content-Length': upstreamLength } : {}),
+      },
     });
   } catch (error) {
     console.error('[video/generate] Error:', error);

--- a/apps/web/src/app/api/video/generate/route.ts
+++ b/apps/web/src/app/api/video/generate/route.ts
@@ -155,12 +155,20 @@ export async function POST(request: Request) {
       'X-Video-Model': 'google/veo-3.1-generate-001',
     };
 
-    // Case 1: gateway already returned the bytes inline as base64. Decode once
-    // and stream them back as binary — small enough to hold, but sent outside a
-    // JSON envelope so the response never trips the buffered-body size limit.
+    // Case 1: gateway already returned the bytes inline as base64. Decode, then
+    // stream them back. A buffered `Response(buf)` — like base64-in-JSON — is
+    // still subject to Vercel's ~4.5 MB response-body limit and would fail with
+    // FUNCTION_PAYLOAD_TOO_LARGE for large clips; only STREAMED responses bypass
+    // that limit, so wrap the buffer in a ReadableStream and return that.
     if (inlineBase64) {
       const buf = Buffer.from(inlineBase64, 'base64');
-      return new Response(buf, {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(buf));
+          controller.close();
+        },
+      });
+      return new Response(stream, {
         status: 200,
         headers: {
           ...baseHeaders,

--- a/apps/web/src/components/video-generator.tsx
+++ b/apps/web/src/components/video-generator.tsx
@@ -19,12 +19,14 @@ export default function VideoGenerator({ className = '' }: VideoGeneratorProps) 
   const [duration, setDuration] = useState(5);
   const [state, setState] = useState<GenerationState>('idle');
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
-  const [videoBase64, setVideoBase64] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [elapsed, setElapsed] = useState(0);
 
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  // Tracks the current `blob:` object URL so we can revoke it (freeing the
+  // buffered video) before creating a new one or on unmount.
+  const objectUrlRef = useRef<string | null>(null);
 
   const clearTimer = () => {
     if (timerRef.current !== null) {
@@ -33,13 +35,21 @@ export default function VideoGenerator({ className = '' }: VideoGeneratorProps) 
     }
   };
 
-  // On unmount, tear down the elapsed-time interval and abort any in-flight
+  const revokeObjectUrl = () => {
+    if (objectUrlRef.current !== null) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+  };
+
+  // On unmount, tear down the elapsed-time interval, abort any in-flight
   // request so it doesn't keep running (up to 5 min) or set state on an
-  // unmounted component.
+  // unmounted component, and revoke any outstanding object URL.
   useEffect(() => {
     return () => {
       clearTimer();
       abortRef.current?.abort();
+      revokeObjectUrl();
     };
   }, []);
 
@@ -48,8 +58,8 @@ export default function VideoGenerator({ className = '' }: VideoGeneratorProps) 
 
     setState('generating');
     setError(null);
+    revokeObjectUrl();
     setVideoUrl(null);
-    setVideoBase64(null);
     setElapsed(0);
     const t0 = Date.now();
 
@@ -59,38 +69,49 @@ export default function VideoGenerator({ className = '' }: VideoGeneratorProps) 
       setElapsed(Math.floor((Date.now() - t0) / 1000));
     }, 1000);
 
+    // Combine the mandated request timeout (AbortSignal.timeout) with the
+    // component's own controller so an unmount still aborts the in-flight
+    // fetch. Either signal firing aborts the request.
     const controller = new AbortController();
     abortRef.current = controller;
-    const timeoutId = setTimeout(() => controller.abort(), CLIENT_TIMEOUT_MS);
 
     try {
       const res = await fetch('/api/video/generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ prompt: prompt.trim(), aspectRatio, duration }),
-        signal: controller.signal,
+        signal: AbortSignal.any([AbortSignal.timeout(CLIENT_TIMEOUT_MS), controller.signal]),
       });
 
-      clearTimeout(timeoutId);
       clearTimer();
-      const data = await res.json();
 
       if (!res.ok) {
-        throw new Error(data.error ?? `HTTP ${res.status}`);
+        let message = `HTTP ${res.status}`;
+        try {
+          const data = await res.json();
+          message = data.error ?? message;
+        } catch {
+          // Non-JSON error body; keep the status-based message.
+        }
+        throw new Error(message);
       }
 
-      setVideoUrl(data.video ?? null);
-      setVideoBase64(data.videoBase64 ?? null);
+      // The route streams the raw video bytes; wrap them in a same-origin
+      // `blob:` URL, which the app's `media-src 'self' blob: data:` CSP permits.
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      objectUrlRef.current = url;
+      setVideoUrl(url);
       setState('done');
     } catch (err) {
-      clearTimeout(timeoutId);
+      console.error('[video-generator] Error:', err);
       clearTimer();
       setError(err instanceof Error ? err.message : 'Unknown error');
       setState('error');
     }
   };
 
-  const videoSrc = videoUrl ?? (videoBase64 ? `data:video/mp4;base64,${videoBase64}` : null);
+  const videoSrc = videoUrl;
 
   return (
     <div className={`bg-white/5 rounded-2xl border border-white/10 p-6 ${className}`}>


### PR DESCRIPTION
## Why this PR

**#572 merged the AI video-generation feature to `main` at its pre-fix head (`3b38ff2`), so `main` currently ships a broken response path.** Three review bots on #572 (Vercel VADE, Devin) flagged defects in the base64-in-JSON video return, but the PR was merged before those fixes could land. `main`'s `apps/web/src/app/api/video/generate/route.ts` still base64-encodes the whole clip into a `NextResponse.json` body.

#572 is merged and cannot be reused, so this is a fresh follow-up branched off current `main`.

## What this repairs (relative to what is now on `main`)

| Finding | Fix |
|---------|-----|
| 🔴 **Vercel VADE (logic)** — base64 inside `NextResponse.json` exceeds Vercel's ~4.5 MB serverless response limit → realistically-sized Veo clips fail with `FUNCTION_PAYLOAD_TOO_LARGE` and never play | Route returns the raw bytes as a `video/mp4` body. A signed URL is **piped through as a `ReadableStream`** (no buffering); inline base64 is decoded once and returned. |
| 🟨 **Devin SEC** — unbounded `arrayBuffer()` buffers the whole file in memory → OOM risk on large clips | Streaming means the file is never held in memory server-side. |
| — CSP: cross-origin `<video>` sources are blocked by `media-src 'self' blob: data:` | Client wraps the streamed bytes in a same-origin **`blob:` URL** (CSP-permitted) and revokes it on replace/unmount. |
| 🟡 **Devin** — fetch used a manual `AbortController` instead of the `.cursorrules`-mandated `AbortSignal.timeout()` | `AbortSignal.any([AbortSignal.timeout(CLIENT_TIMEOUT_MS), controller.signal])` — satisfies the rule while keeping unmount-abort. |
| 🟡 **Devin** — bare client `catch` without logging (`.cursorrules` violation) | `console.error` added in the catch. |

## Validation

- `apps/web` `npm run type-check` (`tsc --noEmit`): **clean**.
- Route tests updated to the streamed-binary contract: **12/12 pass** (`video-generate-route.test.ts`).

## Scope

Only the three video files are touched (route, component, route test). The remaining Devin comments on #572 (in-memory limiter across cold starts, rate-limit-before-validation, unique test IPs, pre-existing playground fetch) are informational / explicitly out-of-scope follow-ups for this experimental feature.

## Next step (human gate)

Base `main` is protected; not auto-merging. Once green, squash-merge to restore a working video-generation path on `main`.

---
_Generated by Claude Code (PR remediation run — post-merge repair of #572)._

---
_Generated by [Claude Code](https://claude.ai/code/session_01119VZuoaJdxaAzK5A6swZo)_