### PR TITLE
fix(unified-ai-sdk): real provider integrations + #532 review fixes (rebased onto main)

### DIFF
--- a/src/unified_ai_sdk/__init__.py
+++ b/src/unified_ai_sdk/__init__.py
@@ -1,13 +1,4 @@
-"""
-Unified AI SDK - Placeholder Module
-====================================
-
-This module provides placeholder implementations for the unified AI SDK classes.
-These are temporary stubs until the actual unified_ai_sdk package is implemented
-or added as a dependency.
-
-TODO: Replace with actual unified_ai_sdk implementation or add as external dependency.
-"""
+"""Unified AI SDK exports."""
 
 from .rate_limiter import ModelProvider, RateLimiter
 from .unified_ai_sdk import AIRequest, AIResponse, TaskType, UnifiedAISDK

--- a/src/unified_ai_sdk/rate_limiter.py
+++ b/src/unified_ai_sdk/rate_limiter.py
@@ -1,12 +1,4 @@
-"""
-Rate Limiter - Placeholder Implementation
-=========================================
-
-Provides basic rate limiting functionality for AI providers.
-This is a placeholder implementation.
-
-TODO: Replace with production-grade rate limiter implementation.
-"""
+"""Lightweight in-process rate limiting helpers for AI providers."""
 
 import asyncio
 import time
@@ -16,7 +8,8 @@ from typing import Any, Optional
 
 
 class ModelProvider(Enum):
-    """AI Model Providers"""
+    """AI model providers."""
+
     CLAUDE = "claude"
     GROK = "grok"
     OPENAI = "openai"
@@ -27,8 +20,7 @@ class RateLimiter:
     """
     Basic rate limiter for AI API requests.
 
-    This is a placeholder implementation that provides basic
-    request throttling per provider.
+    Provides simple request throttling per provider.
     """
 
     def __init__(self, config: Optional[dict[str, Any]] = None):
@@ -60,7 +52,9 @@ class RateLimiter:
             t for t in self._request_times[provider_name] if t > cutoff_time
         ]
         self._token_usage[provider_name] = [
-            (t, tokens) for t, tokens in self._token_usage[provider_name] if t > cutoff_time
+            (t, tokens)
+            for t, tokens in self._token_usage[provider_name]
+            if t > cutoff_time
         ]
 
         # Check request rate limit
@@ -89,14 +83,20 @@ class RateLimiter:
                 t for t in self._request_times[provider_name] if t > cutoff_time
             ]
             recent_tokens = sum(
-                tokens for t, tokens in self._token_usage[provider_name] if t > cutoff_time
+                tokens
+                for t, tokens in self._token_usage[provider_name]
+                if t > cutoff_time
             )
 
             stats[provider_name] = {
                 "requests_last_minute": len(recent_requests),
                 "tokens_last_minute": recent_tokens,
-                "limit_requests": self.config.get(provider_name, {}).get("requests_per_minute", 100),
-                "limit_tokens": self.config.get(provider_name, {}).get("tokens_per_minute", 50000),
+                "limit_requests": self.config.get(provider_name, {}).get(
+                    "requests_per_minute", 100
+                ),
+                "limit_tokens": self.config.get(provider_name, {}).get(
+                    "tokens_per_minute", 50000
+                ),
             }
 
         return stats

--- a/src/unified_ai_sdk/unified_ai_sdk.py
+++ b/src/unified_ai_sdk/unified_ai_sdk.py
@@ -1,23 +1,48 @@
-"""
-Unified AI SDK - Placeholder Implementation
-===========================================
+"""Unified interface for Gemini, Anthropic, and OpenAI requests."""
 
-Provides unified interface for multiple AI providers.
-This is a placeholder implementation.
+from __future__ import annotations
 
-TODO: Replace with production unified AI SDK implementation.
-"""
-
+import asyncio
+import logging
+import os
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Any, Callable
 
-# Import ModelProvider from rate_limiter
-from .rate_limiter import ModelProvider
+from .rate_limiter import ModelProvider, RateLimiter
+
+logger = logging.getLogger(__name__)
+
+try:
+    from google import genai as _genai
+    from google.genai import types as _genai_types
+
+    _GENAI_AVAILABLE = True
+except ImportError:
+    _genai = None
+    _genai_types = None
+    _GENAI_AVAILABLE = False
+
+try:
+    import anthropic as _anthropic_sdk
+
+    _ANTHROPIC_AVAILABLE = True
+except ImportError:
+    _anthropic_sdk = None
+    _ANTHROPIC_AVAILABLE = False
+
+try:
+    import openai as _openai_sdk
+
+    _OPENAI_AVAILABLE = True
+except ImportError:
+    _openai_sdk = None
+    _OPENAI_AVAILABLE = False
 
 
 class TaskType(Enum):
-    """Task types for AI processing"""
+    """Task types for AI processing."""
+
     VIDEO_ANALYSIS = "video_analysis"
     CODE_GENERATION = "code_generation"
     TREND_ANALYSIS = "trend_analysis"
@@ -32,10 +57,11 @@ class TaskType(Enum):
 
 @dataclass
 class AIRequest:
-    """Request object for AI operations"""
+    """Request object for AI operations."""
+
     prompt: str
     model: str
-    provider: Union[ModelProvider, str]  # ModelProvider enum or string
+    provider: ModelProvider | str
     task_type: TaskType
     temperature: float = 0.7
     max_tokens: int = 4000
@@ -44,80 +70,270 @@ class AIRequest:
 
 @dataclass
 class AIResponse:
-    """Response object from AI operations"""
+    """Response object from AI operations."""
+
     content: str
     model: str
     provider: str
     success: bool = True
     tokens_used: int = 0
-    error: Optional[str] = None
+    error: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
 class UnifiedAISDK:
-    """
-    Unified interface for multiple AI providers.
+    """Unified AI client with provider-specific routing and retries."""
 
-    This is a placeholder implementation that provides a basic
-    structure for unified AI requests.
+    def __init__(self, config: dict[str, Any] | None = None):
+        self.config = dict(config or {})
+        retry_attempts = int(self.config.get("retry_attempts", 3))
+        if retry_attempts < 1:
+            raise ValueError("retry_attempts must be at least 1")
+        self.retry_attempts = retry_attempts
+        self.retry_base_delay = float(self.config.get("retry_base_delay", 1.0))
+        self.retry_max_delay = float(self.config.get("retry_max_delay", 8.0))
+        # Bound per-request latency so a slow upstream can't pin the
+        # asyncio.to_thread worker for the SDK default (OpenAI/Anthropic: 600s).
+        self.request_timeout = float(self.config.get("request_timeout", 60.0))
+        self.rate_limiter = RateLimiter(self.config.get("rate_limits"))
 
-    TODO: Implement actual provider integrations for Claude, Grok, OpenAI, etc.
-    """
-
-    def __init__(self, config: Optional[dict[str, Any]] = None):
-        """
-        Initialize Unified AI SDK.
-
-        Args:
-            config: Configuration dict with API keys and settings
-        """
-        self.config = config if config is not None else {}
-
-    async def unified_request(self, request: AIRequest) -> AIResponse:
-        """
-        Execute a unified AI request across providers.
-
-        Args:
-            request: AIRequest object with prompt and configuration
-
-        Returns:
-            AIResponse with the result
-
-        Note:
-            This is a placeholder that returns a simulated response.
-            TODO: Implement actual provider API calls.
-        """
-        # Get provider name
-        provider_name = request.provider.value if isinstance(request.provider, ModelProvider) else str(request.provider)
-
-        # Placeholder implementation - returns simulated response
-        return AIResponse(
-            content=f"[Placeholder response for {request.task_type.value} task using {request.model}]",
-            model=request.model,
-            provider=provider_name,
-            success=True,
-            tokens_used=len(request.prompt.split()) * 2,  # Rough estimate
-            metadata={
-                "task_type": request.task_type.value,
-                "temperature": request.temperature,
-                "max_tokens": request.max_tokens,
-                "note": "This is a placeholder response. Implement actual AI provider integration."
-            }
+        self._gemini_key = (
+            self.config.get("gemini_api_key")
+            or os.getenv("GEMINI_API_KEY")
+            or os.getenv("GOOGLE_GENERATIVE_AI_API_KEY")
+            or os.getenv("GOOGLE_API_KEY")
+        )
+        self._anthropic_key = self.config.get("anthropic_api_key") or os.getenv(
+            "ANTHROPIC_API_KEY"
+        )
+        self._openai_key = self.config.get("openai_api_key") or os.getenv(
+            "OPENAI_API_KEY"
         )
 
-    async def health_check(self) -> dict[str, Any]:
-        """
-        Check health status of all configured providers.
+        self._gemini_client: object | None = None
+        self._anthropic_client: object | None = None
+        self._openai_client: object | None = None
 
-        Returns:
-            Dict with health status for each provider
-        """
-        return {
-            "status": "placeholder",
-            "providers": {
-                "claude": "not_implemented",
-                "grok": "not_implemented",
-                "openai": "not_implemented",
-            },
-            "note": "Placeholder health check - implement actual provider checks"
+        self._handlers: dict[str, Callable[[AIRequest], tuple[str, int]]] = {
+            "openai": self._generate_openai,
+            "claude": self._generate_anthropic,
+            "gemini": self._generate_gemini,
         }
+
+        self._init_clients()
+
+    async def unified_request(self, request: AIRequest) -> AIResponse:
+        """Execute a provider-specific request with retry handling."""
+        try:
+            provider_name = self._normalize_provider(request.provider)
+        except ValueError as exc:
+            # Unsupported provider (e.g. ModelProvider.GROK, which MCPBridge
+            # routes) must not raise: honor the contract of returning a
+            # structured failure response rather than an unhandled exception.
+            return AIResponse(
+                content="",
+                model=request.model,
+                provider=str(request.provider),
+                success=False,
+                error=str(exc),
+                metadata={
+                    "task_type": request.task_type.value,
+                    "temperature": request.temperature,
+                    "max_tokens": request.max_tokens,
+                    "attempts": 0,
+                },
+            )
+        provider = self._rate_limit_provider(provider_name)
+
+        for attempt in range(1, self.retry_attempts + 1):
+            try:
+                await self.rate_limiter.wait_if_needed(provider, request.max_tokens)
+                content, tokens_used = await asyncio.to_thread(
+                    self._dispatch_sync, provider_name, request
+                )
+                return AIResponse(
+                    content=content,
+                    model=request.model,
+                    provider=provider_name,
+                    success=True,
+                    tokens_used=tokens_used,
+                    metadata={
+                        "task_type": request.task_type.value,
+                        "temperature": request.temperature,
+                        "max_tokens": request.max_tokens,
+                        "attempts": attempt,
+                    },
+                )
+            except Exception as exc:
+                logger.warning(
+                    "UnifiedAISDK %s attempt %s/%s failed: %s",
+                    provider_name,
+                    attempt,
+                    self.retry_attempts,
+                    exc,
+                )
+                if attempt >= self.retry_attempts:
+                    return AIResponse(
+                        content="",
+                        model=request.model,
+                        provider=provider_name,
+                        success=False,
+                        error=str(exc),
+                        metadata={
+                            "task_type": request.task_type.value,
+                            "temperature": request.temperature,
+                            "max_tokens": request.max_tokens,
+                            "attempts": attempt,
+                        },
+                    )
+
+                delay = min(
+                    self.retry_base_delay * (2 ** (attempt - 1)),
+                    self.retry_max_delay,
+                )
+                if delay > 0:
+                    await asyncio.sleep(delay)
+
+        # Unreachable: retry_attempts >= 1 is enforced in __init__, so the loop
+        # always returns on its final attempt. Explicit terminal keeps strict
+        # mypy's missing-return check satisfied.
+        raise RuntimeError("unified_request exhausted retries without returning")
+
+    async def health_check(self) -> dict[str, Any]:
+        """Report which providers are ready for live traffic."""
+        providers = {
+            "gemini": {
+                "configured": bool(self._gemini_key),
+                "sdk_available": _GENAI_AVAILABLE,
+                "ready": self._gemini_client is not None,
+            },
+            "anthropic": {
+                "configured": bool(self._anthropic_key),
+                "sdk_available": _ANTHROPIC_AVAILABLE,
+                "ready": self._anthropic_client is not None,
+            },
+            "openai": {
+                "configured": bool(self._openai_key),
+                "sdk_available": _OPENAI_AVAILABLE,
+                "ready": self._openai_client is not None,
+            },
+        }
+        ready_count = sum(1 for info in providers.values() if info["ready"])
+        return {
+            "status": "ok" if ready_count else "degraded",
+            "ready_providers": ready_count,
+            "providers": providers,
+        }
+
+    def _init_clients(self) -> None:
+        if _GENAI_AVAILABLE and self._gemini_key:
+            try:
+                self._gemini_client = _genai.Client(api_key=self._gemini_key)
+            except Exception as exc:
+                logger.warning("UnifiedAISDK failed to init Gemini client: %s", exc)
+
+        if _ANTHROPIC_AVAILABLE and self._anthropic_key:
+            try:
+                self._anthropic_client = _anthropic_sdk.Anthropic(
+                    api_key=self._anthropic_key
+                )
+            except Exception as exc:
+                logger.warning("UnifiedAISDK failed to init Anthropic client: %s", exc)
+
+        if _OPENAI_AVAILABLE and self._openai_key:
+            try:
+                self._openai_client = _openai_sdk.OpenAI(api_key=self._openai_key)
+            except Exception as exc:
+                logger.warning("UnifiedAISDK failed to init OpenAI client: %s", exc)
+
+    def _normalize_provider(self, provider: ModelProvider | str) -> str:
+        provider_name = (
+            provider.value if isinstance(provider, ModelProvider) else str(provider)
+        ).lower()
+        if provider_name in {"claude", "anthropic"}:
+            return "claude"
+        if provider_name in {"openai", "gemini"}:
+            return provider_name
+        raise ValueError(f"Unsupported provider: {provider_name}")
+
+    def _rate_limit_provider(self, provider_name: str) -> ModelProvider:
+        if provider_name == "claude":
+            return ModelProvider.CLAUDE
+        if provider_name == "openai":
+            return ModelProvider.OPENAI
+        return ModelProvider.GEMINI
+
+    def _dispatch_sync(self, provider_name: str, request: AIRequest) -> tuple[str, int]:
+        handler = self._handlers[provider_name]
+        content, tokens_used = handler(request)
+        if not content:
+            raise RuntimeError(
+                f"{provider_name} (model={request.model}) returned empty content"
+            )
+        return content, tokens_used
+
+    def _generate_openai(self, request: AIRequest) -> tuple[str, int]:
+        if self._openai_client is None:
+            raise RuntimeError(f"OpenAI client is not configured for {request.model}")
+        response = self._openai_client.chat.completions.create(  # type: ignore[attr-defined]
+            model=request.model,
+            messages=[{"role": "user", "content": request.prompt}],
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+            timeout=self.request_timeout,
+        )
+        choices = getattr(response, "choices", None)
+        if not choices or len(choices) == 0:
+            raise RuntimeError(f"OpenAI ({request.model}) returned no choices")
+        content = choices[0].message.content or ""
+        usage = getattr(response, "usage", None)
+        tokens_used = int(getattr(usage, "total_tokens", 0) or 0)
+        return content, tokens_used
+
+    def _generate_anthropic(self, request: AIRequest) -> tuple[str, int]:
+        if self._anthropic_client is None:
+            raise RuntimeError(
+                f"Anthropic client is not configured for {request.model}"
+            )
+        response = self._anthropic_client.messages.create(  # type: ignore[attr-defined]
+            model=request.model,
+            max_tokens=request.max_tokens,
+            # The repo requires anthropic>=0.78.0, which supports adaptive thinking.
+            # `temperature` is intentionally omitted: Anthropic rejects a non-1
+            # temperature when extended thinking is enabled, and the default
+            # AIRequest.temperature (0.7) would fail every request. This mirrors
+            # the canonical calls in llm_router / protocol_bridge.
+            thinking={"type": "adaptive"},
+            messages=[{"role": "user", "content": request.prompt}],
+            timeout=self.request_timeout,
+        )
+        text_blocks = [
+            getattr(block, "text", "")
+            for block in response.content
+            if getattr(block, "type", None) == "text"
+        ]
+        usage = getattr(response, "usage", None)
+        input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
+        output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
+        return "\n".join(text_blocks), input_tokens + output_tokens
+
+    def _generate_gemini(self, request: AIRequest) -> tuple[str, int]:
+        if self._gemini_client is None:
+            raise RuntimeError(f"Gemini client is not configured for {request.model}")
+        kwargs: dict[str, Any] = {"model": request.model, "contents": request.prompt}
+        if _GENAI_AVAILABLE and _genai_types is not None:
+            kwargs["config"] = _genai_types.GenerateContentConfig(
+                temperature=request.temperature,
+                max_output_tokens=request.max_tokens,
+            )
+        response = self._gemini_client.models.generate_content(**kwargs)  # type: ignore[attr-defined]
+        text = response.text
+        if text is None and not getattr(response, "candidates", None):
+            raise RuntimeError(f"Gemini ({request.model}) returned no candidates")
+        if text is None:
+            parts = response.candidates[0].content.parts
+            text_parts = [part.text for part in parts if getattr(part, "text", None)]
+            text = "\n".join(text_parts) if text_parts else ""
+        usage = getattr(response, "usage_metadata", None)
+        tokens_used = int(getattr(usage, "total_token_count", 0) or 0)
+        return text or "", tokens_used

--- a/tests/unit/test_unified_ai_sdk.py
+++ b/tests/unit/test_unified_ai_sdk.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import unified_ai_sdk.unified_ai_sdk as sdk_mod
+from unified_ai_sdk import AIRequest, ModelProvider, TaskType, UnifiedAISDK
+
+
+class TestUnifiedAISDK:
+    async def test_unified_request_uses_openai_client(self):
+        sdk = UnifiedAISDK({"retry_attempts": 1})
+        choice = SimpleNamespace(message=SimpleNamespace(content="openai response"))
+        usage = SimpleNamespace(total_tokens=123)
+        sdk._openai_client = MagicMock()
+        sdk._openai_client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+        )
+
+        result = await sdk.unified_request(
+            AIRequest(
+                prompt="Say hello",
+                model="gpt-4o",
+                provider=ModelProvider.OPENAI,
+                task_type=TaskType.GENERIC,
+            )
+        )
+
+        assert result.success is True
+        assert result.content == "openai response"
+        assert result.provider == "openai"
+        assert result.tokens_used == 123
+
+    async def test_unified_request_uses_anthropic_client(self):
+        sdk = UnifiedAISDK({"retry_attempts": 1})
+        sdk._anthropic_client = MagicMock()
+        sdk._anthropic_client.messages.create.return_value = SimpleNamespace(
+            content=[
+                SimpleNamespace(type="thinking", text="hidden"),
+                SimpleNamespace(type="text", text="alpha"),
+                SimpleNamespace(type="text", text="beta"),
+            ],
+            usage=SimpleNamespace(input_tokens=11, output_tokens=22),
+        )
+
+        result = await sdk.unified_request(
+            AIRequest(
+                prompt="Summarize this",
+                model="claude-opus-4-8",
+                provider=ModelProvider.CLAUDE,
+                task_type=TaskType.SUMMARIZATION,
+            )
+        )
+
+        assert result.success is True
+        assert result.content == "alpha\nbeta"
+        assert result.provider == "claude"
+        assert result.tokens_used == 33
+
+    async def test_unified_request_uses_gemini_client(self, monkeypatch):
+        sdk = UnifiedAISDK({"retry_attempts": 1})
+        config_factory = MagicMock(side_effect=lambda **kwargs: kwargs)
+        monkeypatch.setattr(sdk_mod, "_GENAI_AVAILABLE", True)
+        monkeypatch.setattr(
+            sdk_mod,
+            "_genai_types",
+            SimpleNamespace(GenerateContentConfig=config_factory),
+            raising=False,
+        )
+        sdk._gemini_client = MagicMock()
+        sdk._gemini_client.models.generate_content.return_value = SimpleNamespace(
+            text=None,
+            candidates=[
+                SimpleNamespace(
+                    content=SimpleNamespace(
+                        parts=[
+                            SimpleNamespace(text="part one"),
+                            SimpleNamespace(text="part two"),
+                        ]
+                    )
+                )
+            ],
+            usage_metadata=SimpleNamespace(total_token_count=88),
+        )
+
+        result = await sdk.unified_request(
+            AIRequest(
+                prompt="Analyze the video",
+                model="gemini-2.5-flash",
+                provider=ModelProvider.GEMINI,
+                task_type=TaskType.VIDEO_ANALYSIS,
+            )
+        )
+
+        assert result.success is True
+        assert result.content == "part one\npart two"
+        assert result.provider == "gemini"
+        assert result.tokens_used == 88
+        assert config_factory.call_args.kwargs == {
+            "temperature": 0.7,
+            "max_output_tokens": 4000,
+        }
+
+    async def test_unified_request_retries_before_succeeding(self):
+        sdk = UnifiedAISDK({"retry_attempts": 2, "retry_base_delay": 0})
+        choice = SimpleNamespace(message=SimpleNamespace(content="retried response"))
+        usage = SimpleNamespace(total_tokens=77)
+        sdk._openai_client = MagicMock()
+        sdk._openai_client.chat.completions.create.side_effect = [
+            RuntimeError("temporary failure"),
+            SimpleNamespace(choices=[choice], usage=usage),
+        ]
+
+        result = await sdk.unified_request(
+            AIRequest(
+                prompt="Retry me",
+                model="gpt-4o",
+                provider=ModelProvider.OPENAI,
+                task_type=TaskType.GENERIC,
+            )
+        )
+
+        assert result.success is True
+        assert result.content == "retried response"
+        assert result.metadata["attempts"] == 2
+
+    async def test_unified_request_returns_error_after_retries(self):
+        sdk = UnifiedAISDK({"retry_attempts": 2, "retry_base_delay": 0})
+        sdk._openai_client = MagicMock()
+        sdk._openai_client.chat.completions.create.side_effect = RuntimeError(
+            "provider unavailable"
+        )
+
+        result = await sdk.unified_request(
+            AIRequest(
+                prompt="Fail cleanly",
+                model="gpt-4o",
+                provider=ModelProvider.OPENAI,
+                task_type=TaskType.GENERIC,
+            )
+        )
+
+        assert result.success is False
+        assert result.content == ""
+        assert "provider unavailable" in (result.error or "")
+        assert result.metadata["attempts"] == 2
+
+    async def test_unified_request_reports_model_when_gemini_client_missing(self):
+        sdk = UnifiedAISDK({"retry_attempts": 1})
+        # Force the precondition explicitly: in CI ambient GEMINI_API_KEY /
+        # GOOGLE_API_KEY plus a globally-patched `_genai` (leaked from other
+        # tests) can make _init_clients build a client, so don't rely on it
+        # defaulting to None.
+        sdk._gemini_client = None
+
+        result = await sdk.unified_request(
+            AIRequest(
+                prompt="Fail cleanly",
+                model="gemini-2.5-flash",
+                provider=ModelProvider.GEMINI,
+                task_type=TaskType.GENERIC,
+            )
+        )
+
+        assert result.success is False
+        assert "gemini-2.5-flash" in (result.error or "")
+
+    async def test_unified_request_unsupported_provider_returns_failure(self):
+        # ModelProvider.GROK has no client in this SDK and MCPBridge routes it;
+        # the contract is a structured failure, not an unhandled ValueError.
+        sdk = UnifiedAISDK({"retry_attempts": 1})
+
+        result = await sdk.unified_request(
+            AIRequest(
+                prompt="Analyze trend",
+                model="grok-beta",
+                provider=ModelProvider.GROK,
+                task_type=TaskType.GENERIC,
+            )
+        )
+
+        assert result.success is False
+        assert result.content == ""
+        assert "grok" in (result.error or "").lower()
+        assert result.metadata["attempts"] == 0
+
+    async def test_anthropic_call_omits_temperature_with_thinking(self):
+        # Anthropic rejects a non-1 temperature when extended thinking is on;
+        # the call must not forward request.temperature.
+        sdk = UnifiedAISDK({"retry_attempts": 1})
+        sdk._anthropic_client = MagicMock()
+        sdk._anthropic_client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="ok")],
+            usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+        )
+
+        result = await sdk.unified_request(
+            AIRequest(
+                prompt="Summarize this",
+                model="claude-opus-4-8",
+                provider=ModelProvider.CLAUDE,
+                task_type=TaskType.SUMMARIZATION,
+            )
+        )
+
+        assert result.success is True
+        _, kwargs = sdk._anthropic_client.messages.create.call_args
+        assert "temperature" not in kwargs
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        # Explicit timeout is forwarded so a slow upstream can't pin the worker.
+        assert kwargs["timeout"] == 60.0


### PR DESCRIPTION
## Summary

Delivers PR #532's `unified_ai_sdk` provider integration (real OpenAI / Anthropic / Gemini calls, retry+backoff, structured failures, live health check) **with all review findings resolved**, rebased cleanly onto current `main`. Net change is exactly **4 files** — same as #532.

Triggered by the `#532 ready-for-review` webhook; every finding below was verified against the source before fixing.

## Correctness fixes (from Copilot's + CodeRabbit's review of #532)

| # | Issue | Fix |
|---|-------|-----|
| 1 | `_generate_anthropic` sent `temperature` (default `0.7`) with `thinking={"type":"adaptive"}` — Anthropic rejects non-1 temperature under extended thinking, so **every default request would 400** | Omit `temperature` (mirrors `llm_router` / `protocol_bridge` / `tri_model_consensus_tool`) |
| 2 | `_normalize_provider` ran outside the retry `try/except` → unhandled `ValueError` for a routed-but-unsupported provider (`ModelProvider.GROK`) instead of the contracted structured failure | Guard resolution; return `AIResponse(success=False)` |
| 3 | `unified_request` had no terminal path after the retry loop → strict-mypy `Missing return statement` | Explicit terminal `raise` after the loop |
| 4 | OpenAI/Anthropic calls relied on the SDK's 600 s default timeout → a slow upstream can pin the `asyncio.to_thread` worker | Pass an explicit `request_timeout` (default 60 s) |

## Tests
- Regression tests: unsupported-provider structured failure, Anthropic temperature/timeout contract, and a **deterministic** gemini-client-missing test (forces its precondition instead of relying on ambient env / a leaked global `_genai` mock — this was the flaky failure the full CI suite surfaced).
- `tests/unit/test_unified_ai_sdk.py`: **8 passed**. `ruff` + `black` + `mypy` clean on the changed files.

## Note on the rebase / force-push
The branch was 17 commits behind `main` (merge-base `a0f7ae8`). A merge would still have applied cleanly (merge-base semantics → 4 files), but I rebased onto current `main` for a clean history, an unambiguous 4-file diff, and to fold in fixes #3–#4. **Merge this PR instead of #532** (they produce the same 4-file result; this one additionally carries the review fixes), then close #532.

## Known pre-existing CI (out of scope)
`lint-python`, `Coverage`, and `Security Scan (trivy)` fail on **current `main`** independently of this change — 30 pre-existing `ruff` errors in unrelated files (`ai_code_generator.py`, `advanced_video_routes.py`) and broken CI action-config (`qlty` / `trivy` input validation). This PR adds no new violations; those are repo-wide health items for the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)