### PR TITLE
fix(skills): SkillRegistry service-container DI (rebased + verified, supersedes #741)

### DIFF
--- a/src/agents/mcp_ecosystem_coordinator.py
+++ b/src/agents/mcp_ecosystem_coordinator.py
@@ -351,12 +351,15 @@ class SkillRegistry:
             "source": meta.get("source", ""),
         }
 
-    def list_skills(self) -> list[dict[str, Any]]:
+    def list_skills(self, source: Optional[str] = None) -> list[dict[str, Any]]:
         """Return metadata for all registered GTM skills."""
-        return [
+        skills = [
             self._build_skill_metadata(skill_id, meta)
             for skill_id, meta in self._skills.items()
         ]
+        if source:
+            return [s for s in skills if self._skills[s["id"]].get("source") == source]
+        return skills
 
     def get_skill(self, skill_id: str) -> Optional[dict[str, Any]]:
         """Get metadata for a specific skill."""
@@ -382,15 +385,13 @@ class SkillRegistry:
         if meta is None:
             raise ValueError(f"Unknown skill: {skill_id}")
 
-        skill_path = meta.get("skillPath") or meta.get("entry_point")
-        class_name = meta.get("className")
+        skill_path = meta.get("skillPath") or meta.get("entry_point")  # e.g. "src/skills/content_generation/main.py"
+        class_name = meta.get("className")  # e.g. "ContentGenerationSkill"
 
         if not skill_path:
-             raise ValueError(f"Skill {skill_id} has no skillPath or entry_point")
+            raise ValueError(f"Skill {skill_id} has no skillPath or entry_point")
 
         if not class_name:
-            # Fallback for origin/main style skills if they don't have className
-            # But HEAD style should have it.
             raise ValueError(f"Skill {skill_id} has no className")
 
         # Convert file path to module path
@@ -401,7 +402,17 @@ class SkillRegistry:
 
         module = importlib.import_module(module_path)
         skill_class = getattr(module, class_name)
-        instance = skill_class()
+
+        # Resolve dependencies from service container
+        dependencies = {}
+        for dep_name in meta.get("dependencies", []):
+            try:
+                from youtube_extension.backend.containers.service_container import get_service
+                dependencies[dep_name] = get_service(dep_name)
+            except Exception as e:
+                logger.warning("Failed to resolve dependency %s for skill %s: %s", dep_name, skill_id, e)
+
+        instance = skill_class(dependencies=dependencies)
         self._instances[skill_id] = instance
         return instance
 

--- a/src/agents/mcp_ecosystem_coordinator.py
+++ b/src/agents/mcp_ecosystem_coordinator.py
@@ -402,17 +402,28 @@ class SkillRegistry:
         skill_class = getattr(module, class_name)
 
         # Resolve dependencies from the service container. Imported lazily to
-        # avoid a circular import at module load time.
-        from youtube_extension.backend.containers.service_container import (
-            get_service,
-        )
+        # avoid a circular import at module load time, and guarded so that a
+        # container import failure (e.g. a missing optional transitive dep)
+        # degrades to no injection instead of breaking every skill invocation.
+        dependencies: dict[str, Any] = {}
+        try:
+            from youtube_extension.backend.containers.service_container import (
+                get_service,
+            )
+        except Exception as e:
+            logger.warning(
+                "Service container unavailable; skipping DI for skill %s: %s",
+                skill_id,
+                e,
+            )
+            get_service = None
 
-        dependencies = {}
-        for dep_name in meta.get("dependencies", []):
-            try:
-                dependencies[dep_name] = get_service(dep_name)
-            except Exception as e:
-                logger.warning("Failed to resolve dependency %s for skill %s: %s", dep_name, skill_id, e)
+        if get_service is not None:
+            for dep_name in meta.get("dependencies", []):
+                try:
+                    dependencies[dep_name] = get_service(dep_name)
+                except Exception as e:
+                    logger.warning("Failed to resolve dependency %s for skill %s: %s", dep_name, skill_id, e)
 
         instance = skill_class(dependencies=dependencies)
         self._instances[skill_id] = instance

--- a/src/agents/mcp_ecosystem_coordinator.py
+++ b/src/agents/mcp_ecosystem_coordinator.py
@@ -10,7 +10,6 @@ import importlib
 import json
 import logging
 import os
-import subprocess
 import sys
 from dataclasses import asdict
 from pathlib import Path
@@ -325,13 +324,14 @@ class SkillRegistry:
             return
 
         skills_data = data.get("skills", {})
+        # Filter for uvai-skills (local GTM skills)
         if isinstance(skills_data, list):
-            # Handle list format from origin/main
+            # Handle list format (defensive: some tooling emits a list)
             for skill in skills_data:
-                if skill.get("source") == "uvai-skills":
+                if skill.get("source") == "uvai-skills" and "id" in skill:
                     self._skills[skill["id"]] = skill
         elif isinstance(skills_data, dict):
-            # Handle dict format from HEAD
+            # Handle dict format (canonical skills-lock.json shape)
             for skill_id, meta in skills_data.items():
                 if meta.get("source") == "uvai-skills":
                     self._skills[skill_id] = meta
@@ -405,12 +405,18 @@ class SkillRegistry:
 
         # Resolve dependencies from service container
         dependencies = {}
-        for dep_name in meta.get("dependencies", []):
+        deps = meta.get("dependencies", [])
+        if deps:
             try:
-                from youtube_extension.backend.containers.service_container import get_service
-                dependencies[dep_name] = get_service(dep_name)
-            except Exception as e:
-                logger.warning("Failed to resolve dependency %s for skill %s: %s", dep_name, skill_id, e)
+                from youtube_extension.backend.containers.service_container import get_service_container
+                container = get_service_container()
+                for dep_name in deps:
+                    try:
+                        dependencies[dep_name] = container.get_service(dep_name)
+                    except Exception as e:
+                        logger.warning("Failed to resolve dependency %s for skill %s: %s", dep_name, skill_id, e)
+            except ImportError as e:
+                logger.error("Failed to import service container: %s", e)
 
         instance = skill_class(dependencies=dependencies)
         self._instances[skill_id] = instance

--- a/src/agents/mcp_ecosystem_coordinator.py
+++ b/src/agents/mcp_ecosystem_coordinator.py
@@ -324,11 +324,10 @@ class SkillRegistry:
             return
 
         skills_data = data.get("skills", {})
-        # Filter for uvai-skills (local GTM skills)
         if isinstance(skills_data, list):
             # Handle list format (defensive: some tooling emits a list)
             for skill in skills_data:
-                if skill.get("source") == "uvai-skills" and "id" in skill:
+                if skill.get("source") == "uvai-skills":
                     self._skills[skill["id"]] = skill
         elif isinstance(skills_data, dict):
             # Handle dict format (canonical skills-lock.json shape)
@@ -385,8 +384,8 @@ class SkillRegistry:
         if meta is None:
             raise ValueError(f"Unknown skill: {skill_id}")
 
-        skill_path = meta.get("skillPath") or meta.get("entry_point")  # e.g. "src/skills/content_generation/main.py"
-        class_name = meta.get("className")  # e.g. "ContentGenerationSkill"
+        skill_path = meta.get("skillPath") or meta.get("entry_point")
+        class_name = meta.get("className")
 
         if not skill_path:
             raise ValueError(f"Skill {skill_id} has no skillPath or entry_point")
@@ -405,18 +404,12 @@ class SkillRegistry:
 
         # Resolve dependencies from service container
         dependencies = {}
-        deps = meta.get("dependencies", [])
-        if deps:
+        for dep_name in meta.get("dependencies", []):
             try:
-                from youtube_extension.backend.containers.service_container import get_service_container
-                container = get_service_container()
-                for dep_name in deps:
-                    try:
-                        dependencies[dep_name] = container.get_service(dep_name)
-                    except Exception as e:
-                        logger.warning("Failed to resolve dependency %s for skill %s: %s", dep_name, skill_id, e)
-            except ImportError as e:
-                logger.error("Failed to import service container: %s", e)
+                from youtube_extension.backend.containers.service_container import get_service
+                dependencies[dep_name] = get_service(dep_name)
+            except Exception as e:
+                logger.warning("Failed to resolve dependency %s for skill %s: %s", dep_name, skill_id, e)
 
         instance = skill_class(dependencies=dependencies)
         self._instances[skill_id] = instance

--- a/src/agents/mcp_ecosystem_coordinator.py
+++ b/src/agents/mcp_ecosystem_coordinator.py
@@ -10,7 +10,6 @@ import importlib
 import json
 import logging
 import os
-import sys
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -402,11 +401,15 @@ class SkillRegistry:
         module = importlib.import_module(module_path)
         skill_class = getattr(module, class_name)
 
-        # Resolve dependencies from service container
+        # Resolve dependencies from the service container. Imported lazily to
+        # avoid a circular import at module load time.
+        from youtube_extension.backend.containers.service_container import (
+            get_service,
+        )
+
         dependencies = {}
         for dep_name in meta.get("dependencies", []):
             try:
-                from youtube_extension.backend.containers.service_container import get_service
                 dependencies[dep_name] = get_service(dep_name)
             except Exception as e:
                 logger.warning("Failed to resolve dependency %s for skill %s: %s", dep_name, skill_id, e)

--- a/src/skills/ab_testing/main.py
+++ b/src/skills/ab_testing/main.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from skills.base import BaseSkill, SkillResult
 
@@ -18,6 +18,11 @@ class ABTestingSkill(BaseSkill):
     version = "1.0.0"
     triggers = ["youtube.video.uploaded"]
     required_env_vars = ["GEMINI_API_KEY", "DATABASE_URL"]
+
+    def __init__(self, dependencies: Optional[dict[str, Any]] = None):
+        super().__init__(dependencies)
+        self.gemini = self.dependencies.get("gemini_service")
+        self.analytics = self.dependencies.get("analytics_service")
 
     async def execute(self, payload: dict[str, Any]) -> SkillResult:
         """Create and manage an A/B test.
@@ -40,6 +45,11 @@ class ABTestingSkill(BaseSkill):
             video_id,
             len(variants),
         )
+
+        if self.gemini:
+            logger.info("Using injected gemini_service for A/B testing")
+        if self.analytics:
+            logger.info("Using injected analytics_service for A/B testing")
 
         return SkillResult(
             status="success",

--- a/src/skills/analytics_dashboard/main.py
+++ b/src/skills/analytics_dashboard/main.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from skills.base import BaseSkill, SkillResult
 
@@ -18,6 +18,11 @@ class AnalyticsDashboardSkill(BaseSkill):
     version = "1.0.0"
     triggers = ["system.cron.daily"]
     required_env_vars = ["DATABASE_URL"]
+
+    def __init__(self, dependencies: Optional[dict[str, Any]] = None):
+        super().__init__(dependencies)
+        self.db = self.dependencies.get("database_service")
+        self.analytics = self.dependencies.get("analytics_service")
 
     async def execute(self, payload: dict[str, Any]) -> SkillResult:
         """Aggregate analytics metrics.
@@ -35,6 +40,11 @@ class AnalyticsDashboardSkill(BaseSkill):
         logger.info(
             "Aggregating %d metrics for range %s", len(metrics), date_range
         )
+
+        if self.db:
+            logger.info("Using injected database_service for aggregation")
+        if self.analytics:
+            logger.info("Using injected analytics_service for aggregation")
 
         return SkillResult(
             status="success",

--- a/src/skills/base.py
+++ b/src/skills/base.py
@@ -28,7 +28,7 @@ class BaseSkill(abc.ABC):
       - name: human-readable name
       - version: semver version string
       - triggers: list of event types that trigger this skill
-      - required_env_vars: env vars needed at runtime
+      - required_env_vars: env vars needed at runtime (LEGACY)
     """
 
     skill_id: str
@@ -36,6 +36,14 @@ class BaseSkill(abc.ABC):
     version: str
     triggers: list[str]
     required_env_vars: list[str] = []
+
+    def __init__(self, dependencies: Optional[dict[str, Any]] = None):
+        """Initialize the skill with injected dependencies.
+
+        Args:
+            dependencies: Dictionary mapping dependency names to service instances.
+        """
+        self.dependencies = dependencies or {}
 
     def get_env(self) -> dict[str, str]:
         """Collect required environment variables for subprocess pass-through.

--- a/src/skills/content_generation/main.py
+++ b/src/skills/content_generation/main.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from skills.base import BaseSkill, SkillResult
 
@@ -18,6 +18,11 @@ class ContentGenerationSkill(BaseSkill):
     version = "1.0.0"
     triggers = ["youtube.video.published", "system.action.manual"]
     required_env_vars = ["GEMINI_API_KEY"]
+
+    def __init__(self, dependencies: Optional[dict[str, Any]] = None):
+        super().__init__(dependencies)
+        self.gemini = self.dependencies.get("gemini_service")
+        self.db = self.dependencies.get("database_service")
 
     async def execute(self, payload: dict[str, Any]) -> SkillResult:
         """Generate content from a video transcript.
@@ -40,6 +45,10 @@ class ContentGenerationSkill(BaseSkill):
             video_id,
             len(transcript),
         )
+
+        if self.gemini:
+            logger.info("Using injected gemini_service for generation")
+            # In a real implementation, we would call self.gemini.process_text(...) here
 
         # Thin wrapper: actual AI generation will be wired in a future iteration
         return SkillResult(

--- a/src/skills/email_campaign/main.py
+++ b/src/skills/email_campaign/main.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from skills.base import BaseSkill, SkillResult
 
@@ -18,6 +18,10 @@ class EmailCampaignSkill(BaseSkill):
     version = "1.0.0"
     triggers = ["crm.lead.scored"]
     required_env_vars = ["GEMINI_API_KEY", "DATABASE_URL"]
+
+    def __init__(self, dependencies: Optional[dict[str, Any]] = None):
+        super().__init__(dependencies)
+        self.email_service = self.dependencies.get("email_service")
 
     async def execute(self, payload: dict[str, Any]) -> SkillResult:
         """Generate an email campaign sequence.
@@ -36,6 +40,9 @@ class EmailCampaignSkill(BaseSkill):
         logger.info(
             "Generating %s email campaign for lead %s", campaign_type, lead_id
         )
+
+        if self.email_service:
+            logger.info("Using injected email_service for campaign dispatch")
 
         return SkillResult(
             status="success",

--- a/src/skills/lead_scorer/main.py
+++ b/src/skills/lead_scorer/main.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from skills.base import BaseSkill, SkillResult
 
@@ -19,6 +19,10 @@ class LeadScorerSkill(BaseSkill):
     triggers = ["youtube.analytics.updated"]
     required_env_vars = ["DATABASE_URL"]
 
+    def __init__(self, dependencies: Optional[dict[str, Any]] = None):
+        super().__init__(dependencies)
+        self.db = self.dependencies.get("database_service")
+
     async def execute(self, payload: dict[str, Any]) -> SkillResult:
         """Score a lead based on engagement signals.
 
@@ -33,6 +37,9 @@ class LeadScorerSkill(BaseSkill):
         signals = payload.get("signals", {})
 
         logger.info("Scoring lead %s with %d signals", lead_id, len(signals))
+
+        if self.db:
+             logger.info("Using injected database_service for lead scoring")
 
         return SkillResult(
             status="success",

--- a/src/skills/seo_optimizer/main.py
+++ b/src/skills/seo_optimizer/main.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from skills.base import BaseSkill, SkillResult
 
@@ -18,6 +18,10 @@ class SEOOptimizerSkill(BaseSkill):
     version = "1.0.0"
     triggers = ["youtube.video.uploaded"]
     required_env_vars = ["GEMINI_API_KEY"]
+
+    def __init__(self, dependencies: Optional[dict[str, Any]] = None):
+        super().__init__(dependencies)
+        self.gemini = self.dependencies.get("gemini_service")
 
     async def execute(self, payload: dict[str, Any]) -> SkillResult:
         """Optimize SEO metadata for a video.
@@ -37,6 +41,9 @@ class SEOOptimizerSkill(BaseSkill):
         tags = payload.get("tags", [])
 
         logger.info("Optimizing SEO for video %s", video_id)
+
+        if self.gemini:
+            logger.info("Using injected gemini_service for SEO optimization")
 
         return SkillResult(
             status="success",

--- a/src/skills/social_scheduler/main.py
+++ b/src/skills/social_scheduler/main.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from skills.base import BaseSkill, SkillResult
 
@@ -18,6 +18,10 @@ class SocialSchedulerSkill(BaseSkill):
     version = "1.0.0"
     triggers = ["ai.content.generated"]
     required_env_vars = ["GEMINI_API_KEY"]
+
+    def __init__(self, dependencies: Optional[dict[str, Any]] = None):
+        super().__init__(dependencies)
+        self.social_api = self.dependencies.get("social_api_service")
 
     async def execute(self, payload: dict[str, Any]) -> SkillResult:
         """Schedule social media posts.
@@ -39,6 +43,9 @@ class SocialSchedulerSkill(BaseSkill):
             platforms,
             schedule_time or "immediate",
         )
+
+        if self.social_api:
+            logger.info("Using injected social_api_service for scheduling")
 
         return SkillResult(
             status="success",

--- a/src/youtube_extension/backend/containers/service_container.py
+++ b/src/youtube_extension/backend/containers/service_container.py
@@ -123,7 +123,32 @@ class ServiceContainer:
         # MCP Orchestrator (Unified Model Context Protocol)
         self.register_singleton("mcp_orchestrator", self._create_mcp_orchestrator)
 
+        # Register aliases for skill dependencies
+        self._register_skill_dependency_aliases()
+
         logger.info("Core services registered")
+
+    def _register_skill_dependency_aliases(self):
+        """Register aliases for services used as skill dependencies."""
+        # AI Services
+        self.register_singleton("gemini_service", lambda: self.get_service("hybrid_processor_service"))
+        self.register_singleton("openai_service", self._create_openai_service_placeholder)
+
+        # Data & Analytics
+        self.register_singleton("database_service", lambda: self.get_service("data_service"))
+        self.register_singleton("analytics_service", lambda: self.get_service("metrics_service"))
+
+        # External Integration
+        self.register_singleton("email_service", lambda: self.get_service("notification_service"))
+        self.register_singleton("social_api_service", self._create_social_api_service_placeholder)
+
+    def _create_openai_service_placeholder(self):
+        """Placeholder for OpenAI service."""
+        return type("OpenAIServicePlaceholder", (), {"status": "placeholder"})()
+
+    def _create_social_api_service_placeholder(self):
+        """Placeholder for Social API service."""
+        return type("SocialAPIServicePlaceholder", (), {"status": "placeholder"})()
 
     def register_singleton(self, name: str, factory: Callable[[], T]) -> None:
         """

--- a/src/youtube_extension/backend/containers/service_container.py
+++ b/src/youtube_extension/backend/containers/service_container.py
@@ -129,10 +129,19 @@ class ServiceContainer:
         logger.info("Core services registered")
 
     def _register_skill_dependency_aliases(self):
-        """Register aliases for services used as skill dependencies."""
+        """Register aliases for services used as skill dependencies.
+
+        Only services backed by a real implementation are aliased here.
+        Dependencies without an implementation (e.g. ``openai_service``,
+        ``social_api_service``) are intentionally left unregistered: resolving
+        them raises ``ValueError``, which ``SkillRegistry._load_skill_instance``
+        catches and degrades to no injection, so a skill's ``if self.social_api:``
+        availability check correctly reports the service as unavailable. This
+        avoids registering truthy placeholder objects that would masquerade as
+        real services (and violate REAL_MODE_ONLY).
+        """
         # AI Services
         self.register_singleton("gemini_service", lambda: self.get_service("hybrid_processor_service"))
-        self.register_singleton("openai_service", self._create_openai_service_placeholder)
 
         # Data & Analytics
         self.register_singleton("database_service", lambda: self.get_service("data_service"))
@@ -140,15 +149,6 @@ class ServiceContainer:
 
         # External Integration
         self.register_singleton("email_service", lambda: self.get_service("notification_service"))
-        self.register_singleton("social_api_service", self._create_social_api_service_placeholder)
-
-    def _create_openai_service_placeholder(self):
-        """Placeholder for OpenAI service."""
-        return type("OpenAIServicePlaceholder", (), {"status": "placeholder"})()
-
-    def _create_social_api_service_placeholder(self):
-        """Placeholder for Social API service."""
-        return type("SocialAPIServicePlaceholder", (), {"status": "placeholder"})()
 
     def register_singleton(self, name: str, factory: Callable[[], T]) -> None:
         """

--- a/tests/integration/test_skill_di.py
+++ b/tests/integration/test_skill_di.py
@@ -1,61 +1,53 @@
-import pytest
-import asyncio
 from unittest.mock import MagicMock
-import sys
-from pathlib import Path
 
-# Add src to sys.path if not already there
-src_path = str(Path(__file__).resolve().parents[2] / "src")
-if src_path not in sys.path:
-    sys.path.insert(0, src_path)
+import pytest
 
 from agents.mcp_ecosystem_coordinator import SkillRegistry
-from youtube_extension.backend.containers.service_container import get_service_container
+from skills.base import SkillResult
+from youtube_extension.backend.containers.service_container import (
+    get_service_container,
+)
+
 
 @pytest.mark.asyncio
 async def test_skill_di_wiring():
-    """Verify that skills are correctly instantiated with their dependencies from the ServiceContainer."""
+    """Verify skills are instantiated with their dependencies from the ServiceContainer."""
     container = get_service_container()
 
-    # Mock services in the container
+    # Inject mock services into the container for testing.
     mock_gemini = MagicMock()
     mock_db = MagicMock()
-
-    # We can inject mocks into the container's _singletons for testing
     container._singletons["gemini_service"] = mock_gemini
     container._singletons["database_service"] = mock_db
 
     registry = SkillRegistry()
 
-    # Test ContentGenerationSkill (requires gemini_service and database_service)
-    skill_id = "content-generation"
-    instance = registry._load_skill_instance(skill_id)
+    # ContentGenerationSkill requires gemini_service and database_service.
+    instance = registry._load_skill_instance("content-generation")
+    assert instance.gemini is mock_gemini
+    assert instance.db is mock_db
 
-    assert instance.gemini == mock_gemini
-    assert instance.db == mock_db
-
-    # Test LeadScorerSkill (requires database_service)
-    skill_id = "lead-scorer"
-    instance = registry._load_skill_instance(skill_id)
-
-    assert instance.db == mock_db
+    # LeadScorerSkill requires only database_service.
+    instance = registry._load_skill_instance("lead-scorer")
+    assert instance.db is mock_db
     assert not hasattr(instance, "gemini") or instance.gemini is None
+
 
 @pytest.mark.asyncio
 async def test_invoke_skill_with_di():
-    """Verify that invoking a skill uses the DI-injected instance."""
+    """Verify that invoking a skill routes the payload to the DI-injected instance."""
     registry = SkillRegistry()
 
-    # Mock the execute method
-    skill_id = "seo-optimizer"
-    instance = registry._load_skill_instance(skill_id)
+    instance = registry._load_skill_instance("seo-optimizer")
 
-    from skills.base import SkillResult
-    instance.execute = asyncio.Future()
-    instance.execute.set_result(SkillResult(status="success", output={"test": "ok"}))
+    # Replace execute with an async callable (a coroutine function), so that
+    # `await instance.execute(payload)` inside invoke_skill works correctly.
+    async def fake_execute(payload):
+        return SkillResult(status="success", output={"test": "ok"})
 
-    payload = {"video_id": "test_video"}
-    result = await registry.invoke_skill(skill_id, payload)
+    instance.execute = fake_execute
+
+    result = await registry.invoke_skill("seo-optimizer", {"video_id": "test_video"})
 
     assert result["status"] == "success"
     assert result["output"]["test"] == "ok"

--- a/tests/integration/test_skill_di.py
+++ b/tests/integration/test_skill_di.py
@@ -1,5 +1,6 @@
 import pytest
-from unittest.mock import MagicMock, AsyncMock
+import asyncio
+from unittest.mock import MagicMock
 import sys
 from pathlib import Path
 
@@ -50,9 +51,8 @@ async def test_invoke_skill_with_di():
     instance = registry._load_skill_instance(skill_id)
 
     from skills.base import SkillResult
-    instance.execute = AsyncMock(
-        return_value=SkillResult(status="success", output={"test": "ok"})
-    )
+    instance.execute = asyncio.Future()
+    instance.execute.set_result(SkillResult(status="success", output={"test": "ok"}))
 
     payload = {"video_id": "test_video"}
     result = await registry.invoke_skill(skill_id, payload)

--- a/tests/integration/test_skill_di.py
+++ b/tests/integration/test_skill_di.py
@@ -1,6 +1,5 @@
 import pytest
-import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, AsyncMock
 import sys
 from pathlib import Path
 
@@ -51,8 +50,9 @@ async def test_invoke_skill_with_di():
     instance = registry._load_skill_instance(skill_id)
 
     from skills.base import SkillResult
-    instance.execute = asyncio.Future()
-    instance.execute.set_result(SkillResult(status="success", output={"test": "ok"}))
+    instance.execute = AsyncMock(
+        return_value=SkillResult(status="success", output={"test": "ok"})
+    )
 
     payload = {"video_id": "test_video"}
     result = await registry.invoke_skill(skill_id, payload)

--- a/tests/integration/test_skill_di.py
+++ b/tests/integration/test_skill_di.py
@@ -1,0 +1,61 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock
+import sys
+from pathlib import Path
+
+# Add src to sys.path if not already there
+src_path = str(Path(__file__).resolve().parents[2] / "src")
+if src_path not in sys.path:
+    sys.path.insert(0, src_path)
+
+from agents.mcp_ecosystem_coordinator import SkillRegistry
+from youtube_extension.backend.containers.service_container import get_service_container
+
+@pytest.mark.asyncio
+async def test_skill_di_wiring():
+    """Verify that skills are correctly instantiated with their dependencies from the ServiceContainer."""
+    container = get_service_container()
+
+    # Mock services in the container
+    mock_gemini = MagicMock()
+    mock_db = MagicMock()
+
+    # We can inject mocks into the container's _singletons for testing
+    container._singletons["gemini_service"] = mock_gemini
+    container._singletons["database_service"] = mock_db
+
+    registry = SkillRegistry()
+
+    # Test ContentGenerationSkill (requires gemini_service and database_service)
+    skill_id = "content-generation"
+    instance = registry._load_skill_instance(skill_id)
+
+    assert instance.gemini == mock_gemini
+    assert instance.db == mock_db
+
+    # Test LeadScorerSkill (requires database_service)
+    skill_id = "lead-scorer"
+    instance = registry._load_skill_instance(skill_id)
+
+    assert instance.db == mock_db
+    assert not hasattr(instance, "gemini") or instance.gemini is None
+
+@pytest.mark.asyncio
+async def test_invoke_skill_with_di():
+    """Verify that invoking a skill uses the DI-injected instance."""
+    registry = SkillRegistry()
+
+    # Mock the execute method
+    skill_id = "seo-optimizer"
+    instance = registry._load_skill_instance(skill_id)
+
+    from skills.base import SkillResult
+    instance.execute = asyncio.Future()
+    instance.execute.set_result(SkillResult(status="success", output={"test": "ok"}))
+
+    payload = {"video_id": "test_video"}
+    result = await registry.invoke_skill(skill_id, payload)
+
+    assert result["status"] == "success"
+    assert result["output"]["test"] == "ok"


### PR DESCRIPTION
## What & why

Replaces `SkillRegistry`'s legacy env-var pass-through with **service-container dependency injection**, matching the repo's DI pattern (`backend/containers/`). Local GTM skills now receive their dependencies (`gemini_service`, `database_service`, etc.) via their constructors, resolved from the global `ServiceContainer`, instead of the registry spawning subprocesses with a hand-mapped env.

This is the same intent as **#741** (`Fixes #699`), but that PR is currently `mergeable_state: dirty` — it was cut against an older `main` and now conflicts. This branch is a **clean rebase onto current `main` (parent `ddf85c3`, i.e. after #753) with the conflicts resolved and the behaviour verified**, so it can supersede #741.

## Changes
- `src/agents/mcp_ecosystem_coordinator.py`: `SkillRegistry` resolves declared `dependencies` from the service container and instantiates skill classes with `dependencies=`. Handles both dict (canonical) and list `skills-lock.json` shapes.
- `src/skills/*/main.py` + `src/skills/base.py`: constructors accept and store injected dependencies.
- `src/youtube_extension/backend/containers/service_container.py`: aliases for skill dependency names.
- `tests/integration/test_skill_di.py`: verifies DI wiring and `invoke_skill` routing.

## Conflict-resolution notes
- Kept `main`'s **dict-format `skills-lock.json`** (dotted triggers, e.g. `youtube.video.published`) — the branch's stale list-format lock was dropped, so this PR does **not** touch `skills-lock.json`.
- Removed now-dead `subprocess` / `sys` imports left over from the env-var spawn path.
- Fixed `test_invoke_skill_with_di`: `execute` had been mocked with a non-callable `asyncio.Future`, so `await instance.execute(payload)` raised `TypeError` and the success assertion could never pass — now mocked with an async callable.

## Verification
- `python -m compileall src tests` — 0 syntax errors.
- `ruff check` on the changed files — no new findings (only pre-existing `UP006/UP035/UP045` that already exist on `main`).
- Functional check against the real `skills-lock.json`: 7 uvai skills load, `content-generation` receives `gemini_service` + `database_service`, dotted-trigger routing works, `invoke_skill` returns success.

> Full `pytest` collection in this sandbox is blocked by an unrelated pre-existing gap (`src/agents/__init__.py` eagerly imports `gemini_video_master_agent`, which needs `google-genai`); the DI path was therefore verified via a targeted harness that loads the coordinator module directly. CI, which installs the `[dev,youtube,ml]` extras, runs the suite normally.

Draft pending human review — does not auto-merge to protected `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RdD9kxLHvB8FJCV85sCYVB)_