### PR TITLE
fix: enforce REAL_MODE_ONLY in MCPBridge + proxy support for yt-dlp metadata

### DIFF
--- a/src/agents/gemini_video_master_agent.py
+++ b/src/agents/gemini_video_master_agent.py
@@ -54,6 +54,14 @@ try:
 except ImportError:
     logging.warning("python-dotenv not available")
 
+try:
+    from youtube_extension.utils.proxy import get_proxy_url, redact_proxy_credentials
+except ImportError:  # pragma: no cover - optional when running outside the package
+    def get_proxy_url() -> "str | None":  # type: ignore[misc]
+        return None
+    def redact_proxy_credentials(text: str) -> str:  # type: ignore[misc]
+        return text
+
 # Banned video IDs (memes, inappropriate content, etc.)
 BANNED_VIDEO_IDS = frozenset(
     [
@@ -688,12 +696,19 @@ class GeminiVideoMasterAgent:
     def _extract_youtube_metadata_with_ytdlp(video_url: str) -> dict[str, Any]:
         import yt_dlp
 
-        options = {
+        proxy_url = get_proxy_url()
+        options: dict[str, Any] = {
             "quiet": True,
             "skip_download": True,
             "extract_flat": False,
             "noplaylist": True,
         }
+        if proxy_url:
+            options["proxy"] = proxy_url
+            logger.debug(
+                "yt-dlp metadata extraction using proxy: %s",
+                redact_proxy_credentials(proxy_url),
+            )
         with yt_dlp.YoutubeDL(options) as ydl:
             info = ydl.extract_info(video_url, download=False)
 

--- a/src/mcp/bridge.py
+++ b/src/mcp/bridge.py
@@ -597,13 +597,13 @@ class MCPBridge:
         self, agents: list, request: MCPBridgeRequest, primary_result: AIResponse
     ) -> dict[str, Any]:
         """Orchestrate agent collaboration"""
-        return {"status": "simulated", "agents": len(agents)}
+        return {"status": "unavailable", "agents": len(agents)}
 
     async def _execute_mcp_tool(
         self, tool_name: str, request: MCPBridgeRequest
     ) -> dict[str, Any]:
         """Execute MCP tool"""
-        return {"tool": tool_name, "status": "executed", "result": "simulated"}
+        return {"tool": tool_name, "status": "unavailable", "result": None}
 
     async def _attempt_fallback_processing(self, request: MCPBridgeRequest) -> bool:
         """Attempt fallback processing on failure"""


### PR DESCRIPTION
## Summary

Carries forward the two still-relevant, non-redundant changes from the placeholder-elimination effort onto **current** `main`. The rest of that effort has already landed on `main` via other merged PRs (real `UnifiedAISDK`/`protocol_bridge` dispatch, `ffmpeg` in the Dockerfile, SSRF base-URL validation via #604), so this PR is intentionally minimal — just the two gaps that remain live on `main`.

## Changes

- **`src/mcp/bridge.py`** — `_orchestrate_collaboration` and `_execute_mcp_tool` no longer return `status="simulated"` / `result="simulated"`, which violates the repo's **REAL_MODE_ONLY** policy ("No mock delays, fake data, or simulated responses in production code"). They now return `status="unavailable"` / `result=None`.
- **`src/agents/gemini_video_master_agent.py`** — route yt-dlp metadata extraction through `get_proxy_url()` / `redact_proxy_credentials()` from `youtube_extension.utils.proxy`, so missing-proxy `403`s from YouTube are closed. Includes a safe `ImportError` fallback for out-of-package execution.

## Verification

- Both files parse (`ast.parse`).
- No existing test on `main` asserts the old `"simulated"` return value for these `MCPBridge` methods (the `simulated` hits in the test suite belong to an unrelated deployment manager).
- Diff is +18/−3 across 2 files.

## Context

The originating branch was 35 commits behind `main`; merging it wholesale would have reverted a large amount of newer work. This PR rebases only the genuinely-unique residual value onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9e3dY5VNyKhqv6GSEkkuu

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9e3dY5VNyKhqv6GSEkkuu)_