### PR TITLE
fix(video): don't log expected unmount AbortError in VideoGenerator

### DIFF
--- a/apps/web/src/components/video-generator.tsx
+++ b/apps/web/src/components/video-generator.tsx
@@ -104,7 +104,13 @@ export default function VideoGenerator({ className = '' }: VideoGeneratorProps) 
       setVideoUrl(url);
       setState('done');
     } catch (err) {
-      console.error('[video-generator] Error:', err);
+      // An unmount aborts the in-flight fetch (abortRef), which rejects with an
+      // AbortError. That's expected teardown, not a failure — don't log it (it
+      // would pollute logs and can trip console-based alerting). Real timeouts
+      // reject with TimeoutError and still get logged.
+      if (!(err instanceof DOMException && err.name === 'AbortError')) {
+        console.error('[video-generator] Error:', err);
+      }
       clearTimer();
       setError(err instanceof Error ? err.message : 'Unknown error');
       setState('error');


### PR DESCRIPTION
## Summary

Follow-up hardening on `apps/web/src/components/video-generator.tsx` — the component landed by #529 and further repaired by #582 (gateway byte streaming). When the component unmounts mid-request, the in-flight `fetch` is aborted via the component's own `AbortController`, which rejects the `await` with a `DOMException` named `AbortError`. That is **expected teardown**, not a failure, but the `catch` block was logging it via `console.error`.

This change guards the log so expected unmount aborts are silent, while genuine failures — including real request timeouts, which reject with `TimeoutError` (not `AbortError`) — still get logged.

## Change

```ts
} catch (err) {
  if (!(err instanceof DOMException && err.name === 'AbortError')) {
    console.error('[video-generator] Error:', err);
  }
  clearTimer();
  setError(err instanceof Error ? err.message : 'Unknown error');
  setState('error');
```

- Prevents log pollution and avoids tripping console-based alerting on normal navigation/unmount.
- Preserves user-facing error state (`setError` / `setState('error')`) unchanged — only the log call is gated.
- Distinct from the `AbortSignal.any([AbortSignal.timeout(...), controller.signal])` timeout wiring, which already reached `main` via #582; this PR only adds the log guard on top of that.

## Scope

Single file, 6 lines net. Rebased onto current `main`; a companion commit was dropped during rebase because its patch had already landed upstream.

## Test plan

- [ ] `turbo run lint` / `apps/web` type-check (no new types introduced; uses global `DOMException`)
- [ ] Manual: start a generation, navigate away before it completes → no `[video-generator] Error:` line in the console; real upstream/timeout errors still logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016d8BiHAxS8GNa1VQ7Wsbx1)_