### PR TITLE
fix(ci): restore apps/web `type-check` script so the build job stops failing on every PR

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint src middleware.ts",
+    "type-check": "tsc --noEmit",
     "test": "vitest run",
     "analyze": "next experimental-analyze --output"
   },


### PR DESCRIPTION
## Summary

The CI `build` job (`.github/workflows/ci.yml`) fails on **every** PR merged against `main` at this step:

```yaml
- name: TypeScript type-check (apps/web)
  run: cd apps/web && npm run type-check
```

because `apps/web/package.json` on `main` has **no `type-check` script**:

```
npm error Missing script: "type-check"
##[error]Process completed with exit code 1.
```

This is a systemic CI regression, not a defect in any individual PR. It surfaced while triaging PR #651 (Python-only MD5→SHA-256), whose `build` check was red purely because of this missing script — the same is true of the rest of the open-PR backlog.

`.github/workflows/AUDIT.md` documents that the `apps/web` type-check step was **added intentionally** ("Added blocking `apps/web` type-check and ESLint steps before the build so CI fails fast on TypeScript or lint regressions"), so the step is correct — it was the `package.json` script that got dropped.

## Change

Restore the one dropped line:

```json
"type-check": "tsc --noEmit"
```

## Verification

- `npm install --legacy-peer-deps` → succeeds (0 vulnerabilities).
- `cd apps/web && npm run type-check` → **`tsc --noEmit` runs and passes cleanly (exit 0)**.

So the fix genuinely unblocks the `build` job rather than just changing the failure mode.

## Scope

- One line in `apps/web/package.json`. No lockfile or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lia1myfwMbkhrmvjFkfnXq)_