### PR TITLE
fix(web): fail-safe AI outage gate — closed-by-default with a verified cheap-GET allowlist (supersedes #658, #660)

### DIFF
--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -94,14 +94,47 @@ describe('proxy rate limiting — production without a working Redis limiter', (
     clearRedisEnv();
 
     const proxy = await loadProxy();
-    // Some AI GETs are paid calls (embedding / OpenAI Realtime secret), so ALL
-    // AI-prefixed routes fail closed regardless of method — a method-based
-    // "GETs are cheap" rule would leak these during a Redis outage.
+    // A handful of AI GETs are themselves paid calls (Gemini embedding here),
+    // so they fail closed even though they are reads — a blanket "GETs are
+    // cheap" rule would leak these during a Redis outage.
     const res = await proxy(apiRequest('/api/video/search?videoId=x&q=y', 'GET'));
 
     expect(res.status).toBe(503);
     const body = await res.json();
     expect(body.code).toBe('rate_limit_unavailable');
+  });
+
+  it('fails CLOSED for GET /api/realtime/session (mints a paid OpenAI Realtime secret)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    const res = await proxy(apiRequest('/api/realtime/session', 'GET'));
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe('rate_limit_unavailable');
+  });
+
+  it('fails OPEN for cheap AI status/health GETs so a Redis outage cannot 503 them', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    // These are AI-prefixed but incur NO paid AI call — pure status/health/info
+    // reads — so they must stay available during a limiter outage.
+    for (const path of [
+      '/api/pipeline',
+      '/api/training/status',
+      '/api/video',
+      '/api/agents/dispatch',
+    ]) {
+      const res = await proxy(apiRequest(path, 'GET'));
+      expect(res.status, `${path} should fail open`).not.toBe(503);
+      expect(res.status, `${path} should fail open`).not.toBe(429);
+    }
   });
 
   it('fails OPEN for non-AI GET routes (e.g. /api/agents/status)', async () => {

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -124,17 +124,37 @@ describe('proxy rate limiting — production without a working Redis limiter', (
 
     const proxy = await loadProxy();
     // These are AI-prefixed but incur NO paid AI call — pure status/health/info
-    // reads — so they must stay available during a limiter outage.
+    // reads (the full CHEAP_AI_GET_ROUTES allowlist) — so they must stay
+    // available during a limiter outage.
     for (const path of [
+      '/api/agents/actions',
+      '/api/agents/dispatch',
       '/api/pipeline',
       '/api/training/status',
       '/api/video',
-      '/api/agents/dispatch',
     ]) {
       const res = await proxy(apiRequest(path, 'GET'));
       expect(res.status, `${path} should fail open`).not.toBe(503);
       expect(res.status, `${path} should fail open`).not.toBe(429);
     }
+  });
+
+  it('fails CLOSED for an unclassified AI GET (safe default — not on the cheap allowlist)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('UVAI_RATE_LIMIT_FAIL_OPEN', '');
+    clearRedisEnv();
+
+    const proxy = await loadProxy();
+    // An AI-prefixed GET that is NOT an explicitly verified cheap read must fail
+    // closed by default, so a newly added billable AI read can't silently bypass
+    // denial-of-wallet protection just because nobody updated an allowlist.
+    // `/api/transcribe/status` sits under the AI `/api/transcribe` prefix and is
+    // not in CHEAP_AI_GET_ROUTES.
+    const res = await proxy(apiRequest('/api/transcribe/status', 'GET'));
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe('rate_limit_unavailable');
   });
 
   it('fails OPEN for non-AI GET routes (e.g. /api/agents/status)', async () => {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -108,6 +108,38 @@ function isAiRoute(pathname: string): boolean {
   return AI_ROUTE_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 }
 
+// AI-prefixed GET endpoints that are NOT cheap reads: each incurs a paid
+// external AI call per request, so they must fail CLOSED on a limiter outage
+// exactly like the writes.
+//   - GET /api/realtime/session  → mints an OpenAI Realtime client secret
+//   - GET /api/video/search      → runs a Gemini embedding of the query
+// Every other GET under an AI prefix (e.g. GET /api/video, GET /api/pipeline,
+// GET /api/training/status, GET /api/agents/{actions,dispatch}) is a cheap
+// status/health/info read and fails OPEN so a Redis outage can't 503 it.
+const PAID_AI_GET_ROUTES = ['/api/realtime/session', '/api/video/search'];
+
+function pathMatches(pathname: string, base: string): boolean {
+  return pathname === base || pathname.startsWith(base + '/');
+}
+
+/**
+ * Is THIS request one that incurs a paid AI provider call, and therefore must
+ * fail CLOSED when the rate limiter is unavailable (denial-of-wallet)? True for
+ * every write to an AI route, plus the handful of AI GETs that are themselves
+ * paid calls. Cheap AI GETs (status/health/info) return false and fail open.
+ */
+function isPaidAiRequest(pathname: string, method: string): boolean {
+  if (!isAiRoute(pathname)) {
+    return false;
+  }
+  // Writes to an AI route always trigger the paid model call.
+  if (method !== 'GET' && method !== 'HEAD') {
+    return true;
+  }
+  // A small, explicit allowlist of GETs that are paid calls despite being reads.
+  return PAID_AI_GET_ROUTES.some((base) => pathMatches(pathname, base));
+}
+
 function getClientIp(request: NextRequest): string {
   // Prefer x-real-ip: set by Vercel's edge network and not client-controllable.
   const realIp = request.headers.get('x-real-ip');
@@ -179,14 +211,18 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
   const clientIp = getClientIp(request);
   const routeClass = isAiRoute(pathname) ? 'ai' : 'api';
   const key = `${routeClass}:${clientIp}`;
+  // Narrower than routeClass: only requests that actually incur a paid AI call
+  // (all AI writes + the paid AI GETs) fail closed on a limiter outage.
+  const expensiveOnOutage = isPaidAiRequest(pathname, request.method);
 
   const redisClient = await getRedisClient();
 
   if (!redisClient && process.env.NODE_ENV === 'production' && !prodRedisWarned) {
     console.error(
       '[RateLimit] No Upstash/KV Redis configured in production (checked UPSTASH_REDIS_REST_* and KV_REST_API_*). ' +
-      'Failing CLOSED for all AI routes (denial-of-wallet protection — some AI GETs are paid calls) and OPEN for ' +
-      'non-AI routes so a limiter outage cannot take down billing/auth/health. ' +
+      'Failing CLOSED for requests that incur a paid AI call (all AI-route writes + the paid AI GETs ' +
+      '/api/realtime/session and /api/video/search — denial-of-wallet protection) and OPEN for everything ' +
+      'else (non-AI routes AND cheap AI status/health GETs) so a limiter outage cannot take down the API. ' +
       'Configure Upstash or Vercel KV for full enforcement. ' +
       'See src/proxy.ts and the rate-limit-middleware agent in config/agent_network.json.'
     );
@@ -220,28 +256,28 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
     resetAt: Math.ceil((Date.now() + WINDOW_SECONDS * 1000) / 1000),
   };
 
-  // Production without a working Redis limiter. Fail CLOSED for ALL AI-prefixed
-  // routes regardless of HTTP method. A method-based "GETs are cheap" heuristic
-  // is unsafe here: several AI GETs are themselves paid calls — e.g.
-  // `GET /api/realtime/session` mints an OpenAI Realtime client secret and
-  // `GET /api/video/search` runs a Gemini embedding — so failing GETs open would
-  // reopen the denial-of-wallet vector (audit findings #4/#7). Non-AI routes
-  // (billing, auth, health, general API) still fail OPEN so a limiter outage
-  // can't take the whole API down. The accepted trade-off is that cheap AI
-  // status GETs (e.g. `GET /api/video`, `GET /api/pipeline`) briefly 503 during
-  // a Redis outage — strictly safer than leaking unmetered paid calls. The
-  // emergency override forces open even for AI routes.
-  if (routeClass !== 'ai' || process.env.UVAI_RATE_LIMIT_FAIL_OPEN === '1') {
-    if (routeClass === 'ai') {
+  // Production without a working Redis limiter. Fail CLOSED only for requests
+  // that actually incur a paid AI call — every AI-route write plus the two paid
+  // AI GETs (`GET /api/realtime/session` mints an OpenAI Realtime client secret,
+  // `GET /api/video/search` runs a Gemini embedding). Failing those open would
+  // reopen the denial-of-wallet vector (audit findings #4/#7). Everything else
+  // fails OPEN so a limiter outage can't take the API down: not just non-AI
+  // routes (billing, auth, health, general API) but also cheap AI status/health
+  // GETs (`GET /api/video`, `GET /api/pipeline`, `GET /api/training/status`,
+  // `GET /api/agents/{actions,dispatch}`), which are free reads and so should
+  // stay available during a Redis outage. The emergency override forces open
+  // even for the paid requests.
+  if (!expensiveOnOutage || process.env.UVAI_RATE_LIMIT_FAIL_OPEN === '1') {
+    if (expensiveOnOutage) {
       console.warn(
-        '[RateLimit] UVAI_RATE_LIMIT_FAIL_OPEN=1 — production AI rate limit failing open (emergency).',
+        '[RateLimit] UVAI_RATE_LIMIT_FAIL_OPEN=1 — production paid-AI rate limit failing open (emergency).',
       );
     }
     return allowResult;
   }
 
-  // AI route, no Redis, no override: deny. This is a limiter *outage*, not a
-  // genuine per-client overage, so it surfaces as 503 (see proxy handler).
+  // Paid AI request, no Redis, no override: deny. This is a limiter *outage*,
+  // not a genuine per-client overage, so it surfaces as 503 (see proxy handler).
   return {
     allowed: false,
     limit,

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -16,9 +16,11 @@ const GENERAL_LIMIT = Number(process.env.UVAI_API_RATE_LIMIT_PER_MINUTE || 60);
 const AI_LIMIT = Number(process.env.UVAI_AI_RATE_LIMIT_PER_MINUTE || 12);
 
 const AI_ROUTE_PREFIXES = [
-  // Both /api/agents/actions (runActionAgent) and /api/agents/dispatch invoke an
-  // LLM per request, so both must fail closed on a limiter outage. The sibling
-  // /api/agents/status is a cheap GET and is intentionally left off (fails open).
+  // /api/agents/actions (runActionAgent) and /api/agents/dispatch invoke an LLM
+  // on POST, so their writes fail closed on a limiter outage; their GET handlers
+  // are cheap availability probes and fail open (see CHEAP_AI_GET_ROUTES). This
+  // list only selects the tighter AI rate-limit tier + the outage boundary; the
+  // sibling /api/agents/status is not AI-prefixed at all (always fails open).
   '/api/agents/actions',
   '/api/agents/dispatch',
   '/api/chat',
@@ -108,25 +110,36 @@ function isAiRoute(pathname: string): boolean {
   return AI_ROUTE_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 }
 
-// AI-prefixed GET endpoints that are NOT cheap reads: each incurs a paid
-// external AI call per request, so they must fail CLOSED on a limiter outage
-// exactly like the writes.
-//   - GET /api/realtime/session  → mints an OpenAI Realtime client secret
-//   - GET /api/video/search      → runs a Gemini embedding of the query
-// Every other GET under an AI prefix (e.g. GET /api/video, GET /api/pipeline,
-// GET /api/training/status, GET /api/agents/{actions,dispatch}) is a cheap
-// status/health/info read and fails OPEN so a Redis outage can't 503 it.
-const PAID_AI_GET_ROUTES = ['/api/realtime/session', '/api/video/search'];
-
-function pathMatches(pathname: string, base: string): boolean {
-  return pathname === base || pathname.startsWith(base + '/');
-}
+// Explicit allowlist of AI-prefixed GET/HEAD endpoints that are cheap reads —
+// pure status/health/info with NO paid provider call. These are the ONLY AI
+// reads that fail OPEN on a limiter outage; every other AI read fails CLOSED.
+// Verified against each handler:
+//   - GET /api/agents/actions   → returns available tool names (env check)
+//   - GET /api/agents/dispatch  → returns backend availability
+//   - GET /api/pipeline         → backend health + config info
+//   - GET /api/training/status  → reads local training status
+//   - GET /api/video            → backend health / API info
+// Matched EXACTLY (not by prefix): paid sub-routes live under these prefixes —
+// e.g. cheap `/api/video` vs paid `/api/video/search`, cheap `/api/pipeline`
+// vs paid POST `/api/pipeline/stream` — so a prefix match would misclassify
+// them. Anything not in this list is treated as paid and fails closed.
+const CHEAP_AI_GET_ROUTES = [
+  '/api/agents/actions',
+  '/api/agents/dispatch',
+  '/api/pipeline',
+  '/api/training/status',
+  '/api/video',
+];
 
 /**
  * Is THIS request one that incurs a paid AI provider call, and therefore must
- * fail CLOSED when the rate limiter is unavailable (denial-of-wallet)? True for
- * every write to an AI route, plus the handful of AI GETs that are themselves
- * paid calls. Cheap AI GETs (status/health/info) return false and fail open.
+ * fail CLOSED when the rate limiter is unavailable (denial-of-wallet)?
+ *
+ * Fails SAFE by default: every AI-route write is paid, and every AI read is
+ * treated as paid UNLESS it is an explicitly verified cheap read. So a newly
+ * added billable AI GET cannot silently bypass outage protection just because
+ * nobody remembered to update a list — the default is closed, and only the
+ * known-cheap reads are opened. Non-AI routes are never treated as paid.
  */
 function isPaidAiRequest(pathname: string, method: string): boolean {
   if (!isAiRoute(pathname)) {
@@ -136,8 +149,8 @@ function isPaidAiRequest(pathname: string, method: string): boolean {
   if (method !== 'GET' && method !== 'HEAD') {
     return true;
   }
-  // A small, explicit allowlist of GETs that are paid calls despite being reads.
-  return PAID_AI_GET_ROUTES.some((base) => pathMatches(pathname, base));
+  // AI reads: paid by default; only the verified cheap reads fail open.
+  return !CHEAP_AI_GET_ROUTES.includes(pathname);
 }
 
 function getClientIp(request: NextRequest): string {
@@ -220,9 +233,10 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
   if (!redisClient && process.env.NODE_ENV === 'production' && !prodRedisWarned) {
     console.error(
       '[RateLimit] No Upstash/KV Redis configured in production (checked UPSTASH_REDIS_REST_* and KV_REST_API_*). ' +
-      'Failing CLOSED for requests that incur a paid AI call (all AI-route writes + the paid AI GETs ' +
-      '/api/realtime/session and /api/video/search — denial-of-wallet protection) and OPEN for everything ' +
-      'else (non-AI routes AND cheap AI status/health GETs) so a limiter outage cannot take down the API. ' +
+      'Failing CLOSED for requests that incur a paid AI call (all AI-route writes + all AI reads except ' +
+      'the explicitly verified cheap GETs in CHEAP_AI_GET_ROUTES — denial-of-wallet protection, safe by ' +
+      'default) and OPEN for everything else (non-AI routes AND cheap AI status/health GETs) so a limiter ' +
+      'outage cannot take down the API. ' +
       'Configure Upstash or Vercel KV for full enforcement. ' +
       'See src/proxy.ts and the rate-limit-middleware agent in config/agent_network.json.'
     );
@@ -256,17 +270,18 @@ async function checkRateLimit(request: NextRequest): Promise<RateLimitResult> {
     resetAt: Math.ceil((Date.now() + WINDOW_SECONDS * 1000) / 1000),
   };
 
-  // Production without a working Redis limiter. Fail CLOSED only for requests
-  // that actually incur a paid AI call — every AI-route write plus the two paid
-  // AI GETs (`GET /api/realtime/session` mints an OpenAI Realtime client secret,
-  // `GET /api/video/search` runs a Gemini embedding). Failing those open would
-  // reopen the denial-of-wallet vector (audit findings #4/#7). Everything else
-  // fails OPEN so a limiter outage can't take the API down: not just non-AI
-  // routes (billing, auth, health, general API) but also cheap AI status/health
-  // GETs (`GET /api/video`, `GET /api/pipeline`, `GET /api/training/status`,
-  // `GET /api/agents/{actions,dispatch}`), which are free reads and so should
-  // stay available during a Redis outage. The emergency override forces open
-  // even for the paid requests.
+  // Production without a working Redis limiter. Fail CLOSED for every request
+  // that incurs a paid AI call — every AI-route write, plus every AI read that
+  // is not an explicitly verified cheap GET (safe by default: an unclassified
+  // AI read fails closed, so e.g. `GET /api/realtime/session` (mints an OpenAI
+  // Realtime secret) and `GET /api/video/search` (Gemini embedding) are covered
+  // without needing a denylist, and a future billable AI GET can't leak by
+  // omission). Failing those open would reopen the denial-of-wallet vector
+  // (audit findings #4/#7). Everything else fails OPEN so a limiter outage can't
+  // take the API down: non-AI routes (billing, auth, health, general API) AND
+  // the cheap AI status/health GETs in CHEAP_AI_GET_ROUTES, which are free reads
+  // that should stay available during a Redis outage. The emergency override
+  // forces open even for the paid requests.
   if (!expensiveOnOutage || process.env.UVAI_RATE_LIMIT_FAIL_OPEN === '1') {
     if (expensiveOnOutage) {
       console.warn(


### PR DESCRIPTION
## Summary

Resolves the review back-and-forth across #655 → #658 → #660 on how the proxy rate limiter should behave when Redis is unavailable in production. This PR replaces the binary heuristics both prior PRs used with a **fail-safe, closed-by-default** rule keyed on whether a request actually incurs a paid AI provider call.

**Intended to supersede #658 (fail-open for AI GETs) and #660 (fail-closed by default).** It keeps #660's safe default *and* #658's availability for genuinely cheap reads, without either one's failure mode.

## The rule

New `isPaidAiRequest(pathname, method)` in `apps/web/src/proxy.ts`:

- Non-AI routes → never treated as paid → **fail OPEN** (a limiter outage can't take down billing/auth/health/general API).
- AI-route **writes** → always paid → **fail CLOSED**.
- AI-route **reads** → **paid by default (fail CLOSED)**, opened only for an explicit, per-handler-verified `CHEAP_AI_GET_ROUTES` allowlist matched **exactly** (not by prefix, so paid sub-routes like `/api/video/search` and `/api/realtime/session` can't slip through).

Safe by default: a newly added billable AI GET fails closed until someone deliberately adds it to the allowlist — it can't leak unmetered paid calls by omission. This closes denial-of-wallet audit findings #4/#7 while restoring availability for the free status/health reads that #660 would have 503'd during an outage.

## Changes

- `apps/web/src/proxy.ts` — add `CHEAP_AI_GET_ROUTES` + `isPaidAiRequest()`, drive the outage branch off `expensiveOnOutage` instead of the coarse `routeClass === 'ai'`, and update the operator log line + comments to match.
- `apps/web/src/proxy.test.ts` — add coverage: paid AI GET fails closed (`/api/realtime/session`), cheap AI GETs fail open (full allowlist), unclassified AI GET fails closed by default (`/api/transcribe/status`).

## Testing

```
npx vitest run src/proxy.test.ts   # 10 passed (10)
```

All existing proxy tests plus the 3 new outage-boundary cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZCTS9zeQUpb1vJcKD42to)_