### PR TITLE
fix(ci): unblock the entire PR backlog — resolve invalid agent_network.json + restore apps/web type-check script

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint src middleware.ts",
+    "type-check": "tsc --noEmit",
     "test": "vitest run",
     "analyze": "next experimental-analyze --output"
   },

--- a/config/agent_network.json
+++ b/config/agent_network.json
@@ -167,7 +167,6 @@
     },
     {
       "id": "content-generation",
-<<<<<<< HEAD
       "name": "Content Generation Skill",
       "role": "Generate blog/social posts from video transcripts",
       "tools": ["generate_fullstack"],
@@ -228,54 +227,6 @@
       "capabilities": ["ab_testing", "variant_management"],
       "skill_source": "uvai-skills",
       "trigger_events": ["video_uploaded"]
-=======
-      "name": "Content Generation Agent",
-      "role": "Generate blog/social posts from video transcripts",
-      "tools": ["content-generation"],
-      "capabilities": ["content_creation", "social_media_posts", "blog_writing"]
-    },
-    {
-      "id": "seo-optimizer",
-      "name": "SEO Optimizer Agent",
-      "role": "Optimize video titles, descriptions, and tags",
-      "tools": ["seo-optimizer"],
-      "capabilities": ["seo", "metadata_optimization", "keyword_research"]
-    },
-    {
-      "id": "social-scheduler",
-      "name": "Social Scheduler Agent",
-      "role": "Schedule cross-platform social media posts",
-      "tools": ["social-scheduler"],
-      "capabilities": ["social_scheduling", "cross_platform_posting", "automated_posting"]
-    },
-    {
-      "id": "lead-scorer",
-      "name": "Lead Scorer Agent",
-      "role": "Score leads based on engagement signals",
-      "tools": ["lead-scorer"],
-      "capabilities": ["lead_scoring", "engagement_analysis", "sales_intelligence"]
-    },
-    {
-      "id": "email-campaign",
-      "name": "Email Campaign Agent",
-      "role": "Generate and send email sequences",
-      "tools": ["email-campaign"],
-      "capabilities": ["email_marketing", "campaign_automation", "copywriting"]
-    },
-    {
-      "id": "analytics-dashboard",
-      "name": "Analytics Dashboard Agent",
-      "role": "Aggregate metrics into dashboard data",
-      "tools": ["analytics-dashboard"],
-      "capabilities": ["data_aggregation", "dashboard_metrics", "reporting"]
-    },
-    {
-      "id": "ab-testing",
-      "name": "A/B Testing Agent",
-      "role": "Run A/B tests on thumbnails and titles",
-      "tools": ["ab-testing"],
-      "capabilities": ["ab_testing", "experiment_design", "conversion_optimization"]
->>>>>>> origin/main
     }
   ]
 }


### PR DESCRIPTION
## Summary

`main` has **two independent systemic CI failures** that turn every open PR red for reasons unrelated to the PR's own diff. This branch fixes **both** so it is a single, self-contained unblock.

### 1. `test` job — invalid `config/agent_network.json` (commit `a99cbf1`)

The file on `main` contained **unresolved git merge-conflict markers** (`<<<<<<< HEAD` / `=======` / `>>>>>>> origin/main` at lines 170/231/278), committed via `c1fe2ca`. That makes it invalid JSON, so `AgentNetwork._load_config()` → `json.loads(...)` crashes and `VideoPipelineOrchestrator()` construction raises:

```
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 170 column 1 (char 6454)
FAILED tests/unit/test_master_roadmap_fixes.py::test_vera_pre_check_gateway_exception_does_not_crash
FAILED tests/unit/test_master_roadmap_fixes.py::test_run_pipeline_resets_results_between_runs
= 2 failed, 7074 passed ... =
```

Resolved by keeping the HEAD variant of the seven GTM skill agents, whose `tools` reference actually-registered MCP tools (`generate_fullstack`, `analyze_video`) and which carries the `skill_source` / `trigger_events` metadata. No code consumes the differing fields (`_apply_config` reads only `id`/`name`/`role`/`tools`/`capabilities`), so the resolution is behaviour-preserving. Verified: valid JSON, 23 agents, no duplicate ids.

### 2. `build` job — missing `apps/web` `type-check` script (commit `d0b990e`)

The CI `build` job runs `cd apps/web && npm run type-check`, but `apps/web/package.json` on `main` has no such script:

```
npm error Missing script: "type-check"
```

Restored the one-line `"type-check": "tsc --noEmit"`. Same fix independently verified green on #690 (its `build` job passed with this script present).

## Verification

- `json.load(config/agent_network.json)` → valid; exercised the exact crash site (`json.loads(config.read_text())`): 23 agents, no duplicate ids.
- `apps/web/package.json` → valid; `type-check` script present.
- Two files changed; no dependency or lockfile changes.

## Relationship to other PRs

- Supersedes #690 (which fixes only the `build` blocker). Once this lands, #690 can be closed.
- Unblocks the substantive open-PR backlog (e.g. #649, #651, #571, #606, #689), whose red `test`/`build` checks are caused by these two issues, not their own diffs.