### PR TITLE
fix(ci): match both major-update forms in dependabot merge guard

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -137,7 +137,7 @@ jobs:
                 continue;
               }
 
-              if (updateType.includes('semver-major')) {
+              if (updateType.includes('version-update:semver-major')) {
                 core.info(`Skipping major update PR #${pullRequest.number}.`);
                 continue;
               }

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -137,7 +137,14 @@ jobs:
                 continue;
               }
 
-              if (updateType.includes('version-update:semver-major')) {
+              // Dependabot reports the update type as 'version-update:semver-major'
+              // (dependabot/fetch-metadata) or the shorter 'semver-major' (the PR
+              // REST dependency.update_type field). Match both so a major bump is
+              // never auto-merged regardless of which form GitHub returns.
+              if (
+                updateType.includes('version-update:semver-major') ||
+                updateType.includes('semver-major')
+              ) {
                 core.info(`Skipping major update PR #${pullRequest.number}.`);
                 continue;
               }


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupthinking/eventrelay/pull/625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->