### PR TITLE
fix(agents): make SLA-violation f-string valid on Python 3.9–3.11

### DIFF
--- a/src/agents/unified/mcp_a2a_mojo_integration.py
+++ b/src/agents/unified/mcp_a2a_mojo_integration.py
@@ -406,11 +406,9 @@ class IntelligentUnifiedAgent(BaseAgent):
 
         # Verify SLA compliance
         if transport_result["transport_latency_ms"] > self.sla["max_latency_ms"]:
-            print(
-                f"⚠️  SLA violation: {
-                    transport_result['transport_latency_ms']:.2f}ms > {
-                    self.sla['max_latency_ms']}ms"
-            )
+            latency_ms = transport_result["transport_latency_ms"]
+            max_latency = self.sla["max_latency_ms"]
+            print(f"⚠️  SLA violation: {latency_ms:.2f}ms > {max_latency}ms")
 
         return {
             "message_id": a2a_msg.id,


### PR DESCRIPTION
## Summary

`main` currently fails to compile on Python 3.9–3.11. `src/agents/unified/mcp_a2a_mojo_integration.py` (in `IntelligentUnifiedAgent.send()`) contained an f-string with **newlines inside its replacement fields**:

```python
f"⚠️  SLA violation: {
    transport_result['transport_latency_ms']:.2f}ms > {
    self.sla['max_latency_ms']}ms"
```

Multi-line expressions inside f-string replacement fields are only legal on **Python 3.12+** (PEP 701). On the project's declared floor (`requires-python = ">=3.9"`) this raises `SyntaxError: unterminated string literal`, breaking import/compile of the whole module.

It was masked because most CI jobs run on 3.12 — but `verification.yml` and `deploy-cloud-run.yml` run on **Python 3.11**, where this is a hard failure.

## Fix

Hoist the two expressions to locals so the f-string stays single-line and valid across all supported versions. No behavior change.

```python
latency_ms = transport_result["transport_latency_ms"]
max_latency = self.sla["max_latency_ms"]
print(f"⚠️  SLA violation: {latency_ms:.2f}ms > {max_latency}ms")
```

## Verification

- `python -m py_compile` on the file passes (Python 3.11).
- `python -m compileall src/` reports **0 errors** on Python 3.11 (was 1 before).

## Notes

- Diff is intentionally minimal (one call site). The rest of the file is not black-compliant on `main`; I deliberately did **not** include incidental reformatting so the fix stays reviewable.
- Opened as a draft — publishing/merge to protected `main` is left for human sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEa33LfGZKgULnW7aAcYKH)_