### PR TITLE
fix(unified-ai-sdk): restore CLAUDE and GROK ModelProvider members (main CI red)

### DIFF
--- a/src/unified_ai_sdk/rate_limiter.py
+++ b/src/unified_ai_sdk/rate_limiter.py
@@ -9,7 +9,8 @@ class ModelProvider(Enum):
     """Supported AI model providers."""
 
     OPENAI = "openai"
-    ANTHROPIC = "anthropic"
+    CLAUDE = "claude"
+    GROK = "grok"
     GEMINI = "gemini"
 
 


### PR DESCRIPTION
## Summary

`main` went **red** after PR #773 (`Consolidate and Process Draft PRs`) merged: the CI `test` job fails with 2 errors.

The consolidation clobbered the `ModelProvider` enum in `src/unified_ai_sdk/rate_limiter.py`, replacing `CLAUDE / GROK / OPENAI / GEMINI` with `OPENAI / ANTHROPIC / GEMINI`. That dropped `CLAUDE` and `GROK` and added an `ANTHROPIC` member that nothing references.

## Impact

`CLAUDE` and `GROK` are used by 12+ call sites, including the SDK's own **runtime** provider resolution — so this is not just a test break; it would `AttributeError` in production provider dispatch:

- `src/unified_ai_sdk/unified_ai_sdk.py:351` → `return ModelProvider.CLAUDE`
- `src/unified_ai_sdk/unified_ai_sdk.py:355` → `return ModelProvider.GROK`
- `src/core/model_router.py`, `src/mcp/bridge.py`

Failing tests on `main`:

```
FAILED tests/unit/test_unified_ai_sdk.py::TestUnifiedAISDK::test_unified_request_uses_anthropic_client - AttributeError: type object 'ModelProvider' has no attribute 'CLAUDE'
FAILED tests/unit/test_unified_ai_sdk.py::TestUnifiedAISDK::test_unified_request_uses_grok_client      - AttributeError: type object 'ModelProvider' has no attribute 'GROK'
= 2 failed, 7081 passed =
```

## Fix

Restore `CLAUDE = "claude"` and `GROK = "grok"`. This matches:
- the pre-#773 enum (verified at `ceeb2fc` and the pre-merge parent),
- all 24 `ModelProvider.*` usages across `src/` and `tests/`,
- the `result.provider == "claude"` / `"grok"` assertions in the tests.

`ANTHROPIC` had **zero** references anywhere and is removed. The TokenBucket rate-limiter rewrite that #773 legitimately introduced in the same file is left untouched.

```diff
     OPENAI = "openai"
-    ANTHROPIC = "anthropic"
+    CLAUDE = "claude"
+    GROK = "grok"
     GEMINI = "gemini"
```

## Verification

```
$ PYTHONPATH=src python -m pytest tests/unit/test_unified_ai_sdk.py -q
14 passed
```

Both previously-failing tests now pass. Branched from latest `main` (`c491730`).

## Note

Opened as a **draft** — merging into the protected `main` branch is left for a human to approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YMFj7PACfwFzutNAyL5RFi)_