### PR TITLE
ci: phase goal tracker workflow + Copilot review fixes (supersedes #531)

### DIFF
--- a/.github/workflows/AUDIT.md
+++ b/.github/workflows/AUDIT.md
@@ -25,6 +25,7 @@ concrete reason, verified against the actual repository tree.
 | `emergency-stop.yml` | KEEP | Manual operational kill-switch with typed confirmation. |
 | `issue-triage.yml` | KEEP | Keyword auto-labeling + triage comment on new issues. |
 | `mcp-optimization.yml` | **DELETE** | Entire workflow targets `mcp-servers/mcp-profiling/` (requirements.txt, investigator_client.py, profiling_server.py) which does not exist — every run fails. |
+| `phase-goal-tracker.yml` | KEEP | Tracks markdown checklists on phase issues, keeps a single status comment updated, and auto-closes the issue when all checklist goals are complete. |
 | `pr-checks.yml` | KEEP | Validates PR title/description; fork-safe comment handling. |
 | `real-processing.yml` | KEEP | Manual single-video processing; well-formed. |
 | `secret-scan.yml` | KEEP | gitleaks on the working tree; action pinned to SHA, checksum-verified install. |

--- a/.github/workflows/AUDIT.md
+++ b/.github/workflows/AUDIT.md
@@ -46,7 +46,7 @@ job rather than merging.
 
 ## Verification
 
-All 21 remaining workflow files were parsed with PyYAML after the changes — all
+All 22 remaining workflow files were parsed with PyYAML after the changes — all
 valid. Referenced paths were checked against the working tree:
 
 - Present: `.github/codeql/codeql-config.yml`, `.gitleaks.toml`, `.trivyignore`,

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,6 +19,7 @@ workflow; this README is the index.
 | Auto Label | `auto-label.yml` | PR opened/reopened/synchronize | Label PRs by changed file type (docs, tests, python, etc.) |
 | Auto-Assign Issues | `auto-assign.yml` | issue opened | Assign new issues to the repository owner |
 | Issue Triage | `issue-triage.yml` | issue opened | Auto-label new issues by keyword and post a triage comment |
+| Phase Goal Tracker | `phase-goal-tracker.yml` | issue opened/edited/reopened; manual | Track phase checklist progress, comment status, auto-close when complete |
 | Bulk Issue Processor | `bulk-issue-processor.yml` | manual | Bulk label / summarize / close-stale across many issues |
 | Close stale issues | `stale.yml` | daily (00:00 UTC) | Mark and close stale issues and PRs |
 | Branch Cleanup | `branch-cleanup.yml` | manual | Gated archive-then-delete of branches (dry-run by default) |

--- a/.github/workflows/phase-goal-tracker.yml
+++ b/.github/workflows/phase-goal-tracker.yml
@@ -70,12 +70,12 @@ jobs:
             const isCompleted = (match) => match[1].toLowerCase() === 'x';
             const completedTasks = taskMatches.filter(isCompleted);
             const maxOpenTasksToShow = 10;
-            const openTaskCount = taskMatches.length - completedTasks.length;
+            const completed = completedTasks.length;
+            const openTaskCount = total - completed;
             const openTasks = taskMatches
               .filter((match) => !isCompleted(match))
               .map((match) => `- [ ] ${match[2]}`)
               .slice(0, maxOpenTasksToShow);
-            const completed = completedTasks.length;
             const progressPercent = Math.round((completed / total) * 100);
             const done = completed === total;
 
@@ -133,4 +133,6 @@ jobs:
                 issue_number: issue.number,
                 state: 'closed',
               });
+            } else if (done) {
+              core.info(`Issue #${issue.number} is already closed.`);
             }

--- a/.github/workflows/phase-goal-tracker.yml
+++ b/.github/workflows/phase-goal-tracker.yml
@@ -1,0 +1,130 @@
+name: Phase Goal Tracker
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to evaluate"
+        required: true
+        type: number
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  track:
+    name: Track phase checklist progress
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate checklist and update tracker comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const issueNumber =
+              context.eventName === 'workflow_dispatch'
+                ? Number(core.getInput('issue_number'))
+                : context.payload.issue.number;
+
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+
+            if (issue.pull_request) {
+              core.info(`Skipping PR #${issue.number}.`);
+              return;
+            }
+
+            const labels = issue.labels.map((label) => label.name.toLowerCase());
+            const title = (issue.title || '').toLowerCase();
+            const body = issue.body || '';
+
+            const phaseIssue =
+              labels.some((label) => /^phase-\d+$/.test(label)) ||
+              title.includes('[phase') ||
+              title.includes('testing & production launch');
+
+            if (!phaseIssue) {
+              core.info(`Skipping non-phase issue #${issue.number}.`);
+              return;
+            }
+
+            const taskMatches = [...body.matchAll(/^\s*-\s+\[( |x|X)\]\s+(.+)$/gm)];
+            const total = taskMatches.length;
+
+            if (total === 0) {
+              core.info(`No checklist found on issue #${issue.number}.`);
+              return;
+            }
+
+            const completedTasks = taskMatches.filter((match) => /x/i.test(match[1]));
+            const openTasks = taskMatches
+              .filter((match) => !/x/i.test(match[1]))
+              .map((match) => `- [ ] ${match[2]}`)
+              .slice(0, 10);
+            const completed = completedTasks.length;
+            const percent = Math.round((completed / total) * 100);
+            const done = completed === total;
+
+            const trackerMarker = '<!-- phase-goal-tracker -->';
+            const summaryBody = [
+              trackerMarker,
+              '## 🎯 Phase Goal Tracker',
+              '',
+              `- Progress: **${completed}/${total}** tasks complete (**${percent}%**)`,
+              `- Status: ${done ? '✅ All goals complete' : '⏳ In progress'}`,
+              '',
+              done
+                ? 'All checklist goals are complete. Closing this issue now.'
+                : `### Next goals\n${openTasks.join('\n')}`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(
+              (comment) =>
+                comment.user?.type === 'Bot' &&
+                typeof comment.body === 'string' &&
+                comment.body.includes(trackerMarker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: summaryBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: summaryBody,
+              });
+            }
+
+            if (done && issue.state !== 'closed') {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: '✅ All tracked goals are complete. Auto-closing this issue.',
+              });
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+            }

--- a/.github/workflows/phase-goal-tracker.yml
+++ b/.github/workflows/phase-goal-tracker.yml
@@ -25,7 +25,7 @@ jobs:
           script: |
             const issueNumber =
               context.eventName === 'workflow_dispatch'
-                ? Number(core.getInput('issue_number'))
+                ? Number(context.payload.inputs?.issue_number)
                 : context.payload.issue.number;
 
             const { data: issue } = await github.rest.issues.get({
@@ -62,10 +62,11 @@ jobs:
             }
 
             const completedTasks = taskMatches.filter((match) => /x/i.test(match[1]));
+            const MAX_OPEN_TASKS_TO_SHOW = 10;
             const openTasks = taskMatches
               .filter((match) => !/x/i.test(match[1]))
               .map((match) => `- [ ] ${match[2]}`)
-              .slice(0, 10);
+              .slice(0, MAX_OPEN_TASKS_TO_SHOW);
             const completed = completedTasks.length;
             const percent = Math.round((completed / total) * 100);
             const done = completed === total;
@@ -83,7 +84,7 @@ jobs:
                 : `### Next goals\n${openTasks.join('\n')}`,
             ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue.number,
@@ -114,13 +115,6 @@ jobs:
             }
 
             if (done && issue.state !== 'closed') {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body: '✅ All tracked goals are complete. Auto-closing this issue.',
-              });
-
               await github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/phase-goal-tracker.yml
+++ b/.github/workflows/phase-goal-tracker.yml
@@ -58,10 +58,10 @@ jobs:
               return;
             }
 
-            const CHECKLIST_ITEM_PATTERN = /^\s*-\s+\[\s*([xX]?)\s*\]\s+(.+)$/;
+            const checklistItemPattern = /^\s*-\s+\[\s*([xX]?)\s*\]\s+(.+)$/;
             const taskMatches = body
               .split('\n')
-              .map((line) => line.match(CHECKLIST_ITEM_PATTERN))
+              .map((line) => line.match(checklistItemPattern))
               .filter(Boolean);
             const total = taskMatches.length;
 
@@ -70,7 +70,7 @@ jobs:
               return;
             }
 
-            const isCompleted = (match) => /[xX]/.test(match[1]);
+            const isCompleted = (match) => match[1].toLowerCase() === 'x';
             const completedTasks = taskMatches.filter(isCompleted);
             const maxOpenTasksToShow = 10;
             const completed = completedTasks.length;

--- a/.github/workflows/phase-goal-tracker.yml
+++ b/.github/workflows/phase-goal-tracker.yml
@@ -25,7 +25,7 @@ jobs:
           script: |
             const issueNumber =
               context.eventName === 'workflow_dispatch'
-                ? Number(context.payload?.inputs?.issue_number)
+                ? Number(context.payload.inputs.issue_number)
                 : context.payload.issue.number;
 
             if (!Number.isInteger(issueNumber)) {
@@ -58,8 +58,11 @@ jobs:
               return;
             }
 
-            const CHECKLIST_ITEM_PATTERN = /^\s*-\s+\[\s*([xX]?)\s*\]\s+(.+)$/gm;
-            const taskMatches = [...body.matchAll(CHECKLIST_ITEM_PATTERN)];
+            const CHECKLIST_ITEM_PATTERN = /^\s*-\s+\[\s*([xX]?)\s*\]\s+(.+)$/;
+            const taskMatches = body
+              .split('\n')
+              .map((line) => line.match(CHECKLIST_ITEM_PATTERN))
+              .filter(Boolean);
             const total = taskMatches.length;
 
             if (total === 0) {
@@ -67,7 +70,7 @@ jobs:
               return;
             }
 
-            const isCompleted = (match) => match[1].toLowerCase() === 'x';
+            const isCompleted = (match) => /[xX]/.test(match[1]);
             const completedTasks = taskMatches.filter(isCompleted);
             const maxOpenTasksToShow = 10;
             const completed = completedTasks.length;
@@ -126,13 +129,15 @@ jobs:
               });
             }
 
-            if (done && issue.state !== 'closed') {
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                state: 'closed',
-              });
-            } else if (done) {
-              core.info(`Issue #${issue.number} is already closed.`);
+            if (done) {
+              if (issue.state !== 'closed') {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                });
+              } else {
+                core.info(`Issue #${issue.number} is already closed.`);
+              }
             }

--- a/.github/workflows/phase-goal-tracker.yml
+++ b/.github/workflows/phase-goal-tracker.yml
@@ -51,7 +51,7 @@ jobs:
             const body = issue.body || '';
 
             const phaseIssue =
-              labels.some((label) => /^phase-\d+$/.test(label)) ||
+              labels.some((label) => /^phase-.+/.test(label)) ||
               title.includes('[phase');
 
             if (!phaseIssue) {
@@ -83,7 +83,18 @@ jobs:
             const progressPercent = Math.round((completed / total) * 100);
             const done = completed === total;
 
+            // A maintainer who reopens a finished phase issue (to add follow-up
+            // tasks or fix a prematurely-checked box) must be able to edit it
+            // before it is auto-closed again, so never auto-close on `reopened`.
+            const isReopen =
+              context.eventName === 'issues' &&
+              context.payload.action === 'reopened';
+            const willClose = done && !isReopen;
+
             const trackerMarker = '<!-- phase-goal-tracker -->';
+            const doneMessage = willClose
+              ? 'All checklist goals are complete. Closing this issue now.'
+              : 'All checklist goals are complete. Auto-close is skipped because the issue was just reopened — edit the checklist or close it manually.';
             const summaryBody = [
               trackerMarker,
               '## 🎯 Phase Goal Tracker',
@@ -92,7 +103,7 @@ jobs:
               `- Status: ${done ? '✅ All goals complete' : '⏳ In progress'}`,
               '',
               done
-                ? 'All checklist goals are complete. Closing this issue now.'
+                ? doneMessage
                 : `### Next goals\n${openTasks.join('\n')}${
                     openTaskCount > maxOpenTasksToShow
                       ? `\n\n_Showing first ${maxOpenTasksToShow} of ${openTaskCount} remaining tasks._`
@@ -130,7 +141,7 @@ jobs:
               });
             }
 
-            if (done) {
+            if (willClose) {
               if (issue.state === 'open') {
                 await github.rest.issues.update({
                   owner: context.repo.owner,
@@ -141,4 +152,8 @@ jobs:
               } else {
                 core.info(`Issue #${issue.number} is already closed.`);
               }
+            } else if (done && isReopen) {
+              core.info(
+                `Issue #${issue.number} is complete but was just reopened; leaving it open for edits.`
+              );
             }

--- a/.github/workflows/phase-goal-tracker.yml
+++ b/.github/workflows/phase-goal-tracker.yml
@@ -72,7 +72,7 @@ jobs:
               return;
             }
 
-            const isCompleted = (match) => Boolean(match?.[1]) && match[1].toLowerCase() === 'x';
+            const isCompleted = (match) => match?.[1]?.toLowerCase() === 'x';
             const completedTasks = taskMatches.filter(isCompleted);
             const maxOpenTasksToShow = 10;
             const completed = completedTasks.length;

--- a/.github/workflows/phase-goal-tracker.yml
+++ b/.github/workflows/phase-goal-tracker.yml
@@ -29,7 +29,9 @@ jobs:
                 : context.payload.issue.number;
 
             if (!Number.isInteger(issueNumber)) {
-              core.setFailed('Invalid issue number input.');
+              core.setFailed(
+                `Invalid issue number input: ${JSON.stringify(context.payload?.inputs?.issue_number)}`
+              );
               return;
             }
 
@@ -58,7 +60,7 @@ jobs:
               return;
             }
 
-            const checklistItemPattern = /^\s*-\s+\[\s*([xX]?)\s*\]\s+(.+)$/;
+            const checklistItemPattern = /^\s*-\s+\[([ xX])\]\s+(.+)$/;
             const taskMatches = body
               .split('\n')
               .map((line) => line.match(checklistItemPattern))
@@ -70,7 +72,7 @@ jobs:
               return;
             }
 
-            const isCompleted = (match) => match[1].toLowerCase() === 'x';
+            const isCompleted = (match) => Boolean(match?.[1]) && match[1].toLowerCase() === 'x';
             const completedTasks = taskMatches.filter(isCompleted);
             const maxOpenTasksToShow = 10;
             const completed = completedTasks.length;

--- a/.github/workflows/phase-goal-tracker.yml
+++ b/.github/workflows/phase-goal-tracker.yml
@@ -52,8 +52,7 @@ jobs:
 
             const phaseIssue =
               labels.some((label) => /^phase-\d+$/.test(label)) ||
-              title.includes('[phase') ||
-              title.includes('testing & production launch');
+              title.includes('[phase');
 
             if (!phaseIssue) {
               core.info(`Skipping non-phase issue #${issue.number}.`);
@@ -132,7 +131,7 @@ jobs:
             }
 
             if (done) {
-              if (issue.state !== 'closed') {
+              if (issue.state === 'open') {
                 await github.rest.issues.update({
                   owner: context.repo.owner,
                   repo: context.repo.repo,

--- a/.github/workflows/phase-goal-tracker.yml
+++ b/.github/workflows/phase-goal-tracker.yml
@@ -12,12 +12,18 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
 
 jobs:
   track:
     name: Track phase checklist progress
     runs-on: ubuntu-latest
+    # Serialize runs per issue: opened/edited/reopened/workflow_dispatch can fire
+    # in rapid succession, and the comment-sync flow is a check-then-act (find the
+    # tracker comment, else create one). Without this, two overlapping runs could
+    # both miss the not-yet-created comment and post duplicate tracker comments.
+    concurrency:
+      group: phase-goal-tracker-${{ github.event.issue.number || inputs.issue_number }}
+      cancel-in-progress: false
     steps:
       - name: Evaluate checklist and update tracker comment
         uses: actions/github-script@v9

--- a/.github/workflows/phase-goal-tracker.yml
+++ b/.github/workflows/phase-goal-tracker.yml
@@ -25,8 +25,13 @@ jobs:
           script: |
             const issueNumber =
               context.eventName === 'workflow_dispatch'
-                ? Number(context.payload.inputs?.issue_number)
+                ? Number(context.payload?.inputs?.issue_number)
                 : context.payload.issue.number;
+
+            if (!Number.isInteger(issueNumber)) {
+              core.setFailed('Invalid issue number input.');
+              return;
+            }
 
             const { data: issue } = await github.rest.issues.get({
               owner: context.repo.owner,
@@ -53,7 +58,7 @@ jobs:
               return;
             }
 
-            const CHECKLIST_ITEM_PATTERN = /^\s*-\s+\[( |x|X)\]\s+(.+)$/gm;
+            const CHECKLIST_ITEM_PATTERN = /^\s*-\s+\[\s*([xX]?)\s*\]\s+(.+)$/gm;
             const taskMatches = [...body.matchAll(CHECKLIST_ITEM_PATTERN)];
             const total = taskMatches.length;
 
@@ -64,11 +69,12 @@ jobs:
 
             const isCompleted = (match) => match[1].toLowerCase() === 'x';
             const completedTasks = taskMatches.filter(isCompleted);
-            const MAX_OPEN_TASKS_TO_SHOW = 10;
+            const maxOpenTasksToShow = 10;
+            const openTaskCount = taskMatches.length - completedTasks.length;
             const openTasks = taskMatches
               .filter((match) => !isCompleted(match))
               .map((match) => `- [ ] ${match[2]}`)
-              .slice(0, MAX_OPEN_TASKS_TO_SHOW);
+              .slice(0, maxOpenTasksToShow);
             const completed = completedTasks.length;
             const progressPercent = Math.round((completed / total) * 100);
             const done = completed === total;
@@ -83,7 +89,11 @@ jobs:
               '',
               done
                 ? 'All checklist goals are complete. Closing this issue now.'
-                : `### Next goals\n${openTasks.join('\n')}`,
+                : `### Next goals\n${openTasks.join('\n')}${
+                    openTaskCount > maxOpenTasksToShow
+                      ? `\n\n_Showing first ${maxOpenTasksToShow} of ${openTaskCount} remaining tasks._`
+                      : ''
+                  }`,
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/phase-goal-tracker.yml
+++ b/.github/workflows/phase-goal-tracker.yml
@@ -53,7 +53,8 @@ jobs:
               return;
             }
 
-            const taskMatches = [...body.matchAll(/^\s*-\s+\[( |x|X)\]\s+(.+)$/gm)];
+            const CHECKLIST_ITEM_PATTERN = /^\s*-\s+\[( |x|X)\]\s+(.+)$/gm;
+            const taskMatches = [...body.matchAll(CHECKLIST_ITEM_PATTERN)];
             const total = taskMatches.length;
 
             if (total === 0) {
@@ -61,14 +62,15 @@ jobs:
               return;
             }
 
-            const completedTasks = taskMatches.filter((match) => /x/i.test(match[1]));
+            const isCompleted = (match) => match[1].toLowerCase() === 'x';
+            const completedTasks = taskMatches.filter(isCompleted);
             const MAX_OPEN_TASKS_TO_SHOW = 10;
             const openTasks = taskMatches
-              .filter((match) => !/x/i.test(match[1]))
+              .filter((match) => !isCompleted(match))
               .map((match) => `- [ ] ${match[2]}`)
               .slice(0, MAX_OPEN_TASKS_TO_SHOW);
             const completed = completedTasks.length;
-            const percent = Math.round((completed / total) * 100);
+            const progressPercent = Math.round((completed / total) * 100);
             const done = completed === total;
 
             const trackerMarker = '<!-- phase-goal-tracker -->';
@@ -76,7 +78,7 @@ jobs:
               trackerMarker,
               '## 🎯 Phase Goal Tracker',
               '',
-              `- Progress: **${completed}/${total}** tasks complete (**${percent}%**)`,
+              `- Progress: **${completed}/${total}** tasks complete (**${progressPercent}%**)`,
               `- Status: ${done ? '✅ All goals complete' : '⏳ In progress'}`,
               '',
               done


### PR DESCRIPTION
## Summary

Carries the `phase-goal-tracker.yml` workflow from **#531** (owner-approved, CI-green) and additionally **resolves the two unresolved Copilot review threads** that were leaving #531 at `mergeable_state: blocked`. Same three files as #531 (`phase-goal-tracker.yml`, workflow `README.md`, `AUDIT.md`) plus one follow-up commit.

This PR **supersedes #531** — recommend closing #531 in its favor once this is merged.

## What the workflow does

Issue-level automation for `[phase` tracking issues: parses markdown checklists, upserts a single marker-based status comment (completed/total, percent, next open goals), and auto-closes the issue at 100% completion. Triggered on `issues` (`opened`/`edited`/`reopened`) and `workflow_dispatch`.

## Review fixes applied on top of #531

- **`reopened` auto-close bug** ([#531 discussion_r3533373324](https://github.com/groupthinking/EventRelay/pull/531#discussion_r3533373324)): reopening a finished phase issue previously re-closed it instantly, preventing a maintainer from adding follow-up tasks. Auto-close is now skipped when the triggering event is `reopened`, and the tracker comment explains the skip.
- **`phase-*` label regex** ([#531 discussion_r3533373336](https://github.com/groupthinking/EventRelay/pull/531#discussion_r3533373336)): `/^phase-\d+$/` only matched numeric-suffix labels, silently skipping `phase-hardening` / `phase-cleanup`. Broadened to `/^phase-.+/` to match the documented `phase-*` intent.

## Verification

- YAML parses; embedded `actions/github-script` body passes `node --check` (async-wrapped).
- No runtime application code touched — CI (test/build/lint/CodeQL/Trivy/security) all passed green on the identical base commit in #531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123HRGZQqKyq44F1JRSoYoj

---
_Generated by [Claude Code](https://claude.ai/code/session_0123HRGZQqKyq44F1JRSoYoj)_