### PR TITLE
fix(ci): unblock CI queue — resolve committed conflict markers in agent_network.json + add missing web type-check script

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint src middleware.ts",
+    "type-check": "tsc --noEmit",
     "test": "vitest run",
     "analyze": "next experimental-analyze --output"
   },

--- a/config/agent_network.json
+++ b/config/agent_network.json
@@ -167,7 +167,6 @@
     },
     {
       "id": "content-generation",
-<<<<<<< HEAD
       "name": "Content Generation Skill",
       "role": "Generate blog/social posts from video transcripts",
       "tools": ["generate_fullstack"],
@@ -228,54 +227,6 @@
       "capabilities": ["ab_testing", "variant_management"],
       "skill_source": "uvai-skills",
       "trigger_events": ["video_uploaded"]
-=======
-      "name": "Content Generation Agent",
-      "role": "Generate blog/social posts from video transcripts",
-      "tools": ["content-generation"],
-      "capabilities": ["content_creation", "social_media_posts", "blog_writing"]
-    },
-    {
-      "id": "seo-optimizer",
-      "name": "SEO Optimizer Agent",
-      "role": "Optimize video titles, descriptions, and tags",
-      "tools": ["seo-optimizer"],
-      "capabilities": ["seo", "metadata_optimization", "keyword_research"]
-    },
-    {
-      "id": "social-scheduler",
-      "name": "Social Scheduler Agent",
-      "role": "Schedule cross-platform social media posts",
-      "tools": ["social-scheduler"],
-      "capabilities": ["social_scheduling", "cross_platform_posting", "automated_posting"]
-    },
-    {
-      "id": "lead-scorer",
-      "name": "Lead Scorer Agent",
-      "role": "Score leads based on engagement signals",
-      "tools": ["lead-scorer"],
-      "capabilities": ["lead_scoring", "engagement_analysis", "sales_intelligence"]
-    },
-    {
-      "id": "email-campaign",
-      "name": "Email Campaign Agent",
-      "role": "Generate and send email sequences",
-      "tools": ["email-campaign"],
-      "capabilities": ["email_marketing", "campaign_automation", "copywriting"]
-    },
-    {
-      "id": "analytics-dashboard",
-      "name": "Analytics Dashboard Agent",
-      "role": "Aggregate metrics into dashboard data",
-      "tools": ["analytics-dashboard"],
-      "capabilities": ["data_aggregation", "dashboard_metrics", "reporting"]
-    },
-    {
-      "id": "ab-testing",
-      "name": "A/B Testing Agent",
-      "role": "Run A/B tests on thumbnails and titles",
-      "tools": ["ab-testing"],
-      "capabilities": ["ab_testing", "experiment_design", "conversion_optimization"]
->>>>>>> origin/main
     }
   ]
 }


### PR DESCRIPTION
## Why

Two repo-level defects are committed to `main` and fail CI for **every** open PR, so the entire ~29-PR queue is stuck in `blocked` / `dirty` and nothing can reach a mergeable state. This PR fixes the root causes rather than patching each PR individually.

## Root causes & fixes

### 1. `config/agent_network.json` — unresolved merge conflict markers (`test` job)
The file was committed (in `c1fe2ca "initial plan for merge conflict resolution"`) with literal `<<<<<<< HEAD` / `=======` / `>>>>>>> origin/main` markers at lines 170/231/278. `src/agents/mcp_agent_network.py:53` loads it via `json.loads(...)`, so `VideoPipelineOrchestrator()` raised `json.decoder.JSONDecodeError` at init — failing the `test` job:

```
FAILED tests/unit/test_master_roadmap_fixes.py::test_vera_pre_check_gateway_exception_does_not_crash
FAILED tests/unit/test_master_roadmap_fixes.py::test_run_pipeline_resets_results_between_runs
  - json.decoder.JSONDecodeError: Expecting property name ... line 170 column 1 (char 6454)
```

Both conflict sides define the same 7 GTM skill agents. Resolved by keeping the **uvai-skills variant** (`skill_source: "uvai-skills"` + `trigger_events`), which matches the already-merged #641 ("integrate GTM skills from uvai-skills"). Result: valid JSON, 23 agents, 7 uvai-skills nodes, no duplicate ids.

### 2. `apps/web` missing `type-check` script (`build` job)
`.github/workflows/ci.yml` runs `cd apps/web && npm run type-check`, but no such script existed in `apps/web/package.json`, so the step failed with `Missing script: "type-check"` on every commit. Added `"type-check": "tsc --noEmit"` — matching the `AUDIT.md` intent to gate on TypeScript regressions.

## Verification (local)
- `config/agent_network.json` loads via `json.loads` → 23 agents, unique ids ✓
- `cd apps/web && npm run type-check` (`tsc --noEmit`) → exit 0 ✓
- `cd apps/web && npm run lint` → passes (matches green `lint-frontend` job) ✓
- `npm run build:web` (`next build --webpack`) → exit 0, full production build ✓

## Scope
Two files, `+1 / −61`. No behavioral change beyond making the committed config parse and the CI type-check step runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019AS6L2p514P9QbzXjY8DHJ)_