### PR TITLE
fix: address CodeRabbit review findings on merged perf pass (#642)

### DIFF
--- a/apps/web/src/lib/transcription-service.ts
+++ b/apps/web/src/lib/transcription-service.ts
@@ -54,11 +54,24 @@ export async function fetchTranscript({
     return { success: false, error: 'url or audioUrl is required', transcript: '' };
   }
 
-  // Fetch YouTube metadata (description, chapters, title) — shared by all strategies
-  const metadataPromise = url ? fetchYouTubeMetadata(url).catch((err) => {
-    console.log('YouTube metadata fetch failed:', err);
-    return null;
-  }) : Promise.resolve(null);
+  // Fetch YouTube metadata (description, chapters, title) lazily and share it.
+  // Only the paid fallback strategies (Gemini/OpenAI) need metadata, so we must
+  // NOT fire an outbound YouTube request on the common free-path success case
+  // where Strategy 1 (backend transcript) returns early — that would undo the
+  // "avoid unnecessary work" intent of this code path. The memoized helper
+  // guarantees at most one fetch, triggered only when a fallback awaits it.
+  let metadataPromise: ReturnType<typeof fetchYouTubeMetadata> | null = null;
+  const getMetadata = (): ReturnType<typeof fetchYouTubeMetadata> => {
+    if (!metadataPromise) {
+      metadataPromise = url
+        ? fetchYouTubeMetadata(url).catch((err) => {
+            console.log('YouTube metadata fetch failed:', err);
+            return null;
+          })
+        : Promise.resolve(null);
+    }
+    return metadataPromise;
+  };
 
   // Strategy 1: Try YouTube transcript API via backend (fast + free).
   // Run this FIRST and return early on success so the paid AI providers
@@ -131,7 +144,7 @@ export async function fetchTranscript({
     if (hasGeminiKey()) {
       const geminiPromise: Promise<TranscriptionResult | null> = (async () => {
         try {
-          const metadata = await metadataPromise;
+          const metadata = await getMetadata();
           const metadataContext = metadata ? formatMetadataAsContext(metadata) : '';
           const geminiPrompt = `You are a video transcription assistant.
 
@@ -196,7 +209,7 @@ INSTRUCTIONS:
     if (process.env.OPENAI_API_KEY) {
       const openaiPromise: Promise<TranscriptionResult | null> = (async () => {
         try {
-          const metadata = await metadataPromise;
+          const metadata = await getMetadata();
           const metadataContext = metadata ? formatMetadataAsContext(metadata) : '';
           const response = await getOpenAI().responses.create({
             model: 'gpt-4o-mini',

--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -1293,14 +1293,39 @@ async def _periodic_cleanup():
             _agent_executions.evict_expired()
             _dispatches.evict_expired()
         except Exception as exc:
-            logger.debug("Periodic cleanup failed: %s", exc)
+            # Log at warning (not debug) so eviction failures are visible in
+            # production — a silently failing sweep would let the in-memory job
+            # stores grow unbounded, defeating the memory-leak fix.
+            logger.warning("Periodic cleanup failed: %s", exc)
         await asyncio.sleep(300)  # Sweep every 5 minutes
+
+
+# Hold a strong module-level reference to the cleanup task. A bare
+# asyncio.create_task(...) is fire-and-forget: the event loop keeps only a weak
+# reference, so the task can be garbage-collected mid-flight and silently stop
+# sweeping. Keeping the reference (and cancelling it on shutdown) keeps the loop
+# alive for the app's lifetime.
+_cleanup_task: "asyncio.Task[None] | None" = None
 
 
 @router.on_event("startup")
 async def startup_event():
     """Start background tasks on API startup."""
-    asyncio.create_task(_periodic_cleanup())
+    global _cleanup_task
+    _cleanup_task = asyncio.create_task(_periodic_cleanup())
+
+
+@router.on_event("shutdown")
+async def shutdown_event():
+    """Cancel background tasks on API shutdown."""
+    global _cleanup_task
+    if _cleanup_task is not None:
+        _cleanup_task.cancel()
+        try:
+            await _cleanup_task
+        except asyncio.CancelledError:
+            pass
+        _cleanup_task = None
 
 
 def _persist_video_job(job: VideoJobStatusResponse) -> None:

--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -811,8 +811,12 @@ async def get_cache_stats_v1(cache_service: CacheService = Depends(get_cache_ser
             return CacheStats(**_stats_cache)
 
         stats = cache_service.get_cache_statistics()
-        _stats_cache = stats
-        _stats_cache_time = now
+        # Only cache successful results. get_cache_statistics() swallows its own
+        # exceptions and returns a zeroed dict with an "error" key on failure;
+        # caching that would serve bogus all-zero stats for the whole TTL window.
+        if "error" not in stats:
+            _stats_cache = stats
+            _stats_cache_time = now
         return CacheStats(**stats)
     except Exception as e:
         logger.error(f"Error getting cache stats: {e}")

--- a/src/youtube_extension/backend/services/data_service.py
+++ b/src/youtube_extension/backend/services/data_service.py
@@ -137,7 +137,9 @@ class DataService:
         """Get all enhanced analysis files with caching to avoid repeated rglob."""
         now = time.time()
         if now - self._file_cache_timestamp < self._file_cache_ttl:
-            return self._file_cache
+            # Return a shallow copy so callers can't mutate the shared cache
+            # (e.g. sort/append) and corrupt it for other readers in the TTL window.
+            return list(self._file_cache)
 
         try:
             if not self.enhanced_analysis_dir.exists():
@@ -156,7 +158,7 @@ class DataService:
 
             self._file_cache = all_files
             self._file_cache_timestamp = now
-            return all_files
+            return list(all_files)
         except Exception as e:
             logger.error(f"Error listing files: {e}")
             return []
@@ -527,8 +529,6 @@ class DataService:
             Cleanup summary
         """
         try:
-            import time
-
             cutoff_time = time.time() - (days_old * 24 * 60 * 60)
             cleanup_summary = {
                 "files_removed": 0,

--- a/src/youtube_extension/backend/services/database_optimizer.py
+++ b/src/youtube_extension/backend/services/database_optimizer.py
@@ -850,17 +850,25 @@ class DatabaseHealthMonitor:
             }
 
 
-def _parse_pool_size(env_var: str, default: int) -> int:
+def _parse_pool_size(env_var: str, default: int, max_allowed: int = 200) -> int:
     """Parse a positive-int pool-size env var, falling back to ``default``.
 
     Runs at import time, so a malformed value (empty string, non-numeric, or
     non-positive) must never crash startup — log a warning and use the default.
+    Values above ``max_allowed`` are clamped so a mistyped env var (e.g. an
+    extra zero) can't exhaust the database's connection limit or file
+    descriptors.
     """
     raw = os.getenv(env_var, str(default))
     try:
         value = int(raw)
         if value <= 0:
             raise ValueError(f"{env_var} must be positive, got {value}")
+        if value > max_allowed:
+            logger.warning(
+                "%s=%d exceeds max_allowed=%d; clamping", env_var, value, max_allowed
+            )
+            return max_allowed
         return value
     except ValueError as error:
         logger.warning(

--- a/src/youtube_extension/backend/services/database_optimizer.py
+++ b/src/youtube_extension/backend/services/database_optimizer.py
@@ -853,10 +853,13 @@ class DatabaseHealthMonitor:
 # Global database optimization system
 # Use /tmp for Cloud Run compatibility (read-only filesystem except /tmp)
 database_url = os.getenv("DATABASE_URL", "sqlite:////tmp/uvai_data/app.db")
-# Increase connection pool size to handle more concurrent requests.
-# min_connections: 5 (keep some ready), max_connections: 50 (handle bursts)
+# Connection pool sizing (applied by the PostgreSQL branch; the SQLite default
+# path ignores these). Env-configurable so deployments can tune concurrency
+# without a code change. Defaults: keep a few ready (5), allow bursts (50).
 connection_pool = DatabaseConnectionPool(
-    database_url, min_connections=5, max_connections=50
+    database_url,
+    min_connections=int(os.getenv("DB_POOL_MIN_CONNECTIONS", "5")),
+    max_connections=int(os.getenv("DB_POOL_MAX_CONNECTIONS", "50")),
 )
 query_optimizer = QueryOptimizer(connection_pool)
 health_monitor = DatabaseHealthMonitor(query_optimizer)

--- a/src/youtube_extension/backend/services/database_optimizer.py
+++ b/src/youtube_extension/backend/services/database_optimizer.py
@@ -850,16 +850,44 @@ class DatabaseHealthMonitor:
             }
 
 
+def _parse_pool_size(env_var: str, default: int) -> int:
+    """Parse a positive-int pool-size env var, falling back to ``default``.
+
+    Runs at import time, so a malformed value (empty string, non-numeric, or
+    non-positive) must never crash startup — log a warning and use the default.
+    """
+    raw = os.getenv(env_var, str(default))
+    try:
+        value = int(raw)
+        if value <= 0:
+            raise ValueError(f"{env_var} must be positive, got {value}")
+        return value
+    except ValueError as error:
+        logger.warning(
+            "Invalid %s=%r (%s); using default %d", env_var, raw, error, default
+        )
+        return default
+
+
 # Global database optimization system
 # Use /tmp for Cloud Run compatibility (read-only filesystem except /tmp)
 database_url = os.getenv("DATABASE_URL", "sqlite:////tmp/uvai_data/app.db")
 # Connection pool sizing (applied by the PostgreSQL branch; the SQLite default
 # path ignores these). Env-configurable so deployments can tune concurrency
 # without a code change. Defaults: keep a few ready (5), allow bursts (50).
+_min_conn = _parse_pool_size("DB_POOL_MIN_CONNECTIONS", 5)
+_max_conn = _parse_pool_size("DB_POOL_MAX_CONNECTIONS", 50)
+if _min_conn > _max_conn:
+    logger.warning(
+        "DB_POOL_MIN_CONNECTIONS (%d) > DB_POOL_MAX_CONNECTIONS (%d); swapping",
+        _min_conn,
+        _max_conn,
+    )
+    _min_conn, _max_conn = _max_conn, _min_conn
 connection_pool = DatabaseConnectionPool(
     database_url,
-    min_connections=int(os.getenv("DB_POOL_MIN_CONNECTIONS", "5")),
-    max_connections=int(os.getenv("DB_POOL_MAX_CONNECTIONS", "50")),
+    min_connections=_min_conn,
+    max_connections=_max_conn,
 )
 query_optimizer = QueryOptimizer(connection_pool)
 health_monitor = DatabaseHealthMonitor(query_optimizer)

--- a/tests/unit/test_pool_size_parsing.py
+++ b/tests/unit/test_pool_size_parsing.py
@@ -38,3 +38,15 @@ class TestParsePoolSize:
     ) -> None:
         monkeypatch.setenv("DB_POOL_TEST", bad)
         assert _parse_pool_size("DB_POOL_TEST", 8) == 8
+
+    def test_value_above_ceiling_is_clamped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DB_POOL_TEST", "1000000")
+        assert _parse_pool_size("DB_POOL_TEST", 5, max_allowed=200) == 200
+
+    def test_value_at_ceiling_is_kept(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DB_POOL_TEST", "200")
+        assert _parse_pool_size("DB_POOL_TEST", 5, max_allowed=200) == 200

--- a/tests/unit/test_pool_size_parsing.py
+++ b/tests/unit/test_pool_size_parsing.py
@@ -1,0 +1,40 @@
+"""Unit tests for the DB connection-pool env-var sizing helper.
+
+Covers `_parse_pool_size`, which runs at import time and therefore must never
+raise on malformed configuration — it should log and fall back to the default.
+"""
+
+import pytest
+
+from youtube_extension.backend.services.database_optimizer import _parse_pool_size
+
+
+class TestParsePoolSize:
+    def test_valid_value_is_used(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DB_POOL_TEST", "17")
+        assert _parse_pool_size("DB_POOL_TEST", 5) == 17
+
+    def test_unset_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DB_POOL_TEST", raising=False)
+        assert _parse_pool_size("DB_POOL_TEST", 42) == 42
+
+    def test_non_numeric_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DB_POOL_TEST", "not-a-number")
+        assert _parse_pool_size("DB_POOL_TEST", 5) == 5
+
+    def test_empty_string_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DB_POOL_TEST", "")
+        assert _parse_pool_size("DB_POOL_TEST", 9) == 9
+
+    @pytest.mark.parametrize("bad", ["0", "-3"])
+    def test_non_positive_falls_back_to_default(
+        self, bad: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DB_POOL_TEST", bad)
+        assert _parse_pool_size("DB_POOL_TEST", 8) == 8


### PR DESCRIPTION
## Summary

Originally this branch duplicated PR #642 (identical commits). #642 was squash-merged into `main` at 06:02 UTC, so the duplicate was dead. Rather than discard it, this branch has been **reset to `main` and repurposed** to carry the follow-up fixes CodeRabbit's review surfaced against that now-live code. It now contains a single focused commit (+57/−16 across 4 files).

## CodeRabbit findings addressed

**🟠 Major**
- **`transcription-service.ts` — eager metadata fetch.** `metadataPromise` was kicked off unconditionally before Strategy 1 (free backend transcript) ran, firing an outbound YouTube request on *every* call even when the free path succeeds and returns early — undermining the cost/latency intent of #642. Replaced with a lazy, memoized `getMetadata()` helper; only the Gemini/OpenAI fallbacks trigger it, and it still fetches at most once.
- **`router.py` — fire-and-forget cleanup task.** `asyncio.create_task(_periodic_cleanup())` kept no reference, so the task could be garbage-collected mid-flight and silently stop sweeping (defeating the memory-leak fix). Now held in a module-level reference and cancelled cleanly on shutdown.

**🟡 Minor**
- **`router.py` — cleanup failures logged at `debug`** (invisible in prod) → raised to `warning`.

**🔵 Trivial / quick wins**
- **`data_service.py`** — removed a redundant local `import time`; `_get_all_files_cached()` now returns a copy so callers can't mutate shared cache state.
- **`database_optimizer.py`** — PostgreSQL pool sizing is now env-configurable (`DB_POOL_MIN_CONNECTIONS` / `DB_POOL_MAX_CONNECTIONS`) instead of hardcoded.

**Deliberately skipped**
- Extracting a shared `truncate_transcript` helper across `real_ai_processor.py` / `vercel_gateway_provider.py` — cross-file refactor, optional polish, low value relative to risk.

## Verification
- All touched Python files pass `py_compile`.
- `transcription-service.ts` verified self-consistent: `metadataPromise` is fully encapsulated in the memoized closure; both fallbacks use `await getMetadata()`. The type annotation reuses `fetchYouTubeMetadata`'s return type (which already includes `null`), so no new imports and no widening.
- Full `pytest` / `next build` run in CI (container is a fresh clone without dev deps installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)