### PR TITLE
fix(web): fail open for cheap AI status GETs, closed only for paid AI calls

### DIFF
--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -129,11 +129,30 @@ describe('proxy rate limiting — production without a working Redis limiter', (
       '/api/pipeline',
       '/api/training/status',
       '/api/video',
+      '/api/agents/actions',
       '/api/agents/dispatch',
     ]) {
       const res = await proxy(apiRequest(path, 'GET'));
       expect(res.status, `${path} should fail open`).not.toBe(503);
       expect(res.status, `${path} should fail open`).not.toBe(429);
+    }
+  });
+
+  it('fails CLOSED for an unclassified AI GET (safe denial-of-wallet default)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    // AI-prefixed GETs are an ALLOWLIST: anything not verified cheap fails closed.
+    // /api/transcribe and /api/chat are AI routes with no cheap GET on the list,
+    // so a GET to them (or any future billable AI read) is denied during an
+    // outage rather than silently leaking an unmetered paid call.
+    for (const path of ['/api/transcribe', '/api/chat', '/api/extract-events']) {
+      const res = await proxy(apiRequest(path, 'GET'));
+      expect(res.status, `${path} should fail closed`).toBe(503);
+      const body = await res.json();
+      expect(body.code, `${path} should fail closed`).toBe('rate_limit_unavailable');
     }
   });
 

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -94,14 +94,47 @@ describe('proxy rate limiting — production without a working Redis limiter', (
     clearRedisEnv();
 
     const proxy = await loadProxy();
-    // Some AI GETs are paid calls (embedding / OpenAI Realtime secret), so ALL
-    // AI-prefixed routes fail closed regardless of method — a method-based
-    // "GETs are cheap" rule would leak these during a Redis outage.
+    // A handful of AI GETs are themselves paid calls (Gemini embedding here),
+    // so they fail closed even though they are reads — a blanket "GETs are
+    // cheap" rule would leak these during a Redis outage.
     const res = await proxy(apiRequest('/api/video/search?videoId=x&q=y', 'GET'));
 
     expect(res.status).toBe(503);
     const body = await res.json();
     expect(body.code).toBe('rate_limit_unavailable');
+  });
+
+  it('fails CLOSED for GET /api/realtime/session (mints a paid OpenAI Realtime secret)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    const res = await proxy(apiRequest('/api/realtime/session', 'GET'));
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe('rate_limit_unavailable');
+  });
+
+  it('fails OPEN for cheap AI status/health GETs so a Redis outage cannot 503 them', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    // These are AI-prefixed but incur NO paid AI call — pure status/health/info
+    // reads — so they must stay available during a limiter outage.
+    for (const path of [
+      '/api/pipeline',
+      '/api/training/status',
+      '/api/video',
+      '/api/agents/dispatch',
+    ]) {
+      const res = await proxy(apiRequest(path, 'GET'));
+      expect(res.status, `${path} should fail open`).not.toBe(503);
+      expect(res.status, `${path} should fail open`).not.toBe(429);
+    }
   });
 
   it('fails OPEN for non-AI GET routes (e.g. /api/agents/status)', async () => {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -16,9 +16,11 @@ const GENERAL_LIMIT = Number(process.env.UVAI_API_RATE_LIMIT_PER_MINUTE || 60);
 const AI_LIMIT = Number(process.env.UVAI_AI_RATE_LIMIT_PER_MINUTE || 12);
 
 const AI_ROUTE_PREFIXES = [
-  // Both /api/agents/actions (runActionAgent) and /api/agents/dispatch invoke an
-  // LLM per request, so both must fail closed on a limiter outage. The sibling
-  // /api/agents/status is a cheap GET and is intentionally left off (fails open).
+  // Writes (POST) to /api/agents/actions (runActionAgent) and /api/agents/dispatch
+  // invoke an LLM per request, so those fail closed on a limiter outage. Their GET
+  // handlers are cheap availability probes (env checks) and fail open — see
+  // CHEAP_AI_GET_ROUTES below. The sibling /api/agents/status carries no AI prefix
+  // here at all, so it is never rate-limited as an AI route and always fails open.
   '/api/agents/actions',
   '/api/agents/dispatch',
   '/api/chat',
@@ -108,36 +110,51 @@ function isAiRoute(pathname: string): boolean {
   return AI_ROUTE_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 }
 
-// AI-prefixed GET endpoints that are NOT cheap reads: each incurs a paid
-// external AI call per request, so they must fail CLOSED on a limiter outage
-// exactly like the writes.
-//   - GET /api/realtime/session  → mints an OpenAI Realtime client secret
-//   - GET /api/video/search      → runs a Gemini embedding of the query
-// Every other GET under an AI prefix (e.g. GET /api/video, GET /api/pipeline,
-// GET /api/training/status, GET /api/agents/{actions,dispatch}) is a cheap
-// status/health/info read and fails OPEN so a Redis outage can't 503 it.
-const PAID_AI_GET_ROUTES = ['/api/realtime/session', '/api/video/search'];
-
-function pathMatches(pathname: string, base: string): boolean {
-  return pathname === base || pathname.startsWith(base + '/');
-}
+// Cheap AI GET/HEAD reads — verified to make NO paid provider call — that stay
+// available (fail OPEN) during a limiter outage. Matched EXACTLY, never by
+// subpath: a paid sibling under the same prefix must not inherit fail-open. In
+// particular GET /api/video is a cheap health/info read, but its subpath GET
+// /api/video/search runs a Gemini embedding — exact matching keeps /api/video
+// open while /api/video/search falls through to the fail-closed default.
+//
+// This is an ALLOWLIST on purpose (inverted from an earlier paid-route denylist):
+// any AI GET not listed here fails CLOSED, so a newly-added billable AI read is
+// protected by default without having to remember to touch this file. Handlers
+// verified cheap:
+//   /api/agents/actions  → { available, tools } (env check)
+//   /api/agents/dispatch → { available } (env check)
+//   /api/pipeline        → checkBackendHealth() + static config
+//   /api/training/status → local training status
+//   /api/video           → backend /health probe + static info
+const CHEAP_AI_GET_ROUTES = [
+  '/api/agents/actions',
+  '/api/agents/dispatch',
+  '/api/pipeline',
+  '/api/training/status',
+  '/api/video',
+];
 
 /**
- * Is THIS request one that incurs a paid AI provider call, and therefore must
- * fail CLOSED when the rate limiter is unavailable (denial-of-wallet)? True for
- * every write to an AI route, plus the handful of AI GETs that are themselves
- * paid calls. Cheap AI GETs (status/health/info) return false and fail open.
+ * Must THIS request fail CLOSED (503) when the rate limiter is unavailable,
+ * because it could incur a paid AI provider call (denial-of-wallet)? True for
+ * every write to an AI route, and for every AI GET/HEAD that is not on the
+ * verified-cheap allowlist. Non-AI routes and the verified-cheap AI reads fail
+ * OPEN so a limiter outage can't take the API down.
+ *
+ * The default for an *unclassified* AI GET is fail-closed: safer to briefly 503
+ * a read we haven't vetted than to leak an unmetered paid call during an outage.
  */
-function isPaidAiRequest(pathname: string, method: string): boolean {
+function failsClosedOnOutage(pathname: string, method: string): boolean {
   if (!isAiRoute(pathname)) {
     return false;
   }
-  // Writes to an AI route always trigger the paid model call.
-  if (method !== 'GET' && method !== 'HEAD') {
-    return true;
+  if (method === 'GET' || method === 'HEAD') {
+    // AI reads fail open only if explicitly verified cheap; all others — paid
+    // reads and any not-yet-classified GET — fail closed.
+    return !CHEAP_AI_GET_ROUTES.includes(pathname);
   }
-  // A small, explicit allowlist of GETs that are paid calls despite being reads.
-  return PAID_AI_GET_ROUTES.some((base) => pathMatches(pathname, base));
+  // Writes to an AI route always trigger the paid model call.
+  return true;
 }
 
 function getClientIp(request: NextRequest): string {
@@ -211,18 +228,19 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
   const clientIp = getClientIp(request);
   const routeClass = isAiRoute(pathname) ? 'ai' : 'api';
   const key = `${routeClass}:${clientIp}`;
-  // Narrower than routeClass: only requests that actually incur a paid AI call
-  // (all AI writes + the paid AI GETs) fail closed on a limiter outage.
-  const expensiveOnOutage = isPaidAiRequest(pathname, request.method);
+  // Narrower than routeClass: only requests that could incur a paid AI call —
+  // all AI writes, plus AI GETs not on the verified-cheap allowlist — fail
+  // closed on a limiter outage.
+  const failClosed = failsClosedOnOutage(pathname, request.method);
 
   const redisClient = await getRedisClient();
 
   if (!redisClient && process.env.NODE_ENV === 'production' && !prodRedisWarned) {
     console.error(
       '[RateLimit] No Upstash/KV Redis configured in production (checked UPSTASH_REDIS_REST_* and KV_REST_API_*). ' +
-      'Failing CLOSED for requests that incur a paid AI call (all AI-route writes + the paid AI GETs ' +
-      '/api/realtime/session and /api/video/search — denial-of-wallet protection) and OPEN for everything ' +
-      'else (non-AI routes AND cheap AI status/health GETs) so a limiter outage cannot take down the API. ' +
+      'Failing CLOSED for requests that could incur a paid AI call (all AI-route writes + every AI GET not on ' +
+      'the verified-cheap allowlist — denial-of-wallet protection) and OPEN for everything else (non-AI routes ' +
+      'AND the verified-cheap AI status/health GETs) so a limiter outage cannot take down the API. ' +
       'Configure Upstash or Vercel KV for full enforcement. ' +
       'See src/proxy.ts and the rate-limit-middleware agent in config/agent_network.json.'
     );
@@ -257,18 +275,19 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
   };
 
   // Production without a working Redis limiter. Fail CLOSED only for requests
-  // that actually incur a paid AI call — every AI-route write plus the two paid
-  // AI GETs (`GET /api/realtime/session` mints an OpenAI Realtime client secret,
-  // `GET /api/video/search` runs a Gemini embedding). Failing those open would
-  // reopen the denial-of-wallet vector (audit findings #4/#7). Everything else
-  // fails OPEN so a limiter outage can't take the API down: not just non-AI
-  // routes (billing, auth, health, general API) but also cheap AI status/health
-  // GETs (`GET /api/video`, `GET /api/pipeline`, `GET /api/training/status`,
-  // `GET /api/agents/{actions,dispatch}`), which are free reads and so should
-  // stay available during a Redis outage. The emergency override forces open
-  // even for the paid requests.
-  if (!expensiveOnOutage || process.env.UVAI_RATE_LIMIT_FAIL_OPEN === '1') {
-    if (expensiveOnOutage) {
+  // that could incur a paid AI call — every AI-route write, plus any AI GET not
+  // on the verified-cheap allowlist (`GET /api/realtime/session` mints an OpenAI
+  // Realtime client secret, `GET /api/video/search` runs a Gemini embedding, and
+  // any unclassified AI read defaults here). Failing those open would reopen the
+  // denial-of-wallet vector (audit findings #4/#7). Everything else fails OPEN so
+  // a limiter outage can't take the API down: not just non-AI routes (billing,
+  // auth, health, general API) but also the verified-cheap AI status/health GETs
+  // (`GET /api/video`, `GET /api/pipeline`, `GET /api/training/status`,
+  // `GET /api/agents/{actions,dispatch}`), which are free reads and so stay
+  // available during a Redis outage. The emergency override forces open even for
+  // the paid requests.
+  if (!failClosed || process.env.UVAI_RATE_LIMIT_FAIL_OPEN === '1') {
+    if (failClosed) {
       console.warn(
         '[RateLimit] UVAI_RATE_LIMIT_FAIL_OPEN=1 — production paid-AI rate limit failing open (emergency).',
       );

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -108,6 +108,38 @@ function isAiRoute(pathname: string): boolean {
   return AI_ROUTE_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 }
 
+// AI-prefixed GET endpoints that are NOT cheap reads: each incurs a paid
+// external AI call per request, so they must fail CLOSED on a limiter outage
+// exactly like the writes.
+//   - GET /api/realtime/session  → mints an OpenAI Realtime client secret
+//   - GET /api/video/search      → runs a Gemini embedding of the query
+// Every other GET under an AI prefix (e.g. GET /api/video, GET /api/pipeline,
+// GET /api/training/status, GET /api/agents/{actions,dispatch}) is a cheap
+// status/health/info read and fails OPEN so a Redis outage can't 503 it.
+const PAID_AI_GET_ROUTES = ['/api/realtime/session', '/api/video/search'];
+
+function pathMatches(pathname: string, base: string): boolean {
+  return pathname === base || pathname.startsWith(base + '/');
+}
+
+/**
+ * Is THIS request one that incurs a paid AI provider call, and therefore must
+ * fail CLOSED when the rate limiter is unavailable (denial-of-wallet)? True for
+ * every write to an AI route, plus the handful of AI GETs that are themselves
+ * paid calls. Cheap AI GETs (status/health/info) return false and fail open.
+ */
+function isPaidAiRequest(pathname: string, method: string): boolean {
+  if (!isAiRoute(pathname)) {
+    return false;
+  }
+  // Writes to an AI route always trigger the paid model call.
+  if (method !== 'GET' && method !== 'HEAD') {
+    return true;
+  }
+  // A small, explicit allowlist of GETs that are paid calls despite being reads.
+  return PAID_AI_GET_ROUTES.some((base) => pathMatches(pathname, base));
+}
+
 function getClientIp(request: NextRequest): string {
   // Prefer x-real-ip: set by Vercel's edge network and not client-controllable.
   const realIp = request.headers.get('x-real-ip');
@@ -179,14 +211,18 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
   const clientIp = getClientIp(request);
   const routeClass = isAiRoute(pathname) ? 'ai' : 'api';
   const key = `${routeClass}:${clientIp}`;
+  // Narrower than routeClass: only requests that actually incur a paid AI call
+  // (all AI writes + the paid AI GETs) fail closed on a limiter outage.
+  const expensiveOnOutage = isPaidAiRequest(pathname, request.method);
 
   const redisClient = await getRedisClient();
 
   if (!redisClient && process.env.NODE_ENV === 'production' && !prodRedisWarned) {
     console.error(
       '[RateLimit] No Upstash/KV Redis configured in production (checked UPSTASH_REDIS_REST_* and KV_REST_API_*). ' +
-      'Failing CLOSED for all AI routes (denial-of-wallet protection — some AI GETs are paid calls) and OPEN for ' +
-      'non-AI routes so a limiter outage cannot take down billing/auth/health. ' +
+      'Failing CLOSED for requests that incur a paid AI call (all AI-route writes + the paid AI GETs ' +
+      '/api/realtime/session and /api/video/search — denial-of-wallet protection) and OPEN for everything ' +
+      'else (non-AI routes AND cheap AI status/health GETs) so a limiter outage cannot take down the API. ' +
       'Configure Upstash or Vercel KV for full enforcement. ' +
       'See src/proxy.ts and the rate-limit-middleware agent in config/agent_network.json.'
     );
@@ -220,28 +256,28 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
     resetAt: Math.ceil((Date.now() + WINDOW_SECONDS * 1000) / 1000),
   };
 
-  // Production without a working Redis limiter. Fail CLOSED for ALL AI-prefixed
-  // routes regardless of HTTP method. A method-based "GETs are cheap" heuristic
-  // is unsafe here: several AI GETs are themselves paid calls — e.g.
-  // `GET /api/realtime/session` mints an OpenAI Realtime client secret and
-  // `GET /api/video/search` runs a Gemini embedding — so failing GETs open would
-  // reopen the denial-of-wallet vector (audit findings #4/#7). Non-AI routes
-  // (billing, auth, health, general API) still fail OPEN so a limiter outage
-  // can't take the whole API down. The accepted trade-off is that cheap AI
-  // status GETs (e.g. `GET /api/video`, `GET /api/pipeline`) briefly 503 during
-  // a Redis outage — strictly safer than leaking unmetered paid calls. The
-  // emergency override forces open even for AI routes.
-  if (routeClass !== 'ai' || process.env.UVAI_RATE_LIMIT_FAIL_OPEN === '1') {
-    if (routeClass === 'ai') {
+  // Production without a working Redis limiter. Fail CLOSED only for requests
+  // that actually incur a paid AI call — every AI-route write plus the two paid
+  // AI GETs (`GET /api/realtime/session` mints an OpenAI Realtime client secret,
+  // `GET /api/video/search` runs a Gemini embedding). Failing those open would
+  // reopen the denial-of-wallet vector (audit findings #4/#7). Everything else
+  // fails OPEN so a limiter outage can't take the API down: not just non-AI
+  // routes (billing, auth, health, general API) but also cheap AI status/health
+  // GETs (`GET /api/video`, `GET /api/pipeline`, `GET /api/training/status`,
+  // `GET /api/agents/{actions,dispatch}`), which are free reads and so should
+  // stay available during a Redis outage. The emergency override forces open
+  // even for the paid requests.
+  if (!expensiveOnOutage || process.env.UVAI_RATE_LIMIT_FAIL_OPEN === '1') {
+    if (expensiveOnOutage) {
       console.warn(
-        '[RateLimit] UVAI_RATE_LIMIT_FAIL_OPEN=1 — production AI rate limit failing open (emergency).',
+        '[RateLimit] UVAI_RATE_LIMIT_FAIL_OPEN=1 — production paid-AI rate limit failing open (emergency).',
       );
     }
     return allowResult;
   }
 
-  // AI route, no Redis, no override: deny. This is a limiter *outage*, not a
-  // genuine per-client overage, so it surfaces as 503 (see proxy handler).
+  // Paid AI request, no Redis, no override: deny. This is a limiter *outage*,
+  // not a genuine per-client overage, so it surfaces as 503 (see proxy handler).
   return {
     allowed: false,
     limit,


### PR DESCRIPTION
## Summary

Refines the rate-limiter outage behavior introduced by #655 (which failed **CLOSED for every AI-prefixed route**, 503'ing cheap status/health GETs that incur no paid AI call). Reconciles the two reviewers on #655: **denial-of-wallet** protection (Vercel VADE) for paid AI calls, **availability** (Copilot) for cheap reads.

> **Supersedes #658.** #658 carried the identical first commit but I cannot push its branch; this PR adds the follow-up commit that resolves #658's open Copilot/Devin review findings, so #658 should be closed in favor of this one.

## Commits

**1. `8d45574` — cost-based outage classification**
Replaces the blanket `routeClass === 'ai'` fail-closed check with a per-request cost predicate. AI **writes** and the paid AI **GETs** (`GET /api/realtime/session` mints an OpenAI Realtime secret; `GET /api/video/search` runs a Gemini embedding) fail closed; cheap AI status GETs and non-AI routes fail open.

**2. `b804a94` — invert the denylist to a fail-closed cheap-read allowlist** *(addresses review on #658)*
- **Security default (Copilot):** the paid-GET *denylist* made every unlisted AI GET fail **open**, so a newly-added billable read would silently bypass protection. Inverted to `CHEAP_AI_GET_ROUTES` — an explicit allowlist of verified-cheap reads — with any unlisted AI GET failing **closed** by default. Matched **exactly** so the paid `GET /api/video/search` falls through to fail-closed while its cheap sibling `GET /api/video` stays open.
- **Stale comment (Copilot + Devin):** clarified the `AI_ROUTE_PREFIXES` header — only `/api/agents/{actions,dispatch}` *writes* fail closed; their GET probes fail open.
- **Test coverage (Devin):** added `/api/agents/actions` to the fail-open loop, plus a new case asserting unclassified AI GETs (`/api/transcribe`, `/api/chat`, `/api/extract-events`) fail **closed** — locking in the safe default.

## Classification (each AI GET handler read to confirm)

| Endpoint | Verdict | Evidence |
|---|---|---|
| `GET /api/realtime/session` | **paid** | fetches OpenAI `client_secrets` |
| `GET /api/video/search` | **paid** | `generateEmbedding(query)` (Gemini) |
| `GET /api/video` | cheap | backend `/health` fetch + static info |
| `GET /api/pipeline` | cheap | `checkBackendHealth()` + config |
| `GET /api/training/status` | cheap | local training status |
| `GET /api/agents/actions` | cheap | `{ available, tools }` (env check) |
| `GET /api/agents/dispatch` | cheap | `{ available }` (env check) |

## Tests

Proxy suite **10/10 green**; `tsc --noEmit` clean; `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)