### PR TITLE
fix(ai-sdk): anchor Gemini retry status parsing + cover audit measurement window

### DIFF
--- a/scripts/nightly_audit_agent.py
+++ b/scripts/nightly_audit_agent.py
@@ -57,8 +57,19 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 class AuditAgent:
-    def __init__(self, dry_run: bool = False):
+    def __init__(
+        self,
+        dry_run: bool = False,
+        lookback_hours: int = 72,
+        active_measurement: bool = False,
+        measurement_samples: int = 3,
+        measurement_interval: float = 1.0,
+    ):
         self.dry_run = dry_run
+        self.lookback_hours = lookback_hours
+        self.active_measurement = active_measurement
+        self.measurement_samples = measurement_samples
+        self.measurement_interval = measurement_interval
         self.log_dir = Path("logs")
         self.log_dir.mkdir(exist_ok=True)
         self.report = []
@@ -89,6 +100,9 @@ class AuditAgent:
         self._add_report_header(start_time)
 
         logger.info("Starting Nightly Audit...")
+        self.report.append(f"Analysis lookback: {self.lookback_hours} hours")
+
+        await self._collect_active_measurements()
 
         # 1. Analysis Phase
         await self.analyze_phase()
@@ -115,7 +129,7 @@ class AuditAgent:
         # Check System Health
         await self._check_system_health()
 
-        # Scan Logs for Errors and Status Codes (Last 24h)
+        # Scan Logs for Errors and Status Codes
         await self._scan_logs()
 
         # Check Metrics for Latency
@@ -151,8 +165,30 @@ class AuditAgent:
                 "details": str(e)
             })
 
+    async def _collect_active_measurements(self):
+        """Collect live metric samples before analysis for more accurate output."""
+        if not self.active_measurement or not self.metrics_service:
+            return
+
+        samples = max(1, self.measurement_samples)
+        interval = max(0.0, self.measurement_interval)
+        self.report.append(f"📏 ACTIVE MEASUREMENT: collecting {samples} live samples")
+
+        try:
+            await self.metrics_service.start_collection()
+            for sample_index in range(samples):
+                await self.metrics_service.get_system_metrics()
+                if interval and sample_index < samples - 1:
+                    await asyncio.sleep(interval)
+
+            persist = getattr(self.metrics_service, "_persist_metrics", None)
+            if persist:
+                await persist()
+        finally:
+            await self.metrics_service.stop_collection()
+
     async def _scan_logs(self):
-        """Scan logs for recent critical failures and status codes > 400 (Last 24h)"""
+        """Scan logs for recent critical failures and status codes > 400."""
         error_log_path = self.log_dir / "error_logs.jsonl"
         structured_log_path = self.log_dir / "structured_logs.jsonl"
 
@@ -162,7 +198,7 @@ class AuditAgent:
             logger.warning("No log files found to scan.")
             return
 
-        cutoff_time = datetime.now(timezone.utc) - timedelta(hours=24)
+        cutoff_time = datetime.now(timezone.utc) - timedelta(hours=self.lookback_hours)
         found_issues = []
 
         for log_file in files_to_scan:
@@ -412,9 +448,38 @@ class AuditAgent:
 async def main():
     parser = argparse.ArgumentParser(description="Jules Audit Agent")
     parser.add_argument("--dry-run", action="store_true", help="Simulate remediation actions")
+    parser.add_argument(
+        "--lookback-hours",
+        type=int,
+        default=72,
+        help="Hours of logs and metrics to scan (default: 72)",
+    )
+    parser.add_argument(
+        "--active-measurement",
+        action="store_true",
+        help="Collect live metric samples before analysis",
+    )
+    parser.add_argument(
+        "--measurement-samples",
+        type=int,
+        default=3,
+        help="Number of live metric samples to collect",
+    )
+    parser.add_argument(
+        "--measurement-interval",
+        type=float,
+        default=1.0,
+        help="Seconds between live metric samples",
+    )
     args = parser.parse_args()
 
-    agent = AuditAgent(dry_run=args.dry_run)
+    agent = AuditAgent(
+        dry_run=args.dry_run,
+        lookback_hours=args.lookback_hours,
+        active_measurement=args.active_measurement,
+        measurement_samples=args.measurement_samples,
+        measurement_interval=args.measurement_interval,
+    )
     await agent.run_audit()
 
 if __name__ == "__main__":

--- a/scripts/nightly_audit_agent.py
+++ b/scripts/nightly_audit_agent.py
@@ -19,10 +19,11 @@ import argparse
 import asyncio
 import json
 import logging
+import os
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 try:
     import orjson
@@ -42,7 +43,6 @@ try:
         HealthStatus,
         get_health_monitoring_service,
     )
-    from youtube_extension.backend.services.logging_service import get_logging_service
     from youtube_extension.backend.services.metrics_service import MetricsService
 except ImportError:
     # Print warning but don't fail immediately, allows dry-run in incomplete envs
@@ -55,6 +55,38 @@ logging.basicConfig(
     format='%(asctime)s - [AuditAgent] - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+
+class FallbackActiveMeasurementService:
+    """Minimal active measurement collector used when MetricsService is unavailable."""
+
+    def __init__(self, log_dir: Path):
+        self.log_dir = log_dir
+        self.measurements = []
+
+    async def start_collection(self):
+        self.log_dir.mkdir(exist_ok=True)
+
+    async def stop_collection(self):
+        return None
+
+    async def get_system_metrics(self):
+        load_average = os.getloadavg()[0] if hasattr(os, "getloadavg") else None
+        measurement = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "source": "fallback_active_measurement",
+            "load_average_1m": load_average,
+        }
+        self.measurements.append(measurement)
+        return measurement
+
+    async def _persist_metrics(self):
+        metrics_path = self.log_dir / "active_measurements.jsonl"
+        with open(metrics_path, "a") as f:
+            for measurement in self.measurements:
+                f.write(json.dumps(measurement) + "\n")
+        self.measurements.clear()
+
 
 class AuditAgent:
     def __init__(
@@ -167,8 +199,11 @@ class AuditAgent:
 
     async def _collect_active_measurements(self):
         """Collect live metric samples before analysis for more accurate output."""
-        if not self.active_measurement or not self.metrics_service:
+        if not self.active_measurement:
             return
+
+        if not self.metrics_service:
+            self.metrics_service = FallbackActiveMeasurementService(self.log_dir)
 
         samples = max(1, self.measurement_samples)
         interval = max(0.0, self.measurement_interval)
@@ -206,7 +241,8 @@ class AuditAgent:
                 with open(log_file, 'rb') as f:
                     for line in f:
                         try:
-                            if not line.strip(): continue
+                            if not line.strip():
+                                continue
                             if HAS_ORJSON:
                                 entry = orjson.loads(line)
                             else:
@@ -297,7 +333,7 @@ class AuditAgent:
         except Exception as e:
             logger.error(f"Error analyzing metrics: {e}")
 
-    async def first_principles_analysis(self, issue: Dict[str, Any]):
+    async def first_principles_analysis(self, issue: dict[str, Any]):
         """
         Five Whys Interrogation
         """

--- a/scripts/nightly_audit_agent.py
+++ b/scripts/nightly_audit_agent.py
@@ -55,6 +55,7 @@ logging.basicConfig(
     format='%(asctime)s - [AuditAgent] - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+SUPPORTS_LOAD_AVERAGE = hasattr(os, "getloadavg")
 
 
 class FallbackActiveMeasurementService:
@@ -71,7 +72,7 @@ class FallbackActiveMeasurementService:
         return None
 
     async def get_system_metrics(self):
-        load_average = os.getloadavg()[0] if hasattr(os, "getloadavg") else None
+        load_average = os.getloadavg()[0] if SUPPORTS_LOAD_AVERAGE else None
         measurement = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "source": "fallback_active_measurement",
@@ -80,7 +81,7 @@ class FallbackActiveMeasurementService:
         self.measurements.append(measurement)
         return measurement
 
-    async def _persist_metrics(self):
+    async def persist_metrics(self):
         metrics_path = self.log_dir / "active_measurements.jsonl"
         with open(metrics_path, "a") as f:
             for measurement in self.measurements:
@@ -98,10 +99,10 @@ class AuditAgent:
         measurement_interval: float = 1.0,
     ):
         self.dry_run = dry_run
-        self.lookback_hours = lookback_hours
+        self.lookback_hours = max(1, lookback_hours)
         self.active_measurement = active_measurement
-        self.measurement_samples = measurement_samples
-        self.measurement_interval = measurement_interval
+        self.measurement_samples = max(1, measurement_samples)
+        self.measurement_interval = max(0.0, measurement_interval)
         self.log_dir = Path("logs")
         self.log_dir.mkdir(exist_ok=True)
         self.report = []
@@ -205,8 +206,8 @@ class AuditAgent:
         if not self.metrics_service:
             self.metrics_service = FallbackActiveMeasurementService(self.log_dir)
 
-        samples = max(1, self.measurement_samples)
-        interval = max(0.0, self.measurement_interval)
+        samples = self.measurement_samples
+        interval = self.measurement_interval
         self.report.append(f"📏 ACTIVE MEASUREMENT: collecting {samples} live samples")
 
         try:
@@ -216,7 +217,7 @@ class AuditAgent:
                 if interval and sample_index < samples - 1:
                     await asyncio.sleep(interval)
 
-            persist = getattr(self.metrics_service, "_persist_metrics", None)
+            persist = getattr(self.metrics_service, "persist_metrics", None)
             if persist:
                 await persist()
         finally:

--- a/src/unified_ai_sdk/unified_ai_sdk.py
+++ b/src/unified_ai_sdk/unified_ai_sdk.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
+from collections.abc import Awaitable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Awaitable
+from typing import Any, Callable
 
 from .rate_limiter import ModelProvider, RateLimiter
 
@@ -247,15 +249,23 @@ class UnifiedAISDK:
 
         # General network errors or specific string-based checks for Gemini
         exc_str = str(exc).lower()
+        status_match = re.search(r"(?:^|:\s+)(\d{3})\b", exc_str)
+        if status_match:
+            status_code = int(status_match.group(1))
+            if status_code == 429 or status_code >= 500:
+                return True
+            if 400 <= status_code < 500:
+                return False
+
         if "timeout" in exc_str or "deadline exceeded" in exc_str:
             return True
-        if "rate limit" in exc_str or "429" in exc_str:
+        if "rate limit" in exc_str:
             return True
-        if "internal server error" in exc_str or "500" in exc_str or "503" in exc_str:
+        if "internal server error" in exc_str:
             return True
 
         # Auth and Validation errors should not be retried
-        if any(term in exc_str for term in ["authentication", "unauthorized", "api_key", "invalid_request", "400", "401", "403"]):
+        if any(term in exc_str for term in ["authentication", "unauthorized", "api_key", "invalid_request"]):
             return False
 
         return True

--- a/src/unified_ai_sdk/unified_ai_sdk.py
+++ b/src/unified_ai_sdk/unified_ai_sdk.py
@@ -249,8 +249,12 @@ class UnifiedAISDK:
 
         # General network errors or specific string-based checks for Gemini
         exc_str = str(exc).lower()
-        # Match provider status codes at the message start or after a response prefix.
-        status_match = re.search(r"(?:^|:\s+)(\d{3})\b", exc_str)
+        # Match common status formats like "400 INVALID_ARGUMENT" or
+        # "response: 500" without treating incidental counts as statuses.
+        status_match = re.match(r"\s*(\d{3})\b", exc_str) or re.search(
+            r"\b(?:http(?: status)?|response|status(?:_code)?|code)\s*[:=]\s*(\d{3})\b",
+            exc_str,
+        )
         if status_match:
             status_code = int(status_match.group(1))
             if status_code == 429 or status_code >= 500:

--- a/src/unified_ai_sdk/unified_ai_sdk.py
+++ b/src/unified_ai_sdk/unified_ai_sdk.py
@@ -249,6 +249,7 @@ class UnifiedAISDK:
 
         # General network errors or specific string-based checks for Gemini
         exc_str = str(exc).lower()
+        # Match provider status codes at the message start or after a response prefix.
         status_match = re.search(r"(?:^|:\s+)(\d{3})\b", exc_str)
         if status_match:
             status_code = int(status_match.group(1))

--- a/src/youtube_extension/backend/services/metrics_service.py
+++ b/src/youtube_extension/backend/services/metrics_service.py
@@ -326,6 +326,10 @@ class MetricsService:
         except Exception as e:
             logger.error(f"Failed to persist metrics: {e}")
 
+    async def persist_metrics(self) -> None:
+        """Persist metrics to disk."""
+        await self._persist_metrics()
+
     async def load_persisted_metrics(self) -> bool:
         """
         Load previously persisted metrics.

--- a/tests/unit/test_metrics_service.py
+++ b/tests/unit/test_metrics_service.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import sys
-import time
 import types
-from collections import deque
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -217,6 +215,19 @@ class TestMetricsServiceInit:
         monkeypatch.chdir(tmp_path)
         svc = MetricsService(config={"collection_interval": 30})
         assert svc.collection_interval == 30
+
+
+class TestMetricsServicePersistMetrics:
+    @pytest.mark.asyncio
+    async def test_persist_metrics_writes_metrics_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        svc = MetricsService()
+        await svc.record_metric("audit.active_sample", 1.0)
+
+        await svc.persist_metrics()
+
+        assert svc.metrics_file.exists()
+        assert "audit.active_sample" in svc.metrics_file.read_text()
 
     def test_custom_retention_period(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)

--- a/tests/unit/test_nightly_audit_agent.py
+++ b/tests/unit/test_nightly_audit_agent.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+
+def _load_audit_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    module_path = repo_root / "scripts" / "nightly_audit_agent.py"
+    spec = importlib.util.spec_from_file_location("nightly_audit_agent", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_scan_logs_uses_extended_72_hour_timeframe(tmp_path, monkeypatch):
+    module = _load_audit_module()
+    monkeypatch.chdir(tmp_path)
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    timestamp = (datetime.now(timezone.utc) - timedelta(hours=48)).isoformat()
+    (log_dir / "structured_logs.jsonl").write_text(
+        f'{{"timestamp": "{timestamp}", "status_code": 503, "message": "stale outage"}}\n'
+    )
+
+    agent = module.AuditAgent(dry_run=True)
+    agent.health_service = None
+    await agent._scan_logs()
+
+    assert agent.lookback_hours == 72
+    assert any("stale outage" in issue["description"] for issue in agent.issues)
+
+
+class _RecordingMetricsService:
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+        self.persisted = False
+        self.samples = 0
+
+    async def start_collection(self):
+        self.started = True
+
+    async def stop_collection(self):
+        self.stopped = True
+
+    async def get_system_metrics(self):
+        self.samples += 1
+        return {"timestamp": datetime.now(timezone.utc).isoformat()}
+
+    async def _persist_metrics(self):
+        self.persisted = True
+
+
+@pytest.mark.asyncio
+async def test_run_audit_collects_active_measurements_before_analysis(tmp_path, monkeypatch):
+    module = _load_audit_module()
+    monkeypatch.chdir(tmp_path)
+
+    metrics_service = _RecordingMetricsService()
+    agent = module.AuditAgent(
+        dry_run=True,
+        active_measurement=True,
+        measurement_samples=2,
+        measurement_interval=0,
+    )
+    agent.health_service = None
+    agent.metrics_service = metrics_service
+
+    await agent.run_audit()
+
+    assert metrics_service.started is True
+    assert metrics_service.samples == 2
+    assert metrics_service.persisted is True
+    assert metrics_service.stopped is True

--- a/tests/unit/test_nightly_audit_agent.py
+++ b/tests/unit/test_nightly_audit_agent.py
@@ -78,3 +78,26 @@ async def test_run_audit_collects_active_measurements_before_analysis(tmp_path, 
     assert metrics_service.samples == 2
     assert metrics_service.persisted is True
     assert metrics_service.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_active_measurement_uses_fallback_when_metrics_service_unavailable(
+    tmp_path, monkeypatch
+):
+    module = _load_audit_module()
+    monkeypatch.chdir(tmp_path)
+
+    agent = module.AuditAgent(
+        dry_run=True,
+        active_measurement=True,
+        measurement_samples=2,
+        measurement_interval=0,
+    )
+    agent.metrics_service = None
+
+    await agent._collect_active_measurements()
+
+    metrics_file = tmp_path / "logs" / "active_measurements.jsonl"
+    lines = metrics_file.read_text().strip().splitlines()
+    assert len(lines) == 2
+    assert any("ACTIVE MEASUREMENT" in line for line in agent.report)

--- a/tests/unit/test_nightly_audit_agent.py
+++ b/tests/unit/test_nightly_audit_agent.py
@@ -53,7 +53,7 @@ class _RecordingMetricsService:
         self.samples += 1
         return {"timestamp": datetime.now(timezone.utc).isoformat()}
 
-    async def _persist_metrics(self):
+    async def persist_metrics(self):
         self.persisted = True
 
 

--- a/tests/unit/test_unified_ai_sdk.py
+++ b/tests/unit/test_unified_ai_sdk.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 import unified_ai_sdk.unified_ai_sdk as sdk_mod
 from unified_ai_sdk import AIRequest, ModelProvider, TaskType, UnifiedAISDK
@@ -204,6 +205,18 @@ class TestUnifiedAISDK:
 
         assert result.success is False
         assert result.metadata["attempts"] == 1
+
+    def test_should_retry_rejects_gemini_400_with_incidental_500(self):
+        sdk = UnifiedAISDK({"retry_attempts": 3, "retry_base_delay": 0})
+
+        assert (
+            sdk._should_retry(
+                RuntimeError(
+                    "400 INVALID_ARGUMENT: input token count 500 exceeds model limit"
+                )
+            )
+            is False
+        )
 
     @pytest.mark.asyncio
     async def test_structured_output_support(self):

--- a/tests/unit/test_unified_ai_sdk.py
+++ b/tests/unit/test_unified_ai_sdk.py
@@ -218,6 +218,29 @@ class TestUnifiedAISDK:
             is False
         )
 
+    def test_should_retry_ignores_non_status_colon_numbers(self):
+        sdk = UnifiedAISDK({"retry_attempts": 3, "retry_base_delay": 0})
+
+        assert (
+            sdk._should_retry(
+                RuntimeError("invalid_request: expected 3 items: 503 found")
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "500 INTERNAL: upstream unavailable",
+            "Response: 500 Internal Server Error",
+            "429 RESOURCE_EXHAUSTED: quota exceeded",
+        ],
+    )
+    def test_should_retry_accepts_retryable_status_formats(self, message):
+        sdk = UnifiedAISDK({"retry_attempts": 3, "retry_base_delay": 0})
+
+        assert sdk._should_retry(RuntimeError(message)) is True
+
     @pytest.mark.asyncio
     async def test_structured_output_support(self):
         sdk = UnifiedAISDK({"retry_attempts": 1})


### PR DESCRIPTION
## Summary

Two related reliability fixes with test coverage.

### 1. Gemini retry status matching (`src/unified_ai_sdk/unified_ai_sdk.py`)
The retry classifier previously used naive substring checks (`"400" in exc_str`, `"500" in exc_str`, `"429" in exc_str`). Any incidental number in an exception message (e.g. "processed 500 items", "batch 429") could be misread as an HTTP status and trigger — or suppress — a retry incorrectly. This is the wasteful-4xx-retry class of bug.

Now the classifier anchors on real status formats via regex (leading `NNN` like `400 INVALID_ARGUMENT`, or `http/response/status/code: NNN`) and only then applies retry rules:
- `429` or `>= 500` → retry
- `4xx` (other) → do not retry

Incidental digits no longer flip the retry decision.

### 2. Nightly audit measurement window (`scripts/nightly_audit_agent.py`, `metrics_service.py`)
Keep the audit measurement active across the measurement window and persist measurements so the nightly audit reports complete data.

## Testing
- `pytest tests/unit/test_unified_ai_sdk.py tests/unit/test_nightly_audit_agent.py tests/unit/test_metrics_service.py` → **82 passed**
- `ruff check` on changed files → clean

## Notes
Draft — opened by the scheduled PR runbook. Diff is scoped to 6 files (~288 insertions); the branch is based on `#643` and the PR diff is clean against `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRD3wTRGVuVwpRcF4rHzwZ)_