### PR TITLE
fix(ci): unblock the PR backlog — add type-check script + resolve committed merge conflict

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint src middleware.ts",
+    "type-check": "tsc --noEmit",
     "test": "vitest run",
     "analyze": "next experimental-analyze --output"
   },

--- a/config/agent_network.json
+++ b/config/agent_network.json
@@ -167,7 +167,6 @@
     },
     {
       "id": "content-generation",
-<<<<<<< HEAD
       "name": "Content Generation Skill",
       "role": "Generate blog/social posts from video transcripts",
       "tools": ["generate_fullstack"],
@@ -228,54 +227,6 @@
       "capabilities": ["ab_testing", "variant_management"],
       "skill_source": "uvai-skills",
       "trigger_events": ["video_uploaded"]
-=======
-      "name": "Content Generation Agent",
-      "role": "Generate blog/social posts from video transcripts",
-      "tools": ["content-generation"],
-      "capabilities": ["content_creation", "social_media_posts", "blog_writing"]
-    },
-    {
-      "id": "seo-optimizer",
-      "name": "SEO Optimizer Agent",
-      "role": "Optimize video titles, descriptions, and tags",
-      "tools": ["seo-optimizer"],
-      "capabilities": ["seo", "metadata_optimization", "keyword_research"]
-    },
-    {
-      "id": "social-scheduler",
-      "name": "Social Scheduler Agent",
-      "role": "Schedule cross-platform social media posts",
-      "tools": ["social-scheduler"],
-      "capabilities": ["social_scheduling", "cross_platform_posting", "automated_posting"]
-    },
-    {
-      "id": "lead-scorer",
-      "name": "Lead Scorer Agent",
-      "role": "Score leads based on engagement signals",
-      "tools": ["lead-scorer"],
-      "capabilities": ["lead_scoring", "engagement_analysis", "sales_intelligence"]
-    },
-    {
-      "id": "email-campaign",
-      "name": "Email Campaign Agent",
-      "role": "Generate and send email sequences",
-      "tools": ["email-campaign"],
-      "capabilities": ["email_marketing", "campaign_automation", "copywriting"]
-    },
-    {
-      "id": "analytics-dashboard",
-      "name": "Analytics Dashboard Agent",
-      "role": "Aggregate metrics into dashboard data",
-      "tools": ["analytics-dashboard"],
-      "capabilities": ["data_aggregation", "dashboard_metrics", "reporting"]
-    },
-    {
-      "id": "ab-testing",
-      "name": "A/B Testing Agent",
-      "role": "Run A/B tests on thumbnails and titles",
-      "tools": ["ab-testing"],
-      "capabilities": ["ab_testing", "experiment_design", "conversion_optimization"]
->>>>>>> origin/main
     }
   ]
 }


### PR DESCRIPTION
## Summary

`main` shipped **two systemic CI failures** that made the required `build` and `test` checks impossible to pass — so every open PR was stuck in `mergeable_state: blocked`. This PR fixes both root causes. Verified locally; no product behavior changes.

## 1. `build` job — missing `type-check` script

The `build` job runs `cd apps/web && npm run type-check` (`.github/workflows/ci.yml:24`), but `apps/web/package.json` defined **no `type-check` script**, so the step failed instantly on every run:

```
npm error Missing script: "type-check"
##[error]Process completed with exit code 1.
```

`AUDIT.md` records this step was added to fail fast on TS regressions — the workflow step landed but the npm script never did (config drift).

**Fix:** add `"type-check": "tsc --noEmit"` to `apps/web/package.json`.
**Verified:** `npm run type-check` → exit 0, 0 errors. CI on this PR confirms the **`build` check now passes** (was red on every PR).

## 2. `test` job — committed merge-conflict markers in `config/agent_network.json`

`config/agent_network.json` shipped to `main` with **unresolved git conflict markers** (`<<<<<<< HEAD` / `=======` / `>>>>>>> origin/main`), making it invalid JSON. `VideoPipelineOrchestrator` loads this file at construction, so parsing blew up the `test` job across the whole backlog:

```
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 170 column 1 (char 6454)
= 2 failed (test_master_roadmap_fixes), 7074 passed, 1 skipped ... =
```

**Fix:** resolved by keeping the **HEAD** side — the GTM skill node definitions from **#641** (*integrate GTM skills from uvai-skills*), which was the intentionally-merged change; the `>>>>>>> origin/main` side was the superseded pre-#641 agent definitions. Both sides share the same array-of-objects structure, and the kept side's `tools` values reference real registered MCP tool names.
**Verified:** the two previously-failing tests now pass locally — `2 passed in 3.49s`.

## ⚠️ Follow-up left for a human decision (not in this PR)

`skills-lock.json` carries a **separate** committed merge conflict whose two sides are **structurally divergent** — HEAD is an object-map (`"content-generation": { ... }`) while `origin/main` is an array (`{ "id": "content-generation", ... }`) — and it's entangled with open PRs **#545** and **#549** (which both reshape `skills-lock.json`). Resolving it is a schema decision, so I've deliberately left it untouched. It is not covered by any test currently on `main`, so it doesn't block CI today, but it should be resolved before #545/#549 land.

## Scope

Two files: `apps/web/package.json` (+1 line), `config/agent_network.json` (conflict markers + superseded side removed). Both changes exist purely to restore green CI on the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)