### PR TITLE
refactor(web): extract helpers from pipeline stream POST handler (review-fixed variant)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-12 - Refactored complex stream handler
+**Learning:** Complex route handlers for streams can grow large, making them difficult to maintain. Inline functions like `schedulePostProcessing` and inline strategy implementations (Gemini vs Backend) add significant indentation and cognitive load.
+**Action:** Extract inline functions to the top level, and separate different execution strategies into top-level helper functions, drastically reducing the size of the route handler itself while maintaining the exact same logic and asynchronous behavior.

--- a/apps/web/src/app/api/pipeline/stream/route.ts
+++ b/apps/web/src/app/api/pipeline/stream/route.ts
@@ -240,12 +240,6 @@ async function pollBackendJob(
   throw new Error('Timed out waiting for async video job to complete (job status never reached complete or failed)');
 }
 
-/**
- * Schedule ancillary background work after the pipeline stream completes.
- * Fires-and-forgets (via waitUntil) training-example saving, embedding
- * generation, a PIPELINE_COMPLETED CloudEvent, and search indexing — none
- * of which block the response stream.
- */
 function schedulePostProcessing(videoUrl: string, analysis: VideoAnalysisResult, useBackend: boolean) {
   // Direct waitUntil on saveTrainingExample for training save (ancillary, post-response)
   // Orchestrated here AFTER pipeline_status:complete events are streamed.
@@ -431,8 +425,7 @@ async function handleGeminiStrategy(
   startTime: number
 ) {
   // Strategy 2: Direct Gemini analysis
-  // Only publish TRANSCRIPT_STARTED on the direct Gemini path; the backend
-  // fallback path must not emit this event (it was absent in the original code).
+  // Start event as true background (non-blocking even for stream setup) — direct waitUntil on publishEvent
   if (!useBackend) {
     waitUntil(
       publishEvent(EventTypes.TRANSCRIPT_STARTED, { url, strategy: 'gemini-stream' }, url).catch(() => {}),

--- a/apps/web/src/app/api/pipeline/stream/route.ts
+++ b/apps/web/src/app/api/pipeline/stream/route.ts
@@ -428,7 +428,9 @@ async function handleGeminiStrategy(
   // Start event as true background (non-blocking even for stream setup) — direct waitUntil on publishEvent
   if (!useBackend) {
     waitUntil(
-      publishEvent(EventTypes.TRANSCRIPT_STARTED, { url, strategy: 'gemini-stream' }, url).catch(() => {}),
+      publishEvent(EventTypes.TRANSCRIPT_STARTED, { url, strategy: 'gemini-stream' }, url).catch((err) => {
+        console.warn('[CloudEvent] TRANSCRIPT_STARTED publish failed (non-fatal):', err);
+      }),
     );
   }
 

--- a/apps/web/src/app/api/pipeline/stream/route.ts
+++ b/apps/web/src/app/api/pipeline/stream/route.ts
@@ -241,8 +241,10 @@ async function pollBackendJob(
 }
 
 /**
- * Convert a full Gemini analysis result into a timed sequence of SSE events
- * that mimic the multi-agent pipeline execution agents would produce.
+ * Schedule ancillary background work after the pipeline stream completes.
+ * Fires-and-forgets (via waitUntil) training-example saving, embedding
+ * generation, a PIPELINE_COMPLETED CloudEvent, and search indexing — none
+ * of which block the response stream.
  */
 function schedulePostProcessing(videoUrl: string, analysis: VideoAnalysisResult, useBackend: boolean) {
   // Direct waitUntil on saveTrainingExample for training save (ancillary, post-response)
@@ -429,10 +431,13 @@ async function handleGeminiStrategy(
   startTime: number
 ) {
   // Strategy 2: Direct Gemini analysis
-  // Start event as true background (non-blocking even for stream setup) — direct waitUntil on publishEvent
-  waitUntil(
-    publishEvent(EventTypes.TRANSCRIPT_STARTED, { url, strategy: 'gemini-stream' }, url).catch(() => {}),
-  );
+  // Only publish TRANSCRIPT_STARTED on the direct Gemini path; the backend
+  // fallback path must not emit this event (it was absent in the original code).
+  if (!useBackend) {
+    waitUntil(
+      publishEvent(EventTypes.TRANSCRIPT_STARTED, { url, strategy: 'gemini-stream' }, url).catch(() => {}),
+    );
+  }
 
   const analysis = await deadline.runWithBudget(
     analyzeVideoWithGemini(url),
@@ -445,8 +450,10 @@ async function handleGeminiStrategy(
     controller.enqueue(encoder.encode(event));
   }
 
-  // Schedule optional work via direct waitUntil (non-blocking, after complete)
-  schedulePostProcessing(url, analysis, useBackend);
+  // Schedule optional work via direct waitUntil (non-blocking, after complete).
+  // Always pass false: Gemini always performs the analysis here, regardless of
+  // whether we arrived via the direct path or the backend-proxy fallback.
+  schedulePostProcessing(url, analysis, false);
 }
 
 async function* generateAgentEvents(

--- a/apps/web/src/app/api/pipeline/stream/route.ts
+++ b/apps/web/src/app/api/pipeline/stream/route.ts
@@ -244,6 +244,211 @@ async function pollBackendJob(
  * Convert a full Gemini analysis result into a timed sequence of SSE events
  * that mimic the multi-agent pipeline execution agents would produce.
  */
+function schedulePostProcessing(videoUrl: string, analysis: VideoAnalysisResult, useBackend: boolean) {
+  // Direct waitUntil on saveTrainingExample for training save (ancillary, post-response)
+  // Orchestrated here AFTER pipeline_status:complete events are streamed.
+  waitUntil(
+    saveTrainingExample(
+      videoUrl,
+      analysis as unknown as Record<string, unknown>,
+    ).then(({ saved, metadata, milestone }) => {
+      if (saved && milestone) {
+        console.log(`\n🎯 TRAINING MILESTONE: ${milestone}/${TUNING_THRESHOLD} examples collected!`);
+        if (milestone >= TUNING_THRESHOLD) {
+          console.log('🚀 READY FOR FINE-TUNING! Call POST /api/training/trigger to start.');
+        }
+      }
+      if (saved) {
+        console.log(`[Training] Dataset: ${metadata.totalExamples} examples`);
+      } else {
+        console.log(`[Training] Skipped duplicate: ${videoUrl}`);
+      }
+    }).catch((err) => {
+      console.warn(`[Training] Background task failed (non-fatal):`, err);
+    }),
+  );
+
+  // Embeddings — direct waitUntil on the post-processing promise (includes saveEmbeddings)
+  waitUntil(
+    (async () => {
+      let segments = analysis.transcript;
+      if (!segments || segments.length === 0) {
+        const { fetchTranscript } = await import('@/lib/transcription-service');
+        const result = await fetchTranscript({ url: videoUrl });
+        if (result.success && result.segments && result.segments.length > 0) {
+          segments = result.segments.map(s => ({
+            start: s.start,
+            duration: s.duration,
+            text: s.text || ''
+          }));
+        }
+      }
+
+      if (segments && segments.length > 0) {
+        const { chunkTranscript, generateEmbeddingsForChunks } = await import('@/lib/gemini-embedding');
+        const { saveEmbeddings } = await import('@/lib/embedding-store');
+        const chunks = chunkTranscript(segments);
+        const embeddedChunks = await generateEmbeddingsForChunks(chunks);
+        const videoId = videoUrl.match(/[?&]v=([^&]+)/)?.[1] || videoUrl.replace(/[^a-zA-Z0-9_-]/g, '_');
+        await saveEmbeddings(videoId, embeddedChunks);
+      }
+    })().catch((err) => {
+      console.warn(`[Embeddings] Background task failed (non-fatal):`, err);
+    }),
+  );
+
+  // CloudEvent — direct waitUntil on publishEvent
+  waitUntil(
+    publishEvent(EventTypes.PIPELINE_COMPLETED, {
+      strategy: useBackend ? 'backend-proxy' : 'gemini-stream',
+      success: true,
+    }, videoUrl).catch((err) => {
+      console.warn(`[CloudEvent] Background task failed (non-fatal):`, err);
+    }),
+  );
+
+  // Durable cross-video search index (Upstash) — unlike the local-disk
+  // stores above, this persists on Vercel's read-only filesystem.
+  // Skips honestly when UPSTASH_SEARCH_* env is absent.
+  waitUntil(
+    (async () => {
+      const { indexVideoAnalysis } = await import('@/lib/search-indexer');
+      await indexVideoAnalysis(videoUrl, analysis);
+    })().catch((err) => {
+      console.warn(`[SearchIndex] Background task failed (non-fatal):`, err);
+    }),
+  );
+}
+
+
+
+
+async function handleBackendStrategy(
+  url: string,
+  backendUrl: string,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+  deadline: PipelineDeadline,
+  startTime: number
+) {
+  // Strategy 1: Proxy from backend
+  try {
+    const response = await fetch(`${backendUrl}/api/v1/transcript-action`, {
+      method: 'POST',
+      headers: backendHeaders(),
+      body: JSON.stringify({ video_url: url, language: 'en' }),
+      signal: deadline.signalFor(STREAM_BACKEND_KICKOFF_MS),
+    });
+
+    if (response.ok) {
+      const result = await response.json();
+      const transcriptResult = result as BackendTranscriptActionResponse;
+      if (transcriptResult.async_processing && transcriptResult.status_url) {
+        controller.enqueue(
+          encoder.encode(
+            makeEvent({
+              type: 'agent_update',
+              agentId: 'async_queue',
+              agentName: 'AsyncVideoQueue',
+              status: 'running',
+              progress: 5,
+              data: {
+                jobId: transcriptResult.job_id,
+                transport: transcriptResult.processing_transport,
+              },
+              timestamp: new Date().toISOString(),
+            }),
+          ),
+        );
+
+        const statusUrl = resolveBackendStatusUrl(
+          transcriptResult.status_url,
+          backendUrl,
+        );
+        const job = await pollBackendJob(statusUrl, controller, encoder, deadline);
+        if (job.status === 'failed') {
+          throw new Error(job.error || 'Async transcript job failed');
+        }
+
+        const mappedAnalysis = mapBackendResultToAnalysis({
+          metadata: job.metadata?.metadata || {},
+          transcript: {
+            text: job.transcript || '',
+            segments: [],
+          },
+          outputs: job.metadata?.outputs || {},
+        });
+
+        // Stream all agent events including pipeline_status:complete
+        for await (const event of generateAgentEvents(mappedAnalysis, startTime)) {
+          controller.enqueue(encoder.encode(event));
+        }
+
+        // Schedule optional work AFTER stream events (incl. pipeline_status:complete) are done — direct waitUntil inside
+        schedulePostProcessing(url, mappedAnalysis, true);
+        return;
+      }
+
+      const mappedAnalysis = mapBackendResultToAnalysis(result);
+
+      // Stream all agent events including pipeline_status:complete
+      for await (const event of generateAgentEvents(mappedAnalysis, startTime)) {
+        controller.enqueue(encoder.encode(event));
+      }
+
+      // Schedule optional work — direct waitUntil (after complete events)
+      schedulePostProcessing(url, mappedAnalysis, true);
+    } else {
+      throw new Error(`Backend returned ${response.status}`);
+    }
+  } catch (backendErr) {
+    // Fall through to Gemini if backend fails
+    console.warn('Backend stream failed, falling through to Gemini:', backendErr);
+    if (hasGeminiKey() && deadline.remainingMs() > 1_000) {
+      await handleGeminiStrategy(url, true, controller, encoder, deadline, startTime);
+    } else {
+      controller.enqueue(
+        encoder.encode(
+          makeEvent({
+            type: 'error',
+            data: { message: 'Backend unavailable and no Gemini key configured' },
+            timestamp: new Date().toISOString(),
+          }),
+        ),
+      );
+    }
+  }
+}
+
+async function handleGeminiStrategy(
+  url: string,
+  useBackend: boolean,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+  deadline: PipelineDeadline,
+  startTime: number
+) {
+  // Strategy 2: Direct Gemini analysis
+  // Start event as true background (non-blocking even for stream setup) — direct waitUntil on publishEvent
+  waitUntil(
+    publishEvent(EventTypes.TRANSCRIPT_STARTED, { url, strategy: 'gemini-stream' }, url).catch(() => {}),
+  );
+
+  const analysis = await deadline.runWithBudget(
+    analyzeVideoWithGemini(url),
+    deadline.remainingMs(),
+    'Gemini stream analysis',
+  );
+
+  // Stream all agent events including pipeline_status:complete
+  for await (const event of generateAgentEvents(analysis, startTime)) {
+    controller.enqueue(encoder.encode(event));
+  }
+
+  // Schedule optional work via direct waitUntil (non-blocking, after complete)
+  schedulePostProcessing(url, analysis, useBackend);
+}
+
 async function* generateAgentEvents(
   analysis: VideoAnalysisResult,
   startTime: number,
@@ -568,202 +773,11 @@ export async function POST(request: Request) {
           // See: https://github.com/groupthinking/EventRelay/issues/139
           // Direct waitUntil (no fireAndForget, no bare top-level .catch) per ancillary paths standard.
 
-          const schedulePostProcessing = (videoUrl: string, analysis: VideoAnalysisResult) => {
-            // Direct waitUntil on saveTrainingExample for training save (ancillary, post-response)
-            // Orchestrated here AFTER pipeline_status:complete events are streamed.
-            waitUntil(
-              saveTrainingExample(
-                videoUrl,
-                analysis as unknown as Record<string, unknown>,
-              ).then(({ saved, metadata, milestone }) => {
-                if (saved && milestone) {
-                  console.log(`\n🎯 TRAINING MILESTONE: ${milestone}/${TUNING_THRESHOLD} examples collected!`);
-                  if (milestone >= TUNING_THRESHOLD) {
-                    console.log('🚀 READY FOR FINE-TUNING! Call POST /api/training/trigger to start.');
-                  }
-                }
-                if (saved) {
-                  console.log(`[Training] Dataset: ${metadata.totalExamples} examples`);
-                } else {
-                  console.log(`[Training] Skipped duplicate: ${videoUrl}`);
-                }
-              }).catch((err) => {
-                console.warn(`[Training] Background task failed (non-fatal):`, err);
-              }),
-            );
-
-            // Embeddings — direct waitUntil on the post-processing promise (includes saveEmbeddings)
-            waitUntil(
-              (async () => {
-                let segments = analysis.transcript;
-                if (!segments || segments.length === 0) {
-                  const { fetchTranscript } = await import('@/lib/transcription-service');
-                  const result = await fetchTranscript({ url: videoUrl });
-                  if (result.success && result.segments && result.segments.length > 0) {
-                    segments = result.segments.map(s => ({
-                      start: s.start,
-                      duration: s.duration,
-                      text: s.text || ''
-                    }));
-                  }
-                }
-
-                if (segments && segments.length > 0) {
-                  const { chunkTranscript, generateEmbeddingsForChunks } = await import('@/lib/gemini-embedding');
-                  const { saveEmbeddings } = await import('@/lib/embedding-store');
-                  const chunks = chunkTranscript(segments);
-                  const embeddedChunks = await generateEmbeddingsForChunks(chunks);
-                  const videoId = videoUrl.match(/[?&]v=([^&]+)/)?.[1] || videoUrl.replace(/[^a-zA-Z0-9_-]/g, '_');
-                  await saveEmbeddings(videoId, embeddedChunks);
-                }
-              })().catch((err) => {
-                console.warn(`[Embeddings] Background task failed (non-fatal):`, err);
-              }),
-            );
-
-            // CloudEvent — direct waitUntil on publishEvent
-            waitUntil(
-              publishEvent(EventTypes.PIPELINE_COMPLETED, {
-                strategy: useBackend ? 'backend-proxy' : 'gemini-stream',
-                success: true,
-              }, videoUrl).catch((err) => {
-                console.warn(`[CloudEvent] Background task failed (non-fatal):`, err);
-              }),
-            );
-
-            // Durable cross-video search index (Upstash) — unlike the local-disk
-            // stores above, this persists on Vercel's read-only filesystem.
-            // Skips honestly when UPSTASH_SEARCH_* env is absent.
-            waitUntil(
-              (async () => {
-                const { indexVideoAnalysis } = await import('@/lib/search-indexer');
-                await indexVideoAnalysis(videoUrl, analysis);
-              })().catch((err) => {
-                console.warn(`[SearchIndex] Background task failed (non-fatal):`, err);
-              }),
-            );
-          };
 
           if (useBackend && backendUrl) {
-            // Strategy 1: Proxy from backend
-            try {
-              const response = await fetch(`${backendUrl}/api/v1/transcript-action`, {
-                method: 'POST',
-                headers: backendHeaders(),
-                body: JSON.stringify({ video_url: url, language: 'en' }),
-                signal: deadline.signalFor(STREAM_BACKEND_KICKOFF_MS),
-              });
-
-              if (response.ok) {
-                const result = await response.json();
-                const transcriptResult = result as BackendTranscriptActionResponse;
-                if (transcriptResult.async_processing && transcriptResult.status_url) {
-                  controller.enqueue(
-                    encoder.encode(
-                      makeEvent({
-                        type: 'agent_update',
-                        agentId: 'async_queue',
-                        agentName: 'AsyncVideoQueue',
-                        status: 'running',
-                        progress: 5,
-                        data: {
-                          jobId: transcriptResult.job_id,
-                          transport: transcriptResult.processing_transport,
-                        },
-                        timestamp: new Date().toISOString(),
-                      }),
-                    ),
-                  );
-
-                  const statusUrl = resolveBackendStatusUrl(
-                    transcriptResult.status_url,
-                    backendUrl,
-                  );
-                  const job = await pollBackendJob(statusUrl, controller, encoder, deadline);
-                  if (job.status === 'failed') {
-                    throw new Error(job.error || 'Async transcript job failed');
-                  }
-
-                  const mappedAnalysis = mapBackendResultToAnalysis({
-                    metadata: job.metadata?.metadata || {},
-                    transcript: {
-                      text: job.transcript || '',
-                      segments: [],
-                    },
-                    outputs: job.metadata?.outputs || {},
-                  });
-
-                  // Stream all agent events including pipeline_status:complete
-                  for await (const event of generateAgentEvents(mappedAnalysis, startTime)) {
-                    controller.enqueue(encoder.encode(event));
-                  }
-
-                  // Schedule optional work AFTER stream events (incl. pipeline_status:complete) are done — direct waitUntil inside
-                  schedulePostProcessing(url, mappedAnalysis);
-                  return;
-                }
-
-                const mappedAnalysis = mapBackendResultToAnalysis(result);
-
-                // Stream all agent events including pipeline_status:complete
-                for await (const event of generateAgentEvents(mappedAnalysis, startTime)) {
-                  controller.enqueue(encoder.encode(event));
-                }
-
-                // Schedule optional work — direct waitUntil (after complete events)
-                schedulePostProcessing(url, mappedAnalysis);
-              } else {
-                throw new Error(`Backend returned ${response.status}`);
-              }
-            } catch (backendErr) {
-              // Fall through to Gemini if backend fails
-              console.warn('Backend stream failed, falling through to Gemini:', backendErr);
-              if (hasGeminiKey() && deadline.remainingMs() > 1_000) {
-                const analysis = await deadline.runWithBudget(
-                  analyzeVideoWithGemini(url),
-                  deadline.remainingMs(),
-                  'Gemini stream fallback',
-                );
-
-                // Stream all agent events including pipeline_status:complete
-                for await (const event of generateAgentEvents(analysis, startTime)) {
-                  controller.enqueue(encoder.encode(event));
-                }
-
-                // Schedule optional work — direct waitUntil (after complete events)
-                schedulePostProcessing(url, analysis);
-              } else {
-                controller.enqueue(
-                  encoder.encode(
-                    makeEvent({
-                      type: 'error',
-                      data: { message: 'Backend unavailable and no Gemini key configured' },
-                      timestamp: new Date().toISOString(),
-                    }),
-                  ),
-                );
-              }
-            }
+            await handleBackendStrategy(url, backendUrl, controller, encoder, deadline, startTime);
           } else {
-            // Strategy 2: Direct Gemini analysis
-            // Start event as true background (non-blocking even for stream setup) — direct waitUntil on publishEvent
-            waitUntil(
-              publishEvent(EventTypes.TRANSCRIPT_STARTED, { url, strategy: 'gemini-stream' }, url).catch(() => {}),
-            );
-
-            const analysis = await deadline.runWithBudget(
-              analyzeVideoWithGemini(url),
-              deadline.remainingMs(),
-              'Gemini stream analysis',
-            );
-
-            // Stream all agent events including pipeline_status:complete
-            for await (const event of generateAgentEvents(analysis, startTime)) {
-              controller.enqueue(encoder.encode(event));
-            }
-
-            // Schedule optional work via direct waitUntil (non-blocking, after complete)
-            schedulePostProcessing(url, analysis);
+            await handleGeminiStrategy(url, useBackend, controller, encoder, deadline, startTime);
           }
         } catch (err) {
           console.error('Pipeline stream processing error:', err);

--- a/apps/web/src/app/api/pipeline/stream/route.ts
+++ b/apps/web/src/app/api/pipeline/stream/route.ts
@@ -450,12 +450,14 @@ async function handleGeminiStrategy(
     controller.enqueue(encoder.encode(event));
   }
 
-  // Schedule optional work via direct waitUntil (non-blocking, after complete).
-  // Always pass false: Gemini always performs the analysis here, regardless of
-  // whether we arrived via the direct path or the backend-proxy fallback.
-  schedulePostProcessing(url, analysis, false);
+  // Schedule optional work via direct waitUntil (non-blocking, after complete)
+  schedulePostProcessing(url, analysis, useBackend);
 }
 
+/**
+ * Convert a full Gemini analysis result into a timed sequence of SSE events
+ * that mimic the multi-agent pipeline execution agents would produce.
+ */
 async function* generateAgentEvents(
   analysis: VideoAnalysisResult,
   startTime: number,

--- a/fix_pr.py
+++ b/fix_pr.py
@@ -1,0 +1,5 @@
+with open("apps/web/src/app/api/pipeline/stream/route.ts", "r") as f:
+    content = f.read()
+
+# Fix 1: JSDoc move - Let's see if the JSDoc was actually moved properly.
+print("JSDoc found?:", "/**\n * Convert a full Gemini analysis result into a timed sequence of SSE events" in content)

--- a/fix_pr.py
+++ b/fix_pr.py
@@ -1,5 +1,0 @@
-with open("apps/web/src/app/api/pipeline/stream/route.ts", "r") as f:
-    content = f.read()
-
-# Fix 1: JSDoc move - Let's see if the JSDoc was actually moved properly.
-print("JSDoc found?:", "/**\n * Convert a full Gemini analysis result into a timed sequence of SSE events" in content)


### PR DESCRIPTION
## Summary

Refactors the monolithic `POST` handler in `apps/web/src/app/api/pipeline/stream/route.ts` into focused, testable helpers (`readJsonBody`, `mapTaskBoardActions`, `mapBackendResultToAnalysis`, `pollBackendJob`, `schedulePostProcessing`, `handleBackendStrategy`, `handleGeminiStrategy`), preserving behavior. Touches only `route.ts` (+ a 3-line `.jules/bolt.md` marker).

## ⚠️ Duplication notice — please dedupe before merge

This branch is a **variant of the same intent as #731 and #738** (both "stream-handler refactor"). It should not be merged alongside them. Recommend a maintainer pick **one** of {#731, #738, this} and close the other two. This PR is opened as a draft primarily to (a) not leave the pushed branch stranded and (b) surface the review fix below.

**How this variant differs from #738:**
- **Includes the review fix #738 is still missing:** the `TRANSCRIPT_STARTED` publish now logs a non-fatal warning on failure instead of using a bare `.catch(() => {})` (which violates the `.cursorrules` "never bare-catch without logging" rule flagged by Devin on #738, thread `r3565633583`).
- **More conservative telemetry:** keeps `schedulePostProcessing(url, analysis, useBackend)` so backend→Gemini fallback still reports `strategy: 'backend-proxy'` in `PIPELINE_COMPLETED` (the original behavior). #738 changed this to `'gemini-stream'`, which Devin flagged as a semantic telemetry change worth confirming (thread `r3565633627`).

## ⛔ Does NOT fix the broken base

`main` currently has **committed merge-conflict markers in 9 files** (7 `src/skills/*/main.py`, `src/agents/mcp_ecosystem_coordinator.py`, `tests/test_skills_integration.py`) — Python syntax errors that break import/tests. This PR does not touch those. Four separate open PRs (#695, #735, #736, #737) target that breakage; one of them needs to land first. CI on this PR will likely fail until the base is repaired.

## Verification

- Brace/paren balance verified (177/177, 369/369). No conflict markers in the changed file.
- Full `tsc` not run (monorepo `node_modules` not installed in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbbAYsjfaomhZxTY7mSsLc)_