### PR TITLE
fix(web): resolve Vercel KV creds + fail-closed only for AI routes (GATE-4 follow-up)

### DIFF
--- a/CONTROL.md
+++ b/CONTROL.md
@@ -13,4 +13,4 @@
 
 **Do not trust without re-verify:** root `ARCHITECTURE.md`, `docs/refactor/STATE.md`, `shared/_core/SYSTEM_STATUS.md`, Drive concept PDFs, empty `packages/*`, `src/vera` (pyc only).
 
-**Owner next action:** fix GitHub + Vercel CLI auth (see EXECUTION-PLAN GATE-0), then say “GATE-0 auth done”.
+**Owner next action:** complete GATE-3 launch config — Cloudflare Turnstile keys, Stripe webhook secret, Stripe price IDs, Google OAuth (see EXECUTION-PLAN GATE-3) — then trigger the GATE-4 Vercel deploy. (GATE-0 CLI auth is resolved via the `env -u GITHUB_TOKEN` / `env -u VERCEL_TOKEN` workaround.)

--- a/apps/web/src/app/api/__tests__/video-route.test.ts
+++ b/apps/web/src/app/api/__tests__/video-route.test.ts
@@ -53,7 +53,7 @@ describe('POST /api/video', () => {
     );
     // Must be a valid 11-char YouTube id — the BFF allowlist now rejects short
     // ids (e.g. `youtu.be/x`) with a 400 before the transcript chain runs.
-    const res = await POST(postRequest({ url: 'https://youtu.be/dQw4w9WgXcQ' }));
+    const res = await POST(postRequest({ url: 'https://youtu.be/auJzb1D-fag' }));
     const body = await res.json();
     expect(body.status).toBe('failed');
     expect(body.result.success).toBe(false);

--- a/apps/web/src/app/api/__tests__/video-route.test.ts
+++ b/apps/web/src/app/api/__tests__/video-route.test.ts
@@ -51,7 +51,9 @@ describe('POST /api/video', () => {
         text: async () => '{}',
       } as unknown as Response),
     );
-    const res = await POST(postRequest({ url: 'https://youtu.be/x' }));
+    // Must be a valid 11-char YouTube id — the BFF allowlist now rejects short
+    // ids (e.g. `youtu.be/x`) with a 400 before the transcript chain runs.
+    const res = await POST(postRequest({ url: 'https://youtu.be/dQw4w9WgXcQ' }));
     const body = await res.json();
     expect(body.status).toBe('failed');
     expect(body.result.success).toBe(false);

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -75,6 +75,31 @@ describe('proxy rate limiting — production without a working Redis limiter', (
     expect(body.code).toBe('rate_limit_unavailable');
   });
 
+  it('fails CLOSED with 503 for /api/agents/actions (LLM route, not just dispatch)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    const res = await proxy(apiRequest('/api/agents/actions'));
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe('rate_limit_unavailable');
+  });
+
+  it('fails OPEN for the cheap /api/agents/status route', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    const res = await proxy(apiRequest('/api/agents/status'));
+
+    expect(res.status).not.toBe(503);
+    expect(res.status).not.toBe(429);
+  });
+
   it('honours UVAI_RATE_LIMIT_FAIL_OPEN=1 to fail open even for AI routes', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '1');

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// A minimal Upstash Redis stand-in; only exercised by the "credentials picked
+// up" scenario. `incr` returns 1 so the first request is always under the limit.
+const incrMock = vi.fn().mockResolvedValue(1);
+const expireMock = vi.fn().mockResolvedValue(1);
+const redisArgs: Array<{ url: string; token: string }> = [];
+vi.mock('@upstash/redis', () => ({
+  Redis: class {
+    incr = incrMock;
+    expire = expireMock;
+    constructor(cfg: { url: string; token: string }) {
+      redisArgs.push(cfg);
+    }
+  },
+}));
+
+function apiRequest(path: string): NextRequest {
+  return new NextRequest(`http://localhost:3000${path}`, {
+    method: 'GET',
+    headers: { 'x-real-ip': '203.0.113.5' },
+  });
+}
+
+// The proxy memoizes its Redis client at module scope, so each scenario loads a
+// fresh module instance (after env is stubbed) to defeat that memoization.
+async function loadProxy() {
+  vi.resetModules();
+  return (await import('./proxy')).proxy;
+}
+
+const REDIS_ENV_KEYS = [
+  'UPSTASH_REDIS_REST_URL',
+  'UPSTASH_REDIS_REST_TOKEN',
+  'KV_REST_API_URL',
+  'KV_REST_API_TOKEN',
+];
+
+function clearRedisEnv() {
+  for (const k of REDIS_ENV_KEYS) vi.stubEnv(k, '');
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+  redisArgs.length = 0;
+});
+
+describe('proxy rate limiting — production without a working Redis limiter', () => {
+  it('fails OPEN for non-AI routes so a limiter outage cannot take down the API', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    const res = await proxy(apiRequest('/api/health'));
+
+    expect(res.status).not.toBe(429);
+    expect(res.status).not.toBe(503);
+    // Request passed through with limiter headers attached.
+    expect(res.headers.get('X-RateLimit-Limit')).toBeTruthy();
+  });
+
+  it('fails CLOSED with 503 for AI routes (denial-of-wallet protection)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    const res = await proxy(apiRequest('/api/chat'));
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe('rate_limit_unavailable');
+  });
+
+  it('honours UVAI_RATE_LIMIT_FAIL_OPEN=1 to fail open even for AI routes', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '1');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    const res = await proxy(apiRequest('/api/chat'));
+
+    expect(res.status).not.toBe(503);
+    expect(res.status).not.toBe(429);
+  });
+
+  it('resolves KV_REST_API_* credentials (Vercel KV) for the limiter', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    clearRedisEnv();
+    vi.stubEnv('KV_REST_API_URL', 'https://kv.example.upstash.io');
+    vi.stubEnv('KV_REST_API_TOKEN', 'kv-token');
+
+    const proxy = await loadProxy();
+    const res = await proxy(apiRequest('/api/chat'));
+
+    expect(redisArgs).toContainEqual({
+      url: 'https://kv.example.upstash.io',
+      token: 'kv-token',
+    });
+    expect(incrMock).toHaveBeenCalled();
+    expect(res.status).not.toBe(503);
+  });
+});

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -16,6 +16,10 @@ const GENERAL_LIMIT = Number(process.env.UVAI_API_RATE_LIMIT_PER_MINUTE || 60);
 const AI_LIMIT = Number(process.env.UVAI_AI_RATE_LIMIT_PER_MINUTE || 12);
 
 const AI_ROUTE_PREFIXES = [
+  // Both /api/agents/actions (runActionAgent) and /api/agents/dispatch invoke an
+  // LLM per request, so both must fail closed on a limiter outage. The sibling
+  // /api/agents/status is a cheap GET and is intentionally left off (fails open).
+  '/api/agents/actions',
   '/api/agents/dispatch',
   '/api/chat',
   '/api/extract-events',

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import type { Redis } from '@upstash/redis';
 import { getToken } from 'next-auth/jwt';
+import { resolveUpstashRedisCredentials } from '@/lib/billing/redis-credentials';
 
 /**
  * Frontend proxy (Next.js 16 middleware): rate limiting (always) + login gating
@@ -37,6 +38,10 @@ type RateLimitResult = {
   limit: number;
   remaining: number;
   resetAt: number;
+  // Set only when `allowed` is false. `exceeded` = a genuine per-client overage
+  // (→ 429); `limiter_unavailable` = the limiter itself could not run, e.g. no
+  // Redis in production on an AI route (→ 503, this is an outage not a quota).
+  reason?: 'exceeded' | 'limiter_unavailable';
 };
 
 type MemoryBucket = {
@@ -74,13 +79,16 @@ function getRedisClient(): Promise<Redis | null> {
   }
 
   redisClientPromise = (async () => {
-    if (process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN) {
+    // Accept either the canonical `UPSTASH_REDIS_REST_*` names or the
+    // `KV_REST_API_*` names that Vercel's Upstash/KV integration injects.
+    // Production only provisions the latter, so hardcoding the former left the
+    // limiter permanently client-less — the same helper the /api/video/generate
+    // route already uses.
+    const creds = resolveUpstashRedisCredentials();
+    if (creds) {
       try {
         const { Redis } = await import('@upstash/redis');
-        return new Redis({
-          url: process.env.UPSTASH_REDIS_REST_URL,
-          token: process.env.UPSTASH_REDIS_REST_TOKEN,
-        });
+        return new Redis({ url: creds.url, token: creds.token });
       } catch {
         // dynamic import failed; fall back to null below
         return null;
@@ -167,9 +175,11 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
   const redisClient = await getRedisClient();
 
   if (!redisClient && process.env.NODE_ENV === 'production' && !prodRedisWarned) {
-    console.warn(
-      '[RateLimit] No UPSTASH_REDIS_* configured in production. Rate limiting is bypassed (fail-open) to avoid silent in-process state. ' +
-      'Configure Upstash for enforcement. See src/proxy.ts and the rate-limit-middleware agent in config/agent_network.json.'
+    console.error(
+      '[RateLimit] No Upstash/KV Redis configured in production (checked UPSTASH_REDIS_REST_* and KV_REST_API_*). ' +
+      'Failing CLOSED for expensive AI routes (denial-of-wallet protection) and OPEN for other API routes so a ' +
+      'limiter outage cannot take down billing/auth/health. Configure Upstash or Vercel KV for full enforcement. ' +
+      'See src/proxy.ts and the rate-limit-middleware agent in config/agent_network.json.'
     );
     prodRedisWarned = true;
   }
@@ -194,26 +204,35 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
     return checkMemoryLimit(key, limit);
   }
 
-  // Production without working Redis: fail-closed (deny) unless emergency override.
-  // Fail-open re-opens denial-of-wallet on AI routes (audit findings #4/#7).
-  const failOpen = process.env.UVAI_RATE_LIMIT_FAIL_OPEN === '1';
-  if (failOpen) {
-    console.warn(
-      '[RateLimit] UVAI_RATE_LIMIT_FAIL_OPEN=1 — production rate limit failing open (emergency).',
-    );
-    return {
-      allowed: true,
-      limit,
-      remaining: limit,
-      resetAt: Math.ceil((Date.now() + WINDOW_SECONDS * 1000) / 1000),
-    };
+  const allowResult: RateLimitResult = {
+    allowed: true,
+    limit,
+    remaining: limit,
+    resetAt: Math.ceil((Date.now() + WINDOW_SECONDS * 1000) / 1000),
+  };
+
+  // Production without a working Redis limiter. Fail CLOSED only for expensive
+  // AI routes (denial-of-wallet, audit findings #4/#7). Every other route —
+  // billing, auth, health, general API — fails OPEN so a limiter outage or
+  // credential misconfiguration cannot take the whole API offline. The
+  // emergency override forces open even for AI routes.
+  if (routeClass !== 'ai' || process.env.UVAI_RATE_LIMIT_FAIL_OPEN === '1') {
+    if (routeClass === 'ai') {
+      console.warn(
+        '[RateLimit] UVAI_RATE_LIMIT_FAIL_OPEN=1 — production AI rate limit failing open (emergency).',
+      );
+    }
+    return allowResult;
   }
 
+  // AI route, no Redis, no override: deny. This is a limiter *outage*, not a
+  // genuine per-client overage, so it surfaces as 503 (see proxy handler).
   return {
     allowed: false,
     limit,
     remaining: 0,
     resetAt: Math.ceil((Date.now() + WINDOW_SECONDS * 1000) / 1000),
+    reason: 'limiter_unavailable',
   };
 }
 
@@ -270,10 +289,16 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   const result = await checkRateLimit(request);
 
   if (!result.allowed) {
+    const outage = result.reason === 'limiter_unavailable';
     return NextResponse.json(
-      { error: 'Rate limit exceeded. Please try again shortly.' },
+      outage
+        ? {
+            error: 'Rate limiter temporarily unavailable. Please try again shortly.',
+            code: 'rate_limit_unavailable',
+          }
+        : { error: 'Rate limit exceeded. Please try again shortly.' },
       {
-        status: 429,
+        status: outage ? 503 : 429,
         headers: {
           'Cache-Control': 'no-store',
           'Retry-After': String(WINDOW_SECONDS),

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -142,11 +142,13 @@ async function checkRedisLimit(redisClient: Redis, key: string, limit: number): 
     await redisClient.expire(redisKey, WINDOW_SECONDS + 5);
   }
 
+  const allowed = count <= limit;
   return {
-    allowed: count <= limit,
+    allowed,
     limit,
     remaining: Math.max(0, limit - count),
     resetAt,
+    reason: allowed ? undefined : 'exceeded',
   };
 }
 
@@ -161,11 +163,13 @@ function checkMemoryLimit(key: string, limit: number): RateLimitResult {
 
   memoryBuckets.set(key, { count, resetAt });
 
+  const allowed = count <= limit;
   return {
-    allowed: count <= limit,
+    allowed,
     limit,
     remaining: Math.max(0, limit - count),
     resetAt: Math.ceil(resetAt / 1000),
+    reason: allowed ? undefined : 'exceeded',
   };
 }
 

--- a/docs/control-plane/plans/EXECUTION-PLAN.md
+++ b/docs/control-plane/plans/EXECUTION-PLAN.md
@@ -15,7 +15,7 @@ GATE-2  Live product baseline   DONE 2026-07-10 — see sessions/gate2-20260710T
 GATE-3  Launch config — AUDIT DONE, launch blocked on Turnstile/Webhook/Prices/OAuth
 GATE-4  Security High — code done on fix/gate4-security-hardening; deploy pending
 GATE-5  Single pipeline reliability (honest handoff)
-GATE-6  Doc consolidation complete
+GATE-6  Doc consolidation       PENDING (all G6 tasks TODO; exit unmet)
 GATE-7  Optional: data plane (BQ/RAG) only if product needs it
 ```
 


### PR DESCRIPTION
## Summary

Follow-up refinements to the GATE-4 fail-closed rate limiter that merged today as **#654** (`fix/gate4-security-hardening`). #654 shipped a fail-closed limiter but had two gaps this PR closes, plus it adds the test coverage that was missing.

## What changed

1. **Resolve Vercel KV credentials.** `proxy.ts` hardcoded `UPSTASH_REDIS_REST_URL/TOKEN`, but production only provisions `KV_REST_API_URL/TOKEN` (Vercel's Upstash/KV integration). That left the limiter **permanently client-less in prod**. Now uses the shared `resolveUpstashRedisCredentials()` helper (same one `/api/video/generate` already uses), which accepts either name pair.

2. **Fail *closed* only for AI routes; fail *open* for everything else.** A limiter outage or credential misconfig previously risked either re-opening denial-of-wallet (fail-open everywhere) or taking billing/auth/health offline (fail-closed everywhere). Now: expensive **AI routes → 503** (denial-of-wallet protection); billing/auth/health/general API → pass through. `UVAI_RATE_LIMIT_FAIL_OPEN=1` remains an emergency override that forces open even for AI routes.

3. **Classify `/api/agents/actions` as an AI route.** It invokes an LLM per request (like `/api/agents/dispatch`), so it must fail closed. The cheap sibling `/api/agents/status` is intentionally left off (fails open).

4. **Distinguish limiter *outage* from quota *overage*.** New `reason: 'exceeded' | 'limiter_unavailable'` field → genuine per-client overage returns **429**, limiter unavailability returns **503** with `code: rate_limit_unavailable`. A 503 is a retriable outage, not a quota rejection.

5. **Test coverage.** New `apps/web/src/proxy.test.ts` (6 cases: fail-open non-AI, fail-closed AI, `/api/agents/actions` closed, `/api/agents/status` open, emergency override, KV cred resolution). Fixed `video-route.test.ts` to use a valid 11-char YouTube id (the BFF allowlist now 400s short ids before the transcript chain runs).

6. **Doc sync.** `CONTROL.md` owner-next-action → GATE-3 launch config; `EXECUTION-PLAN.md` GATE-6 marked PENDING.

## Verification

`vitest run src/proxy.test.ts src/app/api/__tests__/video-route.test.ts` → **9 passed**. `main` CI is green; these commits are clean on top of the merged #654.

## Notes

Draft — protected `main` requires owner approval to merge. Opened as the terminal (publish-gate) state of the PR-remediation routine: this is real unmerged work surfaced for review rather than auto-merged to a protected branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhffxA2ByWSw2s5JPS6ETa)_