### PR TITLE
fix: repair unterminated f-string breaking Python 3.9–3.11 parsing

### DIFF
--- a/src/agents/unified/mcp_a2a_mojo_integration.py
+++ b/src/agents/unified/mcp_a2a_mojo_integration.py
@@ -407,9 +407,9 @@ class IntelligentUnifiedAgent(BaseAgent):
         # Verify SLA compliance
         if transport_result["transport_latency_ms"] > self.sla["max_latency_ms"]:
             print(
-                f"⚠️  SLA violation: {
-                    transport_result['transport_latency_ms']:.2f}ms > {
-                    self.sla['max_latency_ms']}ms"
+                f"⚠️  SLA violation: "
+                f"{transport_result['transport_latency_ms']:.2f}ms > "
+                f"{self.sla['max_latency_ms']}ms"
             )
 
         return {


### PR DESCRIPTION
## Summary

`src/agents/unified/mcp_a2a_mojo_integration.py` had an SLA-violation log line whose f-string placed **newlines inside the `{ ... }` replacement fields**. That syntax is only valid under [PEP 701](https://peps.python.org/pep-0701/) on **Python 3.12+**. This project targets **Python 3.9+** (`pyproject.toml` → `target-version = ['py39', 'py310', 'py311', 'py312']`, and CLAUDE.md "Target Python 3.9+"), so on 3.9–3.11 the file raised:

```
SyntaxError: unterminated string literal (detected at line 410)
```

…at **parse time**, breaking `ast.parse`, `black`, `ruff`, and any import of the module on every supported interpreter below 3.12.

## Why it was masked

- **CI runs on Python 3.12**, where PEP 701 makes the original code valid — so CI never flagged it.
- The consumer test `tests/unit/test_security_fixes.py` imports `validate_agent_identifier` / `sanitize_message_content` from this module inside a broad `except (ImportError, Exception)`, silently swallowing the `SyntaxError` on 3.9–3.11.

The net effect: a declared-supported source file was unparseable on 3 of the 4 supported Python versions, with no signal.

## The fix

Rewrite the f-string using implicit string concatenation with no newlines inside the braces — semantically identical output, valid on all supported interpreters:

```python
print(
    f"⚠️  SLA violation: "
    f"{transport_result['transport_latency_ms']:.2f}ms > "
    f"{self.sla['max_latency_ms']}ms"
)
```

## Verification

- `ast.parse` of the file now succeeds on **Python 3.11** (previously a `SyntaxError`).
- Full-repo scan (`git ls-files '*.py'`) parses **clean on 3.11 — 0 remaining syntax errors**.
- Module compilation past the parse stage confirmed (residual failures in the sandbox are only missing runtime deps like `aiohttp`, unrelated to this change).

## Scope

One-line-equivalent, no behavior change. No API, model, or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JC3ARmbcmrdRxGJ61shnRP)_