### PR TITLE
fix(video): log non-JSON error body in video-generator catch (.cursorrules follow-up to #582)

### DIFF
--- a/apps/web/src/components/video-generator.tsx
+++ b/apps/web/src/components/video-generator.tsx
@@ -90,8 +90,9 @@ export default function VideoGenerator({ className = '' }: VideoGeneratorProps) 
         try {
           const data = await res.json();
           message = data.error ?? message;
-        } catch {
+        } catch (parseErr) {
           // Non-JSON error body; keep the status-based message.
+          console.error('[video-generator] Non-JSON error body:', parseErr);
         }
         throw new Error(message);
       }


### PR DESCRIPTION
## Why this PR

The video-generation streaming repair landed on `main` via **#582** (squash-merged as `f5a5dcb`). During that review, Devin flagged one 🟡 nit that #582 merged *without* fixing:

> **Error silently swallowed when parsing non-JSON error response** — `apps/web/src/components/video-generator.tsx` has a bare inner `catch {}` (comment only, no logging) when `res.json()` fails on a non-JSON error body. This violates `.cursorrules:28` ("Never do: bare catch without logging"); every other catch in the file logs via `console.error('[video-generator] …')`.

This PR is the clean, standalone follow-up that resolves exactly that nit — nothing else.

## Change

```diff
-        } catch {
+        } catch (parseErr) {
           // Non-JSON error body; keep the status-based message.
+          console.error('[video-generator] Non-JSON error body:', parseErr);
         }
```

One file, +2/−1, rebased onto current `main` (no conflict). The streaming/blob work it follows is already in `main`.

## Next step (human gate)

Base `main` is protected — **not auto-merging**. Trivial lint-level fix; squash-merge when convenient.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYwpiBce6QprKiVmVfpU5n