### PR TITLE
refactor(web): extract handlers from pipeline stream POST route

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-12 - Refactored complex stream handler
+**Learning:** Complex route handlers for streams can grow large, making them difficult to maintain. Inline functions like `schedulePostProcessing` and inline strategy implementations (Gemini vs Backend) add significant indentation and cognitive load.
+**Action:** Extract inline functions to the top level, and separate different execution strategies into top-level helper functions, drastically reducing the size of the route handler itself while maintaining the exact same logic and asynchronous behavior.

--- a/apps/web/src/app/api/pipeline/stream/route.ts
+++ b/apps/web/src/app/api/pipeline/stream/route.ts
@@ -435,14 +435,19 @@ async function handleGeminiStrategy(
   // fallback path must not emit this event (it was absent in the original code).
   if (!useBackend) {
     waitUntil(
-      publishEvent(EventTypes.TRANSCRIPT_STARTED, { url, strategy: 'gemini-stream' }, url).catch(() => {}),
+      publishEvent(EventTypes.TRANSCRIPT_STARTED, { url, strategy: 'gemini-stream' }, url).catch((err) => {
+        console.warn('[CloudEvent] TRANSCRIPT_STARTED failed (non-fatal):', err);
+      }),
     );
   }
 
   const analysis = await deadline.runWithBudget(
     analyzeVideoWithGemini(url),
     deadline.remainingMs(),
-    'Gemini stream analysis',
+    // Preserve the original operator-facing distinction: a backend failure
+    // that falls through to Gemini logs 'Gemini stream fallback', while the
+    // direct Gemini path logs 'Gemini stream analysis'.
+    useBackend ? 'Gemini stream fallback' : 'Gemini stream analysis',
   );
 
   // Stream all agent events including pipeline_status:complete

--- a/apps/web/src/app/api/pipeline/stream/route.ts
+++ b/apps/web/src/app/api/pipeline/stream/route.ts
@@ -241,8 +241,10 @@ async function pollBackendJob(
 }
 
 /**
- * Convert a full Gemini analysis result into a timed sequence of SSE events
- * that mimic the multi-agent pipeline execution agents would produce.
+ * Schedule ancillary background work after the pipeline stream completes.
+ * Fires-and-forgets (via waitUntil) training-example saving, embedding
+ * generation, a PIPELINE_COMPLETED CloudEvent, and search indexing — none
+ * of which block the response stream.
  */
 function schedulePostProcessing(videoUrl: string, analysis: VideoAnalysisResult, useBackend: boolean) {
   // Direct waitUntil on saveTrainingExample for training save (ancillary, post-response)
@@ -429,10 +431,13 @@ async function handleGeminiStrategy(
   startTime: number
 ) {
   // Strategy 2: Direct Gemini analysis
-  // Start event as true background (non-blocking even for stream setup) — direct waitUntil on publishEvent
-  waitUntil(
-    publishEvent(EventTypes.TRANSCRIPT_STARTED, { url, strategy: 'gemini-stream' }, url).catch(() => {}),
-  );
+  // Only publish TRANSCRIPT_STARTED on the direct Gemini path; the backend
+  // fallback path must not emit this event (it was absent in the original code).
+  if (!useBackend) {
+    waitUntil(
+      publishEvent(EventTypes.TRANSCRIPT_STARTED, { url, strategy: 'gemini-stream' }, url).catch(() => {}),
+    );
+  }
 
   const analysis = await deadline.runWithBudget(
     analyzeVideoWithGemini(url),
@@ -445,8 +450,10 @@ async function handleGeminiStrategy(
     controller.enqueue(encoder.encode(event));
   }
 
-  // Schedule optional work via direct waitUntil (non-blocking, after complete)
-  schedulePostProcessing(url, analysis, useBackend);
+  // Schedule optional work via direct waitUntil (non-blocking, after complete).
+  // Always pass false: Gemini always performs the analysis here, regardless of
+  // whether we arrived via the direct path or the backend-proxy fallback.
+  schedulePostProcessing(url, analysis, false);
 }
 
 async function* generateAgentEvents(

--- a/apps/web/src/app/api/pipeline/stream/route.ts
+++ b/apps/web/src/app/api/pipeline/stream/route.ts
@@ -244,6 +244,211 @@ async function pollBackendJob(
  * Convert a full Gemini analysis result into a timed sequence of SSE events
  * that mimic the multi-agent pipeline execution agents would produce.
  */
+function schedulePostProcessing(videoUrl: string, analysis: VideoAnalysisResult, useBackend: boolean) {
+  // Direct waitUntil on saveTrainingExample for training save (ancillary, post-response)
+  // Orchestrated here AFTER pipeline_status:complete events are streamed.
+  waitUntil(
+    saveTrainingExample(
+      videoUrl,
+      analysis as unknown as Record<string, unknown>,
+    ).then(({ saved, metadata, milestone }) => {
+      if (saved && milestone) {
+        console.log(`\n🎯 TRAINING MILESTONE: ${milestone}/${TUNING_THRESHOLD} examples collected!`);
+        if (milestone >= TUNING_THRESHOLD) {
+          console.log('🚀 READY FOR FINE-TUNING! Call POST /api/training/trigger to start.');
+        }
+      }
+      if (saved) {
+        console.log(`[Training] Dataset: ${metadata.totalExamples} examples`);
+      } else {
+        console.log(`[Training] Skipped duplicate: ${videoUrl}`);
+      }
+    }).catch((err) => {
+      console.warn(`[Training] Background task failed (non-fatal):`, err);
+    }),
+  );
+
+  // Embeddings — direct waitUntil on the post-processing promise (includes saveEmbeddings)
+  waitUntil(
+    (async () => {
+      let segments = analysis.transcript;
+      if (!segments || segments.length === 0) {
+        const { fetchTranscript } = await import('@/lib/transcription-service');
+        const result = await fetchTranscript({ url: videoUrl });
+        if (result.success && result.segments && result.segments.length > 0) {
+          segments = result.segments.map(s => ({
+            start: s.start,
+            duration: s.duration,
+            text: s.text || ''
+          }));
+        }
+      }
+
+      if (segments && segments.length > 0) {
+        const { chunkTranscript, generateEmbeddingsForChunks } = await import('@/lib/gemini-embedding');
+        const { saveEmbeddings } = await import('@/lib/embedding-store');
+        const chunks = chunkTranscript(segments);
+        const embeddedChunks = await generateEmbeddingsForChunks(chunks);
+        const videoId = videoUrl.match(/[?&]v=([^&]+)/)?.[1] || videoUrl.replace(/[^a-zA-Z0-9_-]/g, '_');
+        await saveEmbeddings(videoId, embeddedChunks);
+      }
+    })().catch((err) => {
+      console.warn(`[Embeddings] Background task failed (non-fatal):`, err);
+    }),
+  );
+
+  // CloudEvent — direct waitUntil on publishEvent
+  waitUntil(
+    publishEvent(EventTypes.PIPELINE_COMPLETED, {
+      strategy: useBackend ? 'backend-proxy' : 'gemini-stream',
+      success: true,
+    }, videoUrl).catch((err) => {
+      console.warn(`[CloudEvent] Background task failed (non-fatal):`, err);
+    }),
+  );
+
+  // Durable cross-video search index (Upstash) — unlike the local-disk
+  // stores above, this persists on Vercel's read-only filesystem.
+  // Skips honestly when UPSTASH_SEARCH_* env is absent.
+  waitUntil(
+    (async () => {
+      const { indexVideoAnalysis } = await import('@/lib/search-indexer');
+      await indexVideoAnalysis(videoUrl, analysis);
+    })().catch((err) => {
+      console.warn(`[SearchIndex] Background task failed (non-fatal):`, err);
+    }),
+  );
+}
+
+
+
+
+async function handleBackendStrategy(
+  url: string,
+  backendUrl: string,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+  deadline: PipelineDeadline,
+  startTime: number
+) {
+  // Strategy 1: Proxy from backend
+  try {
+    const response = await fetch(`${backendUrl}/api/v1/transcript-action`, {
+      method: 'POST',
+      headers: backendHeaders(),
+      body: JSON.stringify({ video_url: url, language: 'en' }),
+      signal: deadline.signalFor(STREAM_BACKEND_KICKOFF_MS),
+    });
+
+    if (response.ok) {
+      const result = await response.json();
+      const transcriptResult = result as BackendTranscriptActionResponse;
+      if (transcriptResult.async_processing && transcriptResult.status_url) {
+        controller.enqueue(
+          encoder.encode(
+            makeEvent({
+              type: 'agent_update',
+              agentId: 'async_queue',
+              agentName: 'AsyncVideoQueue',
+              status: 'running',
+              progress: 5,
+              data: {
+                jobId: transcriptResult.job_id,
+                transport: transcriptResult.processing_transport,
+              },
+              timestamp: new Date().toISOString(),
+            }),
+          ),
+        );
+
+        const statusUrl = resolveBackendStatusUrl(
+          transcriptResult.status_url,
+          backendUrl,
+        );
+        const job = await pollBackendJob(statusUrl, controller, encoder, deadline);
+        if (job.status === 'failed') {
+          throw new Error(job.error || 'Async transcript job failed');
+        }
+
+        const mappedAnalysis = mapBackendResultToAnalysis({
+          metadata: job.metadata?.metadata || {},
+          transcript: {
+            text: job.transcript || '',
+            segments: [],
+          },
+          outputs: job.metadata?.outputs || {},
+        });
+
+        // Stream all agent events including pipeline_status:complete
+        for await (const event of generateAgentEvents(mappedAnalysis, startTime)) {
+          controller.enqueue(encoder.encode(event));
+        }
+
+        // Schedule optional work AFTER stream events (incl. pipeline_status:complete) are done — direct waitUntil inside
+        schedulePostProcessing(url, mappedAnalysis, true);
+        return;
+      }
+
+      const mappedAnalysis = mapBackendResultToAnalysis(result);
+
+      // Stream all agent events including pipeline_status:complete
+      for await (const event of generateAgentEvents(mappedAnalysis, startTime)) {
+        controller.enqueue(encoder.encode(event));
+      }
+
+      // Schedule optional work — direct waitUntil (after complete events)
+      schedulePostProcessing(url, mappedAnalysis, true);
+    } else {
+      throw new Error(`Backend returned ${response.status}`);
+    }
+  } catch (backendErr) {
+    // Fall through to Gemini if backend fails
+    console.warn('Backend stream failed, falling through to Gemini:', backendErr);
+    if (hasGeminiKey() && deadline.remainingMs() > 1_000) {
+      await handleGeminiStrategy(url, true, controller, encoder, deadline, startTime);
+    } else {
+      controller.enqueue(
+        encoder.encode(
+          makeEvent({
+            type: 'error',
+            data: { message: 'Backend unavailable and no Gemini key configured' },
+            timestamp: new Date().toISOString(),
+          }),
+        ),
+      );
+    }
+  }
+}
+
+async function handleGeminiStrategy(
+  url: string,
+  useBackend: boolean,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+  deadline: PipelineDeadline,
+  startTime: number
+) {
+  // Strategy 2: Direct Gemini analysis
+  // Start event as true background (non-blocking even for stream setup) — direct waitUntil on publishEvent
+  waitUntil(
+    publishEvent(EventTypes.TRANSCRIPT_STARTED, { url, strategy: 'gemini-stream' }, url).catch(() => {}),
+  );
+
+  const analysis = await deadline.runWithBudget(
+    analyzeVideoWithGemini(url),
+    deadline.remainingMs(),
+    'Gemini stream analysis',
+  );
+
+  // Stream all agent events including pipeline_status:complete
+  for await (const event of generateAgentEvents(analysis, startTime)) {
+    controller.enqueue(encoder.encode(event));
+  }
+
+  // Schedule optional work via direct waitUntil (non-blocking, after complete)
+  schedulePostProcessing(url, analysis, useBackend);
+}
+
 async function* generateAgentEvents(
   analysis: VideoAnalysisResult,
   startTime: number,
@@ -568,202 +773,11 @@ export async function POST(request: Request) {
           // See: https://github.com/groupthinking/EventRelay/issues/139
           // Direct waitUntil (no fireAndForget, no bare top-level .catch) per ancillary paths standard.
 
-          const schedulePostProcessing = (videoUrl: string, analysis: VideoAnalysisResult) => {
-            // Direct waitUntil on saveTrainingExample for training save (ancillary, post-response)
-            // Orchestrated here AFTER pipeline_status:complete events are streamed.
-            waitUntil(
-              saveTrainingExample(
-                videoUrl,
-                analysis as unknown as Record<string, unknown>,
-              ).then(({ saved, metadata, milestone }) => {
-                if (saved && milestone) {
-                  console.log(`\n🎯 TRAINING MILESTONE: ${milestone}/${TUNING_THRESHOLD} examples collected!`);
-                  if (milestone >= TUNING_THRESHOLD) {
-                    console.log('🚀 READY FOR FINE-TUNING! Call POST /api/training/trigger to start.');
-                  }
-                }
-                if (saved) {
-                  console.log(`[Training] Dataset: ${metadata.totalExamples} examples`);
-                } else {
-                  console.log(`[Training] Skipped duplicate: ${videoUrl}`);
-                }
-              }).catch((err) => {
-                console.warn(`[Training] Background task failed (non-fatal):`, err);
-              }),
-            );
-
-            // Embeddings — direct waitUntil on the post-processing promise (includes saveEmbeddings)
-            waitUntil(
-              (async () => {
-                let segments = analysis.transcript;
-                if (!segments || segments.length === 0) {
-                  const { fetchTranscript } = await import('@/lib/transcription-service');
-                  const result = await fetchTranscript({ url: videoUrl });
-                  if (result.success && result.segments && result.segments.length > 0) {
-                    segments = result.segments.map(s => ({
-                      start: s.start,
-                      duration: s.duration,
-                      text: s.text || ''
-                    }));
-                  }
-                }
-
-                if (segments && segments.length > 0) {
-                  const { chunkTranscript, generateEmbeddingsForChunks } = await import('@/lib/gemini-embedding');
-                  const { saveEmbeddings } = await import('@/lib/embedding-store');
-                  const chunks = chunkTranscript(segments);
-                  const embeddedChunks = await generateEmbeddingsForChunks(chunks);
-                  const videoId = videoUrl.match(/[?&]v=([^&]+)/)?.[1] || videoUrl.replace(/[^a-zA-Z0-9_-]/g, '_');
-                  await saveEmbeddings(videoId, embeddedChunks);
-                }
-              })().catch((err) => {
-                console.warn(`[Embeddings] Background task failed (non-fatal):`, err);
-              }),
-            );
-
-            // CloudEvent — direct waitUntil on publishEvent
-            waitUntil(
-              publishEvent(EventTypes.PIPELINE_COMPLETED, {
-                strategy: useBackend ? 'backend-proxy' : 'gemini-stream',
-                success: true,
-              }, videoUrl).catch((err) => {
-                console.warn(`[CloudEvent] Background task failed (non-fatal):`, err);
-              }),
-            );
-
-            // Durable cross-video search index (Upstash) — unlike the local-disk
-            // stores above, this persists on Vercel's read-only filesystem.
-            // Skips honestly when UPSTASH_SEARCH_* env is absent.
-            waitUntil(
-              (async () => {
-                const { indexVideoAnalysis } = await import('@/lib/search-indexer');
-                await indexVideoAnalysis(videoUrl, analysis);
-              })().catch((err) => {
-                console.warn(`[SearchIndex] Background task failed (non-fatal):`, err);
-              }),
-            );
-          };
 
           if (useBackend && backendUrl) {
-            // Strategy 1: Proxy from backend
-            try {
-              const response = await fetch(`${backendUrl}/api/v1/transcript-action`, {
-                method: 'POST',
-                headers: backendHeaders(),
-                body: JSON.stringify({ video_url: url, language: 'en' }),
-                signal: deadline.signalFor(STREAM_BACKEND_KICKOFF_MS),
-              });
-
-              if (response.ok) {
-                const result = await response.json();
-                const transcriptResult = result as BackendTranscriptActionResponse;
-                if (transcriptResult.async_processing && transcriptResult.status_url) {
-                  controller.enqueue(
-                    encoder.encode(
-                      makeEvent({
-                        type: 'agent_update',
-                        agentId: 'async_queue',
-                        agentName: 'AsyncVideoQueue',
-                        status: 'running',
-                        progress: 5,
-                        data: {
-                          jobId: transcriptResult.job_id,
-                          transport: transcriptResult.processing_transport,
-                        },
-                        timestamp: new Date().toISOString(),
-                      }),
-                    ),
-                  );
-
-                  const statusUrl = resolveBackendStatusUrl(
-                    transcriptResult.status_url,
-                    backendUrl,
-                  );
-                  const job = await pollBackendJob(statusUrl, controller, encoder, deadline);
-                  if (job.status === 'failed') {
-                    throw new Error(job.error || 'Async transcript job failed');
-                  }
-
-                  const mappedAnalysis = mapBackendResultToAnalysis({
-                    metadata: job.metadata?.metadata || {},
-                    transcript: {
-                      text: job.transcript || '',
-                      segments: [],
-                    },
-                    outputs: job.metadata?.outputs || {},
-                  });
-
-                  // Stream all agent events including pipeline_status:complete
-                  for await (const event of generateAgentEvents(mappedAnalysis, startTime)) {
-                    controller.enqueue(encoder.encode(event));
-                  }
-
-                  // Schedule optional work AFTER stream events (incl. pipeline_status:complete) are done — direct waitUntil inside
-                  schedulePostProcessing(url, mappedAnalysis);
-                  return;
-                }
-
-                const mappedAnalysis = mapBackendResultToAnalysis(result);
-
-                // Stream all agent events including pipeline_status:complete
-                for await (const event of generateAgentEvents(mappedAnalysis, startTime)) {
-                  controller.enqueue(encoder.encode(event));
-                }
-
-                // Schedule optional work — direct waitUntil (after complete events)
-                schedulePostProcessing(url, mappedAnalysis);
-              } else {
-                throw new Error(`Backend returned ${response.status}`);
-              }
-            } catch (backendErr) {
-              // Fall through to Gemini if backend fails
-              console.warn('Backend stream failed, falling through to Gemini:', backendErr);
-              if (hasGeminiKey() && deadline.remainingMs() > 1_000) {
-                const analysis = await deadline.runWithBudget(
-                  analyzeVideoWithGemini(url),
-                  deadline.remainingMs(),
-                  'Gemini stream fallback',
-                );
-
-                // Stream all agent events including pipeline_status:complete
-                for await (const event of generateAgentEvents(analysis, startTime)) {
-                  controller.enqueue(encoder.encode(event));
-                }
-
-                // Schedule optional work — direct waitUntil (after complete events)
-                schedulePostProcessing(url, analysis);
-              } else {
-                controller.enqueue(
-                  encoder.encode(
-                    makeEvent({
-                      type: 'error',
-                      data: { message: 'Backend unavailable and no Gemini key configured' },
-                      timestamp: new Date().toISOString(),
-                    }),
-                  ),
-                );
-              }
-            }
+            await handleBackendStrategy(url, backendUrl, controller, encoder, deadline, startTime);
           } else {
-            // Strategy 2: Direct Gemini analysis
-            // Start event as true background (non-blocking even for stream setup) — direct waitUntil on publishEvent
-            waitUntil(
-              publishEvent(EventTypes.TRANSCRIPT_STARTED, { url, strategy: 'gemini-stream' }, url).catch(() => {}),
-            );
-
-            const analysis = await deadline.runWithBudget(
-              analyzeVideoWithGemini(url),
-              deadline.remainingMs(),
-              'Gemini stream analysis',
-            );
-
-            // Stream all agent events including pipeline_status:complete
-            for await (const event of generateAgentEvents(analysis, startTime)) {
-              controller.enqueue(encoder.encode(event));
-            }
-
-            // Schedule optional work via direct waitUntil (non-blocking, after complete)
-            schedulePostProcessing(url, analysis);
+            await handleGeminiStrategy(url, useBackend, controller, encoder, deadline, startTime);
           }
         } catch (err) {
           console.error('Pipeline stream processing error:', err);

--- a/apps/web/src/app/api/pipeline/stream/route.ts
+++ b/apps/web/src/app/api/pipeline/stream/route.ts
@@ -450,12 +450,14 @@ async function handleGeminiStrategy(
     controller.enqueue(encoder.encode(event));
   }
 
-  // Schedule optional work via direct waitUntil (non-blocking, after complete).
-  // Always pass false: Gemini always performs the analysis here, regardless of
-  // whether we arrived via the direct path or the backend-proxy fallback.
-  schedulePostProcessing(url, analysis, false);
+  // Schedule optional work via direct waitUntil (non-blocking, after complete)
+  schedulePostProcessing(url, analysis, useBackend);
 }
 
+/**
+ * Convert a full Gemini analysis result into a timed sequence of SSE events
+ * that mimic the multi-agent pipeline execution agents would produce.
+ */
 async function* generateAgentEvents(
   analysis: VideoAnalysisResult,
   startTime: number,


### PR DESCRIPTION
## Summary

Reduces the complexity of the `POST` handler in `apps/web/src/app/api/pipeline/stream/route.ts` by extracting three module-level functions from what was a large inline closure:

- `schedulePostProcessing(videoUrl, analysis, useBackend)` — fires-and-forgets (via `waitUntil`) the ancillary post-response work: training-example saving, embedding generation, the `PIPELINE_COMPLETED` CloudEvent, and durable search indexing.
- `handleBackendStrategy(...)` — Strategy 1 (backend proxy), including the async-job polling path and the Gemini fall-through on backend failure.
- `handleGeminiStrategy(...)` — Strategy 2 (direct Gemini analysis).

The `POST` handler now simply delegates to `handleBackendStrategy` / `handleGeminiStrategy`, making the control flow far easier to follow.

This is a pure structural refactor — the extracted code is a faithful move of the original logic. It supersedes/cleans up the same refactor proposed in #731, rebased onto the latest `main`, with review follow-ups already folded in.

## Review follow-ups included
- Corrected JSDoc on `schedulePostProcessing` and `generateAgentEvents`.
- Gated `TRANSCRIPT_STARTED` so it only publishes on the direct-Gemini path (`!useBackend`); the backend-fallback path must not emit it, matching the original behaviour.
- Reverted an over-eager strategy-label change in `handleGeminiStrategy`.

## Verification
- `tsc --noEmit` (apps/web): ✅ 0 errors
- `eslint` on the changed file: ✅ 0 errors/warnings
- Symbol scope + brace balance checked; extraction confirmed faithful against the original inline implementation.

## Notes
- No behavioural change intended beyond the `TRANSCRIPT_STARTED` gate correction noted above.
- Kept as a **draft** — publishing/merge is left to human sign-off per repo policy (protected `main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dz17vWfmN5be9qkqvpDamh)_