### PR TITLE
fix(orchestrator): recover from transient Redis errors during consumer-group setup

### DIFF
--- a/infrastructure/docker/docker-compose.full.yml
+++ b/infrastructure/docker/docker-compose.full.yml
@@ -79,12 +79,14 @@ services:
       context: .
       dockerfile: Dockerfile
     image: youtube-extension-orchestrator:dev
-    command: python -m youtube_extension.backend.services.phase3_integration_test
+    command: python -m youtube_extension.orchestrator.main
     restart: unless-stopped
     environment:
       - APP_ENV=${APP_ENV:-production}
       - DATABASE_URL=${DATABASE_URL}
       - REDIS_URL=redis://redis:6379/1
+      - MESSAGE_QUEUE_URL=redis://redis:6379/1
+      - ORCHESTRATOR_QUEUE_NAME=orchestrator_tasks
       - RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
@@ -293,4 +295,3 @@ volumes:
     driver: local
   loki-data:
     driver: local
-

--- a/infrastructure/docker/docker-compose.full.yml
+++ b/infrastructure/docker/docker-compose.full.yml
@@ -87,13 +87,12 @@ services:
       - REDIS_URL=redis://redis:6379/1
       - MESSAGE_QUEUE_URL=redis://redis:6379/1
       - ORCHESTRATOR_QUEUE_NAME=orchestrator_tasks
-      - RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - GOOGLE_AI_API_KEY=${GOOGLE_AI_API_KEY}
     depends_on:
       - backend
-      - rabbitmq
+      - redis
     networks:
       - uvai-network
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dependencies = [
     "opencv-python>=4.8.0",
     "orjson>=3.9.0",
     "aiohttp>=3.8.0",
+    "redis>=5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,6 +70,7 @@ opencv-python-headless>=5.0.0.93
 asyncio-throttle>=1.0.0
 websockets>=12.0
 gitpython>=3.1.0
+redis>=5.0.0
 
 # Observability (optional - can be removed for minimal builds)
 # ddtrace>=2.1.0

--- a/src/youtube_extension/orchestrator/main.py
+++ b/src/youtube_extension/orchestrator/main.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 import signal
+from urllib.parse import urlparse
 
 try:
     import redis.asyncio as redis
@@ -14,6 +15,18 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger("orchestrator")
+
+
+def redact_url(url: str) -> str:
+    """Redact credentials from URL for safe logging."""
+    try:
+        parsed = urlparse(url)
+        if parsed.password or parsed.username:
+            redacted = parsed._replace(netloc=f"{parsed.username or ''}:***@{parsed.hostname}:{parsed.port or ''}")
+            return redacted.geturl()
+        return url.split('@')[-1] if '@' in url else url
+    except Exception:
+        return "redis://***"
 
 
 async def process(msg):
@@ -30,7 +43,7 @@ async def main():
     In a full production environment, this service would consume messages from
     RabbitMQ or Redis to trigger video processing tasks asynchronously.
 
-    Current Status: Implemented Redis consumer with fallback to Standby mode.
+    Current Status: Implemented Redis Streams consumer with acknowledged delivery.
     """
     logger.info("🚀 Orchestrator Service Starting...")
 
@@ -45,15 +58,27 @@ async def main():
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, signal_handler)
 
-    redis_url = os.getenv("MESSAGE_QUEUE_URL", "redis://localhost:6379")
-    queue_name = os.getenv("ORCHESTRATOR_QUEUE_NAME", "orchestrator_tasks")
+    # Accept REDIS_URL as fallback for deployed environments
+    redis_url = os.getenv("MESSAGE_QUEUE_URL") or os.getenv("REDIS_URL", "redis://localhost:6379")
+    stream_name = os.getenv("ORCHESTRATOR_QUEUE_NAME", "orchestrator_tasks")
+    consumer_group = os.getenv("ORCHESTRATOR_CONSUMER_GROUP", "orchestrator_workers")
+    consumer_name = os.getenv("HOSTNAME", "orchestrator_1")
     redis_client = None
 
     if redis is not None:
         try:
-            # We don't verify connection on initialization as blpop will fail if invalid
             redis_client = redis.from_url(redis_url)
-            logger.info(f"✅ Orchestrator initialized and connected to Redis at {redis_url} (Queue: {queue_name})")
+            # Redact credentials from URL for safe logging
+            safe_url = redact_url(redis_url)
+            logger.info(f"✅ Orchestrator initialized and connected to Redis at {safe_url} (Stream: {stream_name})")
+            
+            # Create consumer group if it doesn't exist (ignore if already exists)
+            try:
+                await redis_client.xgroup_create(stream_name, consumer_group, id='0', mkstream=True)
+                logger.info(f"Created consumer group '{consumer_group}' for stream '{stream_name}'")
+            except Exception as e:
+                # Group already exists, which is fine
+                logger.debug(f"Consumer group setup: {e}")
         except Exception as e:
             logger.error(f"Failed to initialize Redis client: {e}")
             redis_client = None
@@ -65,11 +90,28 @@ async def main():
     while not stop_event.is_set():
         try:
             if redis_client:
-                # Use blpop with a timeout of 1 second so we can check stop_event frequently
-                result = await redis_client.blpop(queue_name, timeout=1)
-                if result:
-                    _, msg = result
-                    await process(msg)
+                # Use Redis Streams with consumer groups for acknowledged delivery
+                # Read with 1 second block timeout so we can check stop_event frequently
+                results = await redis_client.xreadgroup(
+                    consumer_group,
+                    consumer_name,
+                    {stream_name: '>'},
+                    count=1,
+                    block=1000  # 1 second in milliseconds
+                )
+                
+                if results:
+                    for stream, messages in results:
+                        for message_id, data in messages:
+                            try:
+                                # Process the message
+                                await process(data)
+                                # Acknowledge successful processing
+                                await redis_client.xack(stream_name, consumer_group, message_id)
+                                logger.debug(f"Acknowledged message {message_id}")
+                            except Exception as proc_error:
+                                logger.error(f"Failed to process message {message_id}: {proc_error}")
+                                # Message remains unacknowledged and can be reclaimed
             else:
                 # Heartbeat for standby mode
                 await asyncio.sleep(60)

--- a/src/youtube_extension/orchestrator/main.py
+++ b/src/youtube_extension/orchestrator/main.py
@@ -3,12 +3,25 @@ import logging
 import os
 import signal
 
+try:
+    import redis.asyncio as redis
+except ImportError:
+    redis = None
+
 # Configure logging
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger("orchestrator")
+
+
+async def process(msg):
+    """Placeholder processing function"""
+    logger.info(f"Processing message: {msg}")
+    # Simulate processing time
+    await asyncio.sleep(0.1)
+
 
 async def main():
     """
@@ -17,7 +30,7 @@ async def main():
     In a full production environment, this service would consume messages from
     RabbitMQ or Redis to trigger video processing tasks asynchronously.
 
-    Current Status: Placeholder for future async worker implementation.
+    Current Status: Implemented Redis consumer with fallback to Standby mode.
     """
     logger.info("🚀 Orchestrator Service Starting...")
 
@@ -32,22 +45,42 @@ async def main():
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, signal_handler)
 
-    logger.info("✅ Orchestrator initialized and waiting for tasks (Mode: Standby)")
+    redis_url = os.getenv("MESSAGE_QUEUE_URL", "redis://localhost:6379")
+    queue_name = os.getenv("ORCHESTRATOR_QUEUE_NAME", "orchestrator_tasks")
+    redis_client = None
+
+    if redis is not None:
+        try:
+            # We don't verify connection on initialization as blpop will fail if invalid
+            redis_client = redis.from_url(redis_url)
+            logger.info(f"✅ Orchestrator initialized and connected to Redis at {redis_url} (Queue: {queue_name})")
+        except Exception as e:
+            logger.error(f"Failed to initialize Redis client: {e}")
+            redis_client = None
+
+    if redis_client is None:
+        logger.info("✅ Orchestrator initialized and waiting for tasks (Mode: Standby)")
 
     # Main loop
     while not stop_event.is_set():
         try:
-            # TODO: Implement RabbitMQ/Redis consumer here
-            # msg = await queue.get()
-            # process(msg)
-
-            # Heartbeat
-            await asyncio.sleep(60)
-            logger.debug("❤️ Orchestrator heartbeat")
+            if redis_client:
+                # Use blpop with a timeout of 1 second so we can check stop_event frequently
+                result = await redis_client.blpop(queue_name, timeout=1)
+                if result:
+                    _, msg = result
+                    await process(msg)
+            else:
+                # Heartbeat for standby mode
+                await asyncio.sleep(60)
+                logger.debug("❤️ Orchestrator heartbeat")
 
         except Exception as e:
             logger.error(f"Error in orchestrator loop: {e}")
             await asyncio.sleep(5)
+
+    if redis_client:
+        await redis_client.aclose()
 
     logger.info("👋 Orchestrator shutting down")
 

--- a/src/youtube_extension/orchestrator/main.py
+++ b/src/youtube_extension/orchestrator/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
@@ -29,14 +31,23 @@ def redact_url(url: str) -> str:
         return "redis://***"
 
 
-async def process(msg):
-    """Placeholder processing function"""
-    logger.info(f"Processing message: {msg}")
-    # Simulate processing time
-    await asyncio.sleep(0.1)
+async def process(msg: dict) -> None:
+    """Handle a single consumed message.
+
+    No real task handler is wired up yet. Per the REAL_MODE_ONLY policy we must
+    not fake success with a mock delay: raising here leaves the message
+    unacknowledged (retained in the stream's pending list) rather than silently
+    dropping real work behind a stub that immediately gets xack'ed.
+    """
+    logger.info(f"Received message (no handler implemented yet): {msg}")
+    raise NotImplementedError(
+        "Orchestrator task handler is not implemented; message left unacknowledged"
+    )
 
 
-async def ensure_consumer_group(redis_client, stream_name, consumer_group):
+async def ensure_consumer_group(
+    redis_client: redis.Redis, stream_name: str, consumer_group: str
+) -> None:
     """Ensure the Redis Streams consumer group exists.
 
     Only the "already exists" (BUSYGROUP) case is treated as success. Any other
@@ -59,7 +70,7 @@ async def ensure_consumer_group(redis_client, stream_name, consumer_group):
             raise
 
 
-async def main():
+async def main() -> None:
     """
     Main Orchestrator Loop.
 
@@ -74,7 +85,7 @@ async def main():
     loop = asyncio.get_running_loop()
     stop_event = asyncio.Event()
 
-    def signal_handler():
+    def signal_handler() -> None:
         logger.info("🛑 Shutdown signal received")
         stop_event.set()
 
@@ -90,7 +101,15 @@ async def main():
 
     if redis is not None:
         try:
-            redis_client = redis.from_url(redis_url)
+            # Bounded timeouts so a hung/half-open connection surfaces as an
+            # exception (which the loop handles) instead of blocking xreadgroup /
+            # xack / xgroup_create indefinitely. socket_timeout must exceed the
+            # 1s xreadgroup block below.
+            redis_client = redis.from_url(
+                redis_url,
+                socket_connect_timeout=5,
+                socket_timeout=10,
+            )
             # Redact credentials from URL for safe logging
             safe_url = redact_url(redis_url)
             logger.info(f"✅ Orchestrator initialized, connecting to Redis at {safe_url} (Stream: {stream_name})")

--- a/src/youtube_extension/orchestrator/main.py
+++ b/src/youtube_extension/orchestrator/main.py
@@ -36,6 +36,29 @@ async def process(msg):
     await asyncio.sleep(0.1)
 
 
+async def ensure_consumer_group(redis_client, stream_name, consumer_group):
+    """Ensure the Redis Streams consumer group exists.
+
+    Only the "already exists" (BUSYGROUP) case is treated as success. Any other
+    error — most importantly a transient ConnectionError while Redis is still
+    starting up — is re-raised so the caller can retry. Swallowing those errors
+    would leave the group uncreated while the consumer keeps looping, producing a
+    permanent NOGROUP failure that never recovers and never consumes any tasks.
+    """
+    try:
+        await redis_client.xgroup_create(
+            stream_name, consumer_group, id='0', mkstream=True
+        )
+        logger.info(
+            f"Created consumer group '{consumer_group}' for stream '{stream_name}'"
+        )
+    except Exception as e:
+        if "BUSYGROUP" in str(e):
+            logger.debug(f"Consumer group '{consumer_group}' already exists")
+        else:
+            raise
+
+
 async def main():
     """
     Main Orchestrator Loop.
@@ -70,15 +93,7 @@ async def main():
             redis_client = redis.from_url(redis_url)
             # Redact credentials from URL for safe logging
             safe_url = redact_url(redis_url)
-            logger.info(f"✅ Orchestrator initialized and connected to Redis at {safe_url} (Stream: {stream_name})")
-            
-            # Create consumer group if it doesn't exist (ignore if already exists)
-            try:
-                await redis_client.xgroup_create(stream_name, consumer_group, id='0', mkstream=True)
-                logger.info(f"Created consumer group '{consumer_group}' for stream '{stream_name}'")
-            except Exception as e:
-                # Group already exists, which is fine
-                logger.debug(f"Consumer group setup: {e}")
+            logger.info(f"✅ Orchestrator initialized, connecting to Redis at {safe_url} (Stream: {stream_name})")
         except Exception as e:
             logger.error(f"Failed to initialize Redis client: {e}")
             redis_client = None
@@ -86,10 +101,20 @@ async def main():
     if redis_client is None:
         logger.info("✅ Orchestrator initialized and waiting for tasks (Mode: Standby)")
 
+    # Whether the consumer group has been confirmed to exist. Created lazily inside
+    # the loop so a transient failure at startup is retried instead of stranding the
+    # consumer, and reset on any loop error so a lost connection or a missing group
+    # (NOGROUP) triggers re-creation on the next iteration.
+    group_ready = False
+
     # Main loop
     while not stop_event.is_set():
         try:
             if redis_client:
+                if not group_ready:
+                    await ensure_consumer_group(redis_client, stream_name, consumer_group)
+                    group_ready = True
+
                 # Use Redis Streams with consumer groups for acknowledged delivery
                 # Read with 1 second block timeout so we can check stop_event frequently
                 results = await redis_client.xreadgroup(
@@ -99,9 +124,9 @@ async def main():
                     count=1,
                     block=1000  # 1 second in milliseconds
                 )
-                
+
                 if results:
-                    for stream, messages in results:
+                    for _stream, messages in results:
                         for message_id, data in messages:
                             try:
                                 # Process the message
@@ -118,6 +143,9 @@ async def main():
                 logger.debug("❤️ Orchestrator heartbeat")
 
         except Exception as e:
+            # Force the group to be re-ensured next iteration: the failure may be a
+            # dropped connection or a missing group (NOGROUP) that needs re-creating.
+            group_ready = False
             logger.error(f"Error in orchestrator loop: {e}")
             await asyncio.sleep(5)
 

--- a/tests/unit/test_orchestrator_consumer.py
+++ b/tests/unit/test_orchestrator_consumer.py
@@ -1,0 +1,78 @@
+"""Unit tests for youtube_extension/orchestrator/main.py.
+
+Covers the hardened Redis Streams consumer-group bootstrap (the paths this PR is
+meant to harden) plus the credential-redaction and stub-handler contracts. The
+Redis client is mocked, so these run without a live Redis or the redis-py package.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from youtube_extension.orchestrator.main import (
+    ensure_consumer_group,
+    process,
+    redact_url,
+)
+
+# ---------------------------------------------------------------------------
+# ensure_consumer_group — the core of the hardening fix
+# ---------------------------------------------------------------------------
+
+async def test_ensure_consumer_group_creates_when_absent() -> None:
+    client = AsyncMock()
+    await ensure_consumer_group(client, "stream", "group")
+    client.xgroup_create.assert_awaited_once_with(
+        "stream", "group", id="0", mkstream=True
+    )
+
+
+async def test_ensure_consumer_group_tolerates_busygroup() -> None:
+    client = AsyncMock()
+    client.xgroup_create.side_effect = Exception(
+        "BUSYGROUP Consumer Group name already exists"
+    )
+    # Must NOT raise: an existing group is the expected idempotent case.
+    await ensure_consumer_group(client, "stream", "group")
+
+
+async def test_ensure_consumer_group_reraises_transient_errors() -> None:
+    client = AsyncMock()
+    client.xgroup_create.side_effect = Exception(
+        "Error 111 connecting to localhost:6379. Connection refused."
+    )
+    # A transient ConnectionError must propagate so the caller retries instead of
+    # silently proceeding without a group (which would stall on NOGROUP forever).
+    with pytest.raises(Exception, match="Connection refused"):
+        await ensure_consumer_group(client, "stream", "group")
+
+
+# ---------------------------------------------------------------------------
+# redact_url — credentials must never reach logs
+# ---------------------------------------------------------------------------
+
+async def test_redact_url_strips_credentials() -> None:
+    redacted = redact_url("redis://admin:supersecret@redis.internal:6379/1")
+    assert "supersecret" not in redacted
+    assert "redis.internal" in redacted
+
+
+async def test_redact_url_passthrough_without_credentials() -> None:
+    assert redact_url("redis://localhost:6379") == "redis://localhost:6379"
+
+
+async def test_redact_url_never_raises_on_garbage() -> None:
+    # Malformed input must degrade to a safe placeholder, never throw.
+    assert redact_url("::not a url::") is not None
+
+
+# ---------------------------------------------------------------------------
+# process — REAL_MODE_ONLY: no silent fake success
+# ---------------------------------------------------------------------------
+
+async def test_process_fails_loudly_until_implemented() -> None:
+    # The stub must raise so the consumer never xack's unprocessed work.
+    with pytest.raises(NotImplementedError):
+        await process({"field": "value"})


### PR DESCRIPTION
## Summary

Hardens the orchestrator Redis Streams consumer (`src/youtube_extension/orchestrator/main.py`) against a transient-startup failure mode, resolving the outstanding review finding on **#729**.

This branch carries the same orchestrator consumer work as #729 (identical head commit `aed7958`) plus this fix on top. It supersedes #729 with the last review finding addressed — merge whichever you prefer and close the other.

## The bug

Consumer-group bootstrap wrapped `xgroup_create` in a bare `except Exception` that logged at `debug` and continued:

```python
try:
    await redis_client.xgroup_create(stream_name, consumer_group, id='0', mkstream=True)
except Exception as e:
    # Group already exists, which is fine
    logger.debug(f"Consumer group setup: {e}")
```

Only `BUSYGROUP` ("group already exists") is a safe-to-ignore error there. A transient `ConnectionError` — Redis not yet reachable at container boot — was swallowed identically, so the group was never created. The main loop's `xreadgroup` then failed permanently with `NOGROUP`, and because group creation ran only once before the loop, it was never retried. The consumer stalled forever, consuming nothing.

## The fix

- Extract `ensure_consumer_group()` that treats **only** `BUSYGROUP` as success and **re-raises** every other error so the caller can retry.
- Create the group lazily **inside** the loop (tracked via a `group_ready` flag) and reset that flag on any loop error. A startup race, a dropped connection, or a missing group (`NOGROUP`) now self-heals on the next iteration instead of stranding the worker.

## Verification

- `python -m py_compile` — passes.
- `ruff check` — clean (also cleared two pre-existing lints in the touched block).
- Behavioral simulation with fakes (redis-py not installed in CI-less runtime):
  - `BUSYGROUP` → swallowed ✅
  - `ConnectionError` → propagates (no longer swallowed) ✅
  - clean create → succeeds once ✅
  - after a failed ensure, `group_ready` resets and the group is re-created on the next iteration ✅

## Notes

- Targets protected `main`; **not** auto-merged — needs a human review/merge.
- No dedicated test module exists for this consumer today; a follow-up could add one around `ensure_consumer_group` and the self-heal path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CcqoCSYy5dvfSXbcuNU2m

---
_Generated by [Claude Code](https://claude.ai/code/session_015CcqoCSYy5dvfSXbcuNU2m)_