### PR TITLE
fix(cloud): make CloudNativeVideoProcessor._extract_video_id case-insensitive

### DIFF
--- a/src/youtube_extension/services/cloud/cloud_video_processor.py
+++ b/src/youtube_extension/services/cloud/cloud_video_processor.py
@@ -13,6 +13,7 @@ Cloud-native video processor using:
 import asyncio
 import logging
 import os
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
@@ -299,12 +300,20 @@ class CloudNativeVideoProcessor:
         return await firestore_service.get_state(video_id)
 
     def _extract_video_id(self, video_url: str) -> str:
-        """Extract video ID from YouTube URL"""
-        # Simple extraction - can be enhanced
-        if 'youtube.com/watch?v=' in video_url:
-            return video_url.split('v=')[1].split('&')[0]
-        elif 'youtu.be/' in video_url:
-            return video_url.split('youtu.be/')[1].split('?')[0]
+        """Extract video ID from a YouTube URL.
+
+        The host/path matching is case-insensitive so uppercase URLs such as
+        ``HTTPS://YOUTUBE.COM/WATCH?V=...`` are handled here too. The
+        API-boundary validator (``models._YOUTUBE_URL_REGEX``) is itself
+        case-insensitive, so without this an uppercase URL would pass
+        validation, fall through the ``else`` branch below, and return the
+        whole URL as the "id" — breaking the downstream metadata fetch.
+        """
+        lowered = video_url.lower()
+        if 'youtube.com/watch?v=' in lowered:
+            return re.split(r'v=', video_url, flags=re.IGNORECASE)[1].split('&')[0]
+        elif 'youtu.be/' in lowered:
+            return re.split(r'youtu\.be/', video_url, flags=re.IGNORECASE)[1].split('?')[0]
         else:
             # Assume it's already an ID
             return video_url

--- a/tests/unit/test_cloud_video_processor.py
+++ b/tests/unit/test_cloud_video_processor.py
@@ -230,6 +230,27 @@ class TestExtractVideoId:
     def test_bare_id_passthrough(self, processor):
         assert processor._extract_video_id("auJzb1D-fag") == "auJzb1D-fag"
 
+    def test_uppercase_watch_url(self, processor):
+        # The API-boundary validator is case-insensitive, so an uppercase URL
+        # reaches here; extraction must not fall through to the bare-id branch
+        # and return the whole URL.
+        assert (
+            processor._extract_video_id("HTTPS://YOUTUBE.COM/WATCH?V=auJzb1D-fag")
+            == "auJzb1D-fag"
+        )
+
+    def test_mixed_case_host(self, processor):
+        assert (
+            processor._extract_video_id("https://M.YOUTUBE.COM/watch?v=auJzb1D-fag")
+            == "auJzb1D-fag"
+        )
+
+    def test_uppercase_short_url(self, processor):
+        assert (
+            processor._extract_video_id("https://YOUTU.BE/auJzb1D-fag?t=10")
+            == "auJzb1D-fag"
+        )
+
 
 # ---------------------------------------------------------------------------
 # 4. process_video_async – queue enabled


### PR DESCRIPTION
## Summary

Closes a latent correctness bug in `CloudNativeVideoProcessor._extract_video_id` surfaced by the CodeRabbit/Devin review on **#605**.

#605 broadened the API-boundary validator (`models._YOUTUBE_URL_REGEX`) to accept **uppercase / mixed-case** YouTube URLs (via `re.IGNORECASE`) and the mobile/music hosts. But `_extract_video_id` still matched hosts with **case-sensitive** substring checks:

```python
if 'youtube.com/watch?v=' in video_url:  # case-sensitive
```

So an uppercase URL like `HTTPS://YOUTUBE.COM/WATCH?V=<id>` now **passes validation**, reaches this method, matches neither branch, and falls through to `else: return video_url` — returning the **whole URL as the "video id"**. That corrupts the Firestore state key and breaks the downstream metadata fetch.

## Change

- Lower-case the URL for the host/path detection and split case-insensitively (`re.split(..., flags=re.IGNORECASE)`), so uppercase and mixed-case `watch` / `youtu.be` URLs extract the id correctly.
- Lenient behaviour for bare ids and short/legacy id lengths is **unchanged** (the existing mocks that use short fake ids like `abc123` still pass).

## Verification

- New regression tests: uppercase watch URL, mixed-case host (`M.YOUTUBE.COM`), uppercase short-link — all pass alongside the existing 5 `TestExtractVideoId` cases (8/8 green).
- No new `ruff` findings (12→12 in-file, all pre-existing); file is outside CI's ruff scope (`backend/` + `main.py`) so `lint-python` is unaffected.
- Full case-insensitivity is completed jointly with #605: that PR makes the shared `video_utils.extract_video_id` case-insensitive; this PR fixes the parallel copy in `cloud_video_processor`. Independent files, no merge conflict.

## Note for maintainer

There are now **two** YouTube-id extractors — `utils/video_utils.extract_video_id` (canonical, regex-based) and this inline `_extract_video_id`. #605 fixed one; this fixes the other. A future cleanup could collapse `_extract_video_id` onto the canonical util, but that enforces the strict 11-char standard and would require updating ~20 unit-test fixtures that currently use short fake ids — deliberately left out of scope here to keep the change surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011CRrJ881XqwK1UieRVXyix)_