### PR TITLE
fix(web): fail closed by default for AI reads (review remediation, supersedes #658)

### DIFF
--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -94,14 +94,47 @@ describe('proxy rate limiting — production without a working Redis limiter', (
     clearRedisEnv();
 
     const proxy = await loadProxy();
-    // Some AI GETs are paid calls (embedding / OpenAI Realtime secret), so ALL
-    // AI-prefixed routes fail closed regardless of method — a method-based
-    // "GETs are cheap" rule would leak these during a Redis outage.
+    // A handful of AI GETs are themselves paid calls (Gemini embedding here),
+    // so they fail closed even though they are reads — a blanket "GETs are
+    // cheap" rule would leak these during a Redis outage.
     const res = await proxy(apiRequest('/api/video/search?videoId=x&q=y', 'GET'));
 
     expect(res.status).toBe(503);
     const body = await res.json();
     expect(body.code).toBe('rate_limit_unavailable');
+  });
+
+  it('fails CLOSED for GET /api/realtime/session (mints a paid OpenAI Realtime secret)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    const res = await proxy(apiRequest('/api/realtime/session', 'GET'));
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe('rate_limit_unavailable');
+  });
+
+  it('fails OPEN for cheap AI status/health GETs so a Redis outage cannot 503 them', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    // These are AI-prefixed but incur NO paid AI call — pure status/health/info
+    // reads — so they must stay available during a limiter outage.
+    for (const path of [
+      '/api/pipeline',
+      '/api/training/status',
+      '/api/video',
+      '/api/agents/dispatch',
+    ]) {
+      const res = await proxy(apiRequest(path, 'GET'));
+      expect(res.status, `${path} should fail open`).not.toBe(503);
+      expect(res.status, `${path} should fail open`).not.toBe(429);
+    }
   });
 
   it('fails OPEN for non-AI GET routes (e.g. /api/agents/status)', async () => {

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -178,6 +178,21 @@ describe('proxy rate limiting — production without a working Redis limiter', (
     expect(res.status).not.toBe(429);
   });
 
+  it('honours UVAI_RATE_LIMIT_FAIL_OPEN=1 to fail open even for a paid AI GET (emergency override)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '1');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    // The override must force even a paid AI GET open (Gemini embedding here),
+    // not just AI writes — the entire wallet boundary is intentionally
+    // bypassable during an outage when the operator sets this emergency flag.
+    const res = await proxy(apiRequest('/api/video/search?videoId=x&q=y', 'GET'));
+
+    expect(res.status).not.toBe(503);
+    expect(res.status).not.toBe(429);
+  });
+
   it('resolves KV_REST_API_* credentials (Vercel KV) for the limiter', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     clearRedisEnv();

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -129,12 +129,29 @@ describe('proxy rate limiting — production without a working Redis limiter', (
       '/api/pipeline',
       '/api/training/status',
       '/api/video',
+      '/api/agents/actions',
       '/api/agents/dispatch',
     ]) {
       const res = await proxy(apiRequest(path, 'GET'));
       expect(res.status, `${path} should fail open`).not.toBe(503);
       expect(res.status, `${path} should fail open`).not.toBe(429);
     }
+  });
+
+  it('fails CLOSED for an unclassified AI GET (fail-closed is the default for the wallet boundary)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    // GET on an AI-prefixed route that is NOT on the cheap-read allowlist. Since
+    // the outage boundary fails closed by default, this must 503 — so a newly
+    // added billable AI read is protected before anyone remembers to classify it.
+    const res = await proxy(apiRequest('/api/transcribe', 'GET'));
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe('rate_limit_unavailable');
   });
 
   it('fails OPEN for non-AI GET routes (e.g. /api/agents/status)', async () => {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -16,9 +16,13 @@ const GENERAL_LIMIT = Number(process.env.UVAI_API_RATE_LIMIT_PER_MINUTE || 60);
 const AI_LIMIT = Number(process.env.UVAI_AI_RATE_LIMIT_PER_MINUTE || 12);
 
 const AI_ROUTE_PREFIXES = [
-  // Both /api/agents/actions (runActionAgent) and /api/agents/dispatch invoke an
-  // LLM per request, so both must fail closed on a limiter outage. The sibling
-  // /api/agents/status is a cheap GET and is intentionally left off (fails open).
+  // Routes that reach an AI provider and so get the tighter AI rate-limit tier.
+  // On a limiter outage the *outage* fail-open/closed decision is per-request:
+  // writes here (and a couple of paid GETs) fail CLOSED, while the cheap GET
+  // handlers on these prefixes — e.g. GET /api/agents/{actions,dispatch},
+  // /api/pipeline, /api/training/status, /api/video — are status/info reads that
+  // fail OPEN (see CHEAP_AI_GET_ROUTES / isPaidAiRequest below). The sibling
+  // /api/agents/status is not an AI route at all (not listed here) and fails open.
   '/api/agents/actions',
   '/api/agents/dispatch',
   '/api/chat',
@@ -108,25 +112,34 @@ function isAiRoute(pathname: string): boolean {
   return AI_ROUTE_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 }
 
-// AI-prefixed GET endpoints that are NOT cheap reads: each incurs a paid
-// external AI call per request, so they must fail CLOSED on a limiter outage
-// exactly like the writes.
-//   - GET /api/realtime/session  → mints an OpenAI Realtime client secret
-//   - GET /api/video/search      → runs a Gemini embedding of the query
-// Every other GET under an AI prefix (e.g. GET /api/video, GET /api/pipeline,
-// GET /api/training/status, GET /api/agents/{actions,dispatch}) is a cheap
-// status/health/info read and fails OPEN so a Redis outage can't 503 it.
-const PAID_AI_GET_ROUTES = ['/api/realtime/session', '/api/video/search'];
-
-function pathMatches(pathname: string, base: string): boolean {
-  return pathname === base || pathname.startsWith(base + '/');
-}
+// The ONLY AI-prefixed GET/HEAD endpoints verified to make no paid provider
+// call — pure status/health/info reads. These are the sole AI reads allowed to
+// fail OPEN on a limiter outage; every other AI GET/HEAD fails CLOSED by
+// default. Modelling this as a cheap *allowlist* (rather than a paid denylist)
+// makes fail-closed the safe default for the denial-of-wallet boundary: a newly
+// added billable read under an existing AI prefix is protected automatically,
+// instead of silently leaking until someone remembers to denylist it. Matched
+// EXACTLY (not by prefix) so the paid GET /api/video/search is not covered by
+// the cheap /api/video.
+//   cheap  → fail OPEN:   the paths below
+//   paid   → fail CLOSED: GET /api/realtime/session (mints an OpenAI Realtime
+//                         secret), GET /api/video/search (Gemini embedding), and
+//                         any other/unclassified AI GET (safe default)
+const CHEAP_AI_GET_ROUTES = [
+  '/api/agents/actions',
+  '/api/agents/dispatch',
+  '/api/pipeline',
+  '/api/training/status',
+  '/api/video',
+];
 
 /**
- * Is THIS request one that incurs a paid AI provider call, and therefore must
- * fail CLOSED when the rate limiter is unavailable (denial-of-wallet)? True for
- * every write to an AI route, plus the handful of AI GETs that are themselves
- * paid calls. Cheap AI GETs (status/health/info) return false and fail open.
+ * Is THIS request one that incurs (or may incur) a paid AI provider call, and
+ * therefore must fail CLOSED when the rate limiter is unavailable
+ * (denial-of-wallet)? True for every write to an AI route, and for every AI
+ * GET/HEAD except the explicitly-verified cheap reads. Failing closed by default
+ * means an unclassified AI read is protected even before it's allowlisted. Cheap
+ * AI reads and all non-AI routes return false and fail open.
  */
 function isPaidAiRequest(pathname: string, method: string): boolean {
   if (!isAiRoute(pathname)) {
@@ -136,8 +149,8 @@ function isPaidAiRequest(pathname: string, method: string): boolean {
   if (method !== 'GET' && method !== 'HEAD') {
     return true;
   }
-  // A small, explicit allowlist of GETs that are paid calls despite being reads.
-  return PAID_AI_GET_ROUTES.some((base) => pathMatches(pathname, base));
+  // AI reads are paid (fail closed) unless explicitly verified cheap.
+  return !CHEAP_AI_GET_ROUTES.includes(pathname);
 }
 
 function getClientIp(request: NextRequest): string {
@@ -220,10 +233,10 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
   if (!redisClient && process.env.NODE_ENV === 'production' && !prodRedisWarned) {
     console.error(
       '[RateLimit] No Upstash/KV Redis configured in production (checked UPSTASH_REDIS_REST_* and KV_REST_API_*). ' +
-      'Failing CLOSED for requests that incur a paid AI call (all AI-route writes + the paid AI GETs ' +
-      '/api/realtime/session and /api/video/search — denial-of-wallet protection) and OPEN for everything ' +
-      'else (non-AI routes AND cheap AI status/health GETs) so a limiter outage cannot take down the API. ' +
-      'Configure Upstash or Vercel KV for full enforcement. ' +
+      'Failing CLOSED for requests that incur a paid AI call (all AI-route writes + every AI GET except the ' +
+      'verified cheap reads /api/agents/{actions,dispatch}, /api/pipeline, /api/training/status and /api/video — ' +
+      'denial-of-wallet protection) and OPEN for everything else (non-AI routes AND those cheap AI GETs) so a ' +
+      'limiter outage cannot take down the API. Configure Upstash or Vercel KV for full enforcement. ' +
       'See src/proxy.ts and the rate-limit-middleware agent in config/agent_network.json.'
     );
     prodRedisWarned = true;
@@ -256,17 +269,17 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
     resetAt: Math.ceil((Date.now() + WINDOW_SECONDS * 1000) / 1000),
   };
 
-  // Production without a working Redis limiter. Fail CLOSED only for requests
-  // that actually incur a paid AI call — every AI-route write plus the two paid
-  // AI GETs (`GET /api/realtime/session` mints an OpenAI Realtime client secret,
-  // `GET /api/video/search` runs a Gemini embedding). Failing those open would
-  // reopen the denial-of-wallet vector (audit findings #4/#7). Everything else
-  // fails OPEN so a limiter outage can't take the API down: not just non-AI
-  // routes (billing, auth, health, general API) but also cheap AI status/health
-  // GETs (`GET /api/video`, `GET /api/pipeline`, `GET /api/training/status`,
-  // `GET /api/agents/{actions,dispatch}`), which are free reads and so should
-  // stay available during a Redis outage. The emergency override forces open
-  // even for the paid requests.
+  // Production without a working Redis limiter. Fail CLOSED for requests that
+  // incur (or may incur) a paid AI call — every AI-route write, plus every AI
+  // GET/HEAD except the verified cheap reads (`GET /api/video`, `/api/pipeline`,
+  // `/api/training/status`, `/api/agents/{actions,dispatch}`). This covers the
+  // known paid GETs (`/api/realtime/session` mints an OpenAI Realtime secret,
+  // `/api/video/search` runs a Gemini embedding) and, because fail-closed is the
+  // default, any future billable AI read too — failing those open would reopen
+  // the denial-of-wallet vector (audit findings #4/#7). Everything else fails
+  // OPEN so a limiter outage can't take the API down: non-AI routes (billing,
+  // auth, health, general API) and the cheap AI status/health GETs, which are
+  // free reads. The emergency override forces open even for the paid requests.
   if (!expensiveOnOutage || process.env.UVAI_RATE_LIMIT_FAIL_OPEN === '1') {
     if (expensiveOnOutage) {
       console.warn(

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -108,6 +108,38 @@ function isAiRoute(pathname: string): boolean {
   return AI_ROUTE_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 }
 
+// AI-prefixed GET endpoints that are NOT cheap reads: each incurs a paid
+// external AI call per request, so they must fail CLOSED on a limiter outage
+// exactly like the writes.
+//   - GET /api/realtime/session  → mints an OpenAI Realtime client secret
+//   - GET /api/video/search      → runs a Gemini embedding of the query
+// Every other GET under an AI prefix (e.g. GET /api/video, GET /api/pipeline,
+// GET /api/training/status, GET /api/agents/{actions,dispatch}) is a cheap
+// status/health/info read and fails OPEN so a Redis outage can't 503 it.
+const PAID_AI_GET_ROUTES = ['/api/realtime/session', '/api/video/search'];
+
+function pathMatches(pathname: string, base: string): boolean {
+  return pathname === base || pathname.startsWith(base + '/');
+}
+
+/**
+ * Is THIS request one that incurs a paid AI provider call, and therefore must
+ * fail CLOSED when the rate limiter is unavailable (denial-of-wallet)? True for
+ * every write to an AI route, plus the handful of AI GETs that are themselves
+ * paid calls. Cheap AI GETs (status/health/info) return false and fail open.
+ */
+function isPaidAiRequest(pathname: string, method: string): boolean {
+  if (!isAiRoute(pathname)) {
+    return false;
+  }
+  // Writes to an AI route always trigger the paid model call.
+  if (method !== 'GET' && method !== 'HEAD') {
+    return true;
+  }
+  // A small, explicit allowlist of GETs that are paid calls despite being reads.
+  return PAID_AI_GET_ROUTES.some((base) => pathMatches(pathname, base));
+}
+
 function getClientIp(request: NextRequest): string {
   // Prefer x-real-ip: set by Vercel's edge network and not client-controllable.
   const realIp = request.headers.get('x-real-ip');
@@ -179,14 +211,18 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
   const clientIp = getClientIp(request);
   const routeClass = isAiRoute(pathname) ? 'ai' : 'api';
   const key = `${routeClass}:${clientIp}`;
+  // Narrower than routeClass: only requests that actually incur a paid AI call
+  // (all AI writes + the paid AI GETs) fail closed on a limiter outage.
+  const expensiveOnOutage = isPaidAiRequest(pathname, request.method);
 
   const redisClient = await getRedisClient();
 
   if (!redisClient && process.env.NODE_ENV === 'production' && !prodRedisWarned) {
     console.error(
       '[RateLimit] No Upstash/KV Redis configured in production (checked UPSTASH_REDIS_REST_* and KV_REST_API_*). ' +
-      'Failing CLOSED for all AI routes (denial-of-wallet protection — some AI GETs are paid calls) and OPEN for ' +
-      'non-AI routes so a limiter outage cannot take down billing/auth/health. ' +
+      'Failing CLOSED for requests that incur a paid AI call (all AI-route writes + the paid AI GETs ' +
+      '/api/realtime/session and /api/video/search — denial-of-wallet protection) and OPEN for everything ' +
+      'else (non-AI routes AND cheap AI status/health GETs) so a limiter outage cannot take down the API. ' +
       'Configure Upstash or Vercel KV for full enforcement. ' +
       'See src/proxy.ts and the rate-limit-middleware agent in config/agent_network.json.'
     );
@@ -220,28 +256,28 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
     resetAt: Math.ceil((Date.now() + WINDOW_SECONDS * 1000) / 1000),
   };
 
-  // Production without a working Redis limiter. Fail CLOSED for ALL AI-prefixed
-  // routes regardless of HTTP method. A method-based "GETs are cheap" heuristic
-  // is unsafe here: several AI GETs are themselves paid calls — e.g.
-  // `GET /api/realtime/session` mints an OpenAI Realtime client secret and
-  // `GET /api/video/search` runs a Gemini embedding — so failing GETs open would
-  // reopen the denial-of-wallet vector (audit findings #4/#7). Non-AI routes
-  // (billing, auth, health, general API) still fail OPEN so a limiter outage
-  // can't take the whole API down. The accepted trade-off is that cheap AI
-  // status GETs (e.g. `GET /api/video`, `GET /api/pipeline`) briefly 503 during
-  // a Redis outage — strictly safer than leaking unmetered paid calls. The
-  // emergency override forces open even for AI routes.
-  if (routeClass !== 'ai' || process.env.UVAI_RATE_LIMIT_FAIL_OPEN === '1') {
-    if (routeClass === 'ai') {
+  // Production without a working Redis limiter. Fail CLOSED only for requests
+  // that actually incur a paid AI call — every AI-route write plus the two paid
+  // AI GETs (`GET /api/realtime/session` mints an OpenAI Realtime client secret,
+  // `GET /api/video/search` runs a Gemini embedding). Failing those open would
+  // reopen the denial-of-wallet vector (audit findings #4/#7). Everything else
+  // fails OPEN so a limiter outage can't take the API down: not just non-AI
+  // routes (billing, auth, health, general API) but also cheap AI status/health
+  // GETs (`GET /api/video`, `GET /api/pipeline`, `GET /api/training/status`,
+  // `GET /api/agents/{actions,dispatch}`), which are free reads and so should
+  // stay available during a Redis outage. The emergency override forces open
+  // even for the paid requests.
+  if (!expensiveOnOutage || process.env.UVAI_RATE_LIMIT_FAIL_OPEN === '1') {
+    if (expensiveOnOutage) {
       console.warn(
-        '[RateLimit] UVAI_RATE_LIMIT_FAIL_OPEN=1 — production AI rate limit failing open (emergency).',
+        '[RateLimit] UVAI_RATE_LIMIT_FAIL_OPEN=1 — production paid-AI rate limit failing open (emergency).',
       );
     }
     return allowResult;
   }
 
-  // AI route, no Redis, no override: deny. This is a limiter *outage*, not a
-  // genuine per-client overage, so it surfaces as 503 (see proxy handler).
+  // Paid AI request, no Redis, no override: deny. This is a limiter *outage*,
+  // not a genuine per-client overage, so it surfaces as 503 (see proxy handler).
   return {
     allowed: false,
     limit,

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -16,7 +16,9 @@ const GENERAL_LIMIT = Number(process.env.UVAI_API_RATE_LIMIT_PER_MINUTE || 60);
 const AI_LIMIT = Number(process.env.UVAI_AI_RATE_LIMIT_PER_MINUTE || 12);
 
 const AI_ROUTE_PREFIXES = [
-  // Routes that reach an AI provider and so get the tighter AI rate-limit tier.
+  // AI-related route prefixes: their writes and paid GETs reach an AI provider,
+  // so the whole prefix gets the tighter AI rate-limit tier (some GET handlers
+  // under these prefixes are cheap status/info reads that reach no provider).
   // On a limiter outage the *outage* fail-open/closed decision is per-request:
   // writes here (and a couple of paid GETs) fail CLOSED, while the cheap GET
   // handlers on these prefixes — e.g. GET /api/agents/{actions,dispatch},
@@ -120,7 +122,10 @@ function isAiRoute(pathname: string): boolean {
 // added billable read under an existing AI prefix is protected automatically,
 // instead of silently leaking until someone remembers to denylist it. Matched
 // EXACTLY (not by prefix) so the paid GET /api/video/search is not covered by
-// the cheap /api/video.
+// the cheap /api/video. Consequence for maintainers: a NEW cheap GET sub-route
+// under an existing AI prefix (e.g. a hypothetical GET /api/pipeline/info) fails
+// closed on an outage until it is added here — the safe default; add verified
+// cheap reads to this list to restore fail-open for them.
 //   cheap  → fail OPEN:   the paths below
 //   paid   → fail CLOSED: GET /api/realtime/session (mints an OpenAI Realtime
 //                         secret), GET /api/video/search (Gemini embedding), and
@@ -237,7 +242,7 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
       'verified cheap reads /api/agents/{actions,dispatch}, /api/pipeline, /api/training/status and /api/video — ' +
       'denial-of-wallet protection) and OPEN for everything else (non-AI routes AND those cheap AI GETs) so a ' +
       'limiter outage cannot take down the API. Configure Upstash or Vercel KV for full enforcement. ' +
-      'See src/proxy.ts and the rate-limit-middleware agent in config/agent_network.json.'
+      'See apps/web/src/proxy.ts and the rate-limit-middleware agent in config/agent_network.json.'
     );
     prodRedisWarned = true;
   }


### PR DESCRIPTION
## Relationship to #658

This branch (`claude/determined-maxwell-p6cak6`) shares #658's base commit and **adds the review remediations that landed on #658**, so it supersedes #658. The fix commits could not be pushed to #658's branch (`claude/determined-maxwell-9y2xuy`) because this session is scoped to develop only on `claude/determined-maxwell-p6cak6`. **Recommend closing #658 in favour of this PR** (or cherry-picking commit `8e9bbf2` onto #658's branch if you'd rather keep #658).

## Background

Follow-up chain #655 → #658. #655 made the rate limiter fail **closed** for every AI route during a Redis/KV outage (denial-of-wallet). #658 refined that so cheap AI status/health GETs stay up while paid AI calls still fail closed. This PR is #658 **plus** the fixes for the review findings that #658 received from Copilot, CodeRabbit, and Devin.

## What changed on top of #658

`apps/web/src/proxy.ts` — **invert the paid-GET denylist to a cheap-read allowlist** (Copilot finding, proxy.ts:119):

- The previous `PAID_AI_GET_ROUTES` *denylist* made every unlisted AI `GET`/`HEAD` fail **open**. A newly added billable read under an existing AI prefix would then silently bypass the denial-of-wallet boundary until someone remembered to denylist it — an unsafe default for a security boundary.
- Replaced with `CHEAP_AI_GET_ROUTES`, an explicit allowlist of the five **verified** cheap reads: `/api/agents/actions`, `/api/agents/dispatch`, `/api/pipeline`, `/api/training/status`, `/api/video`. Every other AI `GET`/`HEAD` now fails **closed by default**.
- Matched **exactly** (not by prefix) so the paid `/api/video/search` is not covered by the cheap `/api/video`.
- **Zero behaviour change for any existing route** — every currently-known cheap GET is still allowlisted (fails open) and both paid GETs (`/api/realtime/session`, `/api/video/search`) still fail closed. Only the default for *hypothetical future/unclassified* AI GETs flips open→closed, which is the safe direction.

Comment/warning corrections (Copilot + Devin, proxy.ts:19-21):

- The `AI_ROUTE_PREFIXES` header comment still claimed `/api/agents/{actions,dispatch}` "must fail closed", contradicting the new fail-open-for-cheap-GETs behaviour. Rewritten to distinguish paid writes/GETs from cheap GETs. The production warning string and the outage-decision comment block were updated to match the allowlist semantics.
- Removed the now-unused `pathMatches` helper.

`apps/web/src/proxy.test.ts` (Devin):

- Added `/api/agents/actions` to the cheap-fail-open loop for parity with the documented cheap set.
- Added a test asserting an **unclassified AI GET** (`GET /api/transcribe`) fails **closed**, locking in the safe default introduced by the inversion.

## Route classification (verified against handlers)

| AI GET route | Cost | Outage behaviour |
|---|---|---|
| `/api/agents/actions`, `/api/agents/dispatch`, `/api/pipeline`, `/api/training/status`, `/api/video` | cheap (status/info/health) | fail **open** |
| `/api/realtime/session` | paid (OpenAI Realtime secret) | fail **closed** |
| `/api/video/search` | paid (Gemini embedding) | fail **closed** |
| any other/unclassified AI GET | unknown | fail **closed** (safe default) |

## Testing

Proxy suite **10/10 pass**; `tsc --noEmit` 0 errors; `eslint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHfnpJfBwHPNi8tZsDNASC)_