### PR TITLE
test(service-container): guard knowledge_dir default in defaults test

### DIFF
--- a/tests/unit/test_service_container.py
+++ b/tests/unit/test_service_container.py
@@ -453,6 +453,7 @@ class TestServiceFactories:
         sc._config = {
             "enhanced_analysis_dir": "/tmp/test_enhanced",
             "feedback_dir": "/tmp/test_feedback",
+            "knowledge_dir": "/tmp/test_knowledge",
         }
         service = sc._create_data_service()
         from youtube_extension.backend.services.data_service import DataService

--- a/tests/unit/test_service_container.py
+++ b/tests/unit/test_service_container.py
@@ -36,7 +36,7 @@ def _bare_container() -> ServiceContainer:
 class TestLoadConfiguration:
     def test_defaults_set_without_env(self, monkeypatch):
         for key in [
-            "CACHE_DIR", "ENHANCED_ANALYSIS_DIR", "FEEDBACK_DIR",
+            "CACHE_DIR", "ENHANCED_ANALYSIS_DIR", "FEEDBACK_DIR", "KNOWLEDGE_DIR",
             "RATE_LIMIT_RPS", "MAX_RECENT_REQUESTS", "VIDEO_PROCESSOR_TYPE",
             "USE_LANGEXTRACT_FALLBACK", "LIVEKIT_URL", "MOZILLA_AI_URL",
             "GEMINI_API_KEY", "GOOGLE_API_KEY", "YOUTUBE_API_KEY",
@@ -49,6 +49,7 @@ class TestLoadConfiguration:
         assert sc._config["cache_dir"] == "/tmp/uvai_cache/markdown_analysis"
         assert sc._config["enhanced_analysis_dir"] == "/tmp/uvai_cache/enhanced_analysis"
         assert sc._config["feedback_dir"] == "/tmp/uvai_cache/feedback"
+        assert sc._config["knowledge_dir"] == "/tmp/uvai_cache/knowledge"
         assert sc._config["rate_limit_rps"] == 5
         assert sc._config["max_recent_requests"] == 1000
         assert sc._config["video_processor_type"] == "auto"


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupthinking/eventrelay/pull/631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->