### PR TITLE
fix(security): remediate top adversarial-audit findings (SSRF/CWE-88, Veo DoW, Sentry PII, action pin)

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -186,7 +186,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -186,7 +186,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Build image for scanning
         run: docker build -t eventrelay:test -f Dockerfile .
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
         with:
           image-ref: 'eventrelay:test'
           format: 'sarif'
@@ -102,7 +102,7 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
       - name: Generate human-readable report
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
         if: always()
         with:
           image-ref: 'eventrelay:test'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Build image for scanning
         run: docker build -t eventrelay:test -f Dockerfile .
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           image-ref: 'eventrelay:test'
           format: 'sarif'
@@ -102,7 +102,7 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
       - name: Generate human-readable report
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         if: always()
         with:
           image-ref: 'eventrelay:test'

--- a/apps/web/src/app/api/video/generate/route.ts
+++ b/apps/web/src/app/api/video/generate/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from 'next/server';
+import { resolveTrustedBillingEmail } from '@/lib/billing/billing-context';
+import { isProSubscriber } from '@/lib/billing/entitlement-store';
 
 export const runtime = 'nodejs'; // streams/buffers the gateway video bytes through
 export const maxDuration = 300; // 5 minutes — video generation takes time
@@ -41,6 +43,24 @@ function checkRateLimit(ip: string): boolean {
 }
 
 export async function POST(request: Request) {
+  // Veo-3.1 is the most expensive AI operation in the app. Gate it behind the
+  // Pro entitlement like the other paid routes (agents/dispatch), so an
+  // unauthenticated caller cannot run up video-generation spend — the per-IP
+  // in-memory limiter below is per-instance and defeated by autoscaling + IP
+  // rotation, so it is a secondary control, not the paywall.
+  const billingEmail = await resolveTrustedBillingEmail(request);
+  const isPro = await isProSubscriber(billingEmail);
+  if (!isPro) {
+    return NextResponse.json(
+      {
+        error: 'Video generation is a Pro feature. Upgrade at /pricing.',
+        upgradeRequired: true,
+        plan: 'free',
+      },
+      { status: 402 }
+    );
+  }
+
   const apiKey = process.env.AI_GATEWAY_API_KEY;
   if (!apiKey) {
     return NextResponse.json(

--- a/src/youtube_extension/backend/api/v1/models.py
+++ b/src/youtube_extension/backend/api/v1/models.py
@@ -17,6 +17,15 @@ from pydantic import BaseModel, ConfigDict, Field, validator
 
 T = TypeVar("T")
 
+# Anchored YouTube-host allowlist. Shared so every video_url field enforces the
+# same host restriction — an arbitrary host (e.g. http://169.254.169.254/<11ch>)
+# or a leading-dash token (--config-locations=...) must NOT reach the yt-dlp /
+# pytube fetch layer. See adversarial audit: unvalidated video_url → SSRF + CWE-88
+# argument injection.
+_YOUTUBE_URL_REGEX = re.compile(
+    r"^(https?://)?(www\.)?(youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/|youtube\.com/shorts/)[a-zA-Z0-9_-]{11}"
+)
+
 
 # ============ Standardized API Response Wrapper ============
 
@@ -26,7 +35,9 @@ class ApiResponse(BaseModel, Generic[T]):
 
     status: str = Field(..., description="'success' or 'error'")
     data: Optional[T] = Field(None, description="Response payload")
-    error: Optional[str] = Field(None, description="Error message (when status='error')")
+    error: Optional[str] = Field(
+        None, description="Error message (when status='error')"
+    )
     detail: Optional[str] = Field(None, description="Additional error detail")
     timestamp: datetime = Field(default_factory=datetime.utcnow)
     request_id: str = Field(default_factory=lambda: f"req_{uuid.uuid4().hex[:12]}")
@@ -145,7 +156,10 @@ class AgentDispatchRequest(BaseModel):
 
     job_id: Optional[str] = None
     events: list[dict[str, Any]] = Field(default_factory=list)
-    transcript: Optional[str] = Field(None, description="Transcript text — events will be auto-extracted if events list is empty")
+    transcript: Optional[str] = Field(
+        None,
+        description="Transcript text — events will be auto-extracted if events list is empty",
+    )
     agent_types: Optional[list[str]] = Field(
         None, description="Specific agent types to dispatch"
     )
@@ -192,6 +206,16 @@ class ChatRequest(BaseModel):
     context: Optional[str] = Field("tooltip-assistant", description="Chat context")
     session_id: Optional[str] = Field("default", description="Session identifier")
     history: Optional[list[dict[str, str]]] = Field(None, description="Chat history")
+
+    @validator("video_url")
+    def validate_video_url(cls, value: Optional[str]) -> Optional[str]:
+        # Optional field: allow None, but any provided URL must be a real
+        # YouTube host — blocks SSRF / yt-dlp arg-injection via /api/v1/chat.
+        if value is None:
+            return value
+        if not _YOUTUBE_URL_REGEX.match(value):
+            raise ValueError("Invalid YouTube URL format")
+        return value
 
     class Config:
         populate_by_name = True
@@ -604,6 +628,14 @@ class TranscriptActionRequest(BaseModel):
         description="Optional Gemini video metadata controls (clip window, fps, resolution)",
     )
 
+    @validator("video_url")
+    def validate_video_url(cls, value: str) -> str:
+        # Anchored YouTube-host allowlist — blocks SSRF / yt-dlp arg-injection
+        # via arbitrary hosts. Matches the sibling video request models.
+        if not _YOUTUBE_URL_REGEX.match(value):
+            raise ValueError("Invalid YouTube URL format")
+        return value
+
 
 class TranscriptActionResponse(BaseModel):
     """Response model for transcript-to-action workflow"""
@@ -625,7 +657,9 @@ class TranscriptActionResponse(BaseModel):
 class KnowledgeIngestRequest(BaseModel):
     """Request model for knowledge ingest."""
 
-    text: str = Field(..., description="Non-empty transcript-derived insight or durable fact")
+    text: str = Field(
+        ..., description="Non-empty transcript-derived insight or durable fact"
+    )
     tags: Optional[Any] = Field(
         default=None, description="Optional topic tags; normalized server-side"
     )

--- a/src/youtube_extension/backend/services/youtube/adapters/robust.py
+++ b/src/youtube_extension/backend/services/youtube/adapters/robust.py
@@ -156,6 +156,9 @@ class RobustYouTubeService:
             proxy_url = get_proxy_url()
             if proxy_url:
                 cmd.extend(["--proxy", proxy_url])
+            # "--" terminates option parsing so a video_url beginning with "-"
+            # is treated as a positional URL, never an injected flag (CWE-88).
+            cmd.append("--")
             cmd.append(video_url)
             result = subprocess.run(
                 cmd,

--- a/src/youtube_extension/main.py
+++ b/src/youtube_extension/main.py
@@ -33,7 +33,10 @@ if _sentry_dsn:
             environment=os.getenv("ENVIRONMENT", os.getenv("VERCEL_ENV", "development")),
             traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.1")),
             integrations=[StarletteIntegration(), FastApiIntegration()],
-            send_default_pii=True,
+            # Do not attach request headers/cookies/body/user IP to events.
+            # send_default_pii=True shipped user PII + auth headers to Sentry.
+            # Opt in per-event via set_user() where genuinely needed instead.
+            send_default_pii=os.getenv("SENTRY_SEND_PII", "false").lower() == "true",
             stream_gen_ai_spans=True,  # Enable for LLM monitoring (works for OpenAI-compatible including Grok/xAI via openai client)
         )
         logger.info("Sentry initialized for backend with AI monitoring")


### PR DESCRIPTION
## Summary
Remediates the highest-severity findings from the adversarial security audit. Five atomic, independently-verified commits. **Zero test regressions** (branch full-suite failure-set is identical to origin/main's; the only local failures trace to a local `.env`, absent in CI).

## Fixes
1. **video_url host validation (SSRF + CWE-88)** — `TranscriptActionRequest.video_url` and `ChatRequest.video_url` were the only video-URL models missing the anchored YouTube-host validator their 4 siblings enforce, letting `http://169.254.169.254/<11ch>` or `--config-locations=...` reach `subprocess.run(["yt-dlp", …, video_url])`. Adds the shared validator. Reachable unauth via the Next.js proxies. *(findings #1,2,3,6,9)*
2. **`--` end-of-options separator** before yt-dlp's positional URL (defense-in-depth for arg-injection).
3. **Sentry `send_default_pii`** → safe-by-default off (`SENTRY_SEND_PII` opt-in); was shipping auth headers/PII.
4. **Pin `aquasecurity/trivy-action@master` → SHA** `b6643a2` (v0.33.1) ×3 (supply-chain).
5. **Gate Veo-3.1 video generation behind Pro** (402) — closes an unauthenticated denial-of-wallet on the costliest AI op; mirrors the peer `agents/dispatch` gate. *(finding #4)*

## Verification
- `ruff` (CI invocation) clean; `black` clean on changed files; new files `tsc --noEmit` clean.
- Validator unit-verified: valid YouTube URLs pass; 169.254.x / leading-dash / vimeo / file:// rejected.
- Full unit suite: branch introduces **0 new failures** vs origin/main (proven by failure-set diff).

## Not included (deliberate — need careful multi-tenant work)
Module-global cross-user state bleed, IDOR on video search, fail-open rate limiter, security headers/body-size wiring, error-detail leakage, Next.js-14.2.0 codegen template. Tracked for a follow-up pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)