### PR TITLE
fix(unified-ai-sdk): add missing ModelProvider.CLAUDE/GROK members (unblocks red main CI)

### DIFF
--- a/src/unified_ai_sdk/rate_limiter.py
+++ b/src/unified_ai_sdk/rate_limiter.py
@@ -9,8 +9,9 @@ class ModelProvider(Enum):
     """Supported AI model providers."""
 
     OPENAI = "openai"
-    ANTHROPIC = "anthropic"
+    CLAUDE = "claude"
     GEMINI = "gemini"
+    GROK = "grok"
 
 
 class TokenBucket:


### PR DESCRIPTION
## Problem

`main` CI is currently **red**. The required `test` job fails on latest `main` (`c491730a`) with two errors in `tests/unit/test_unified_ai_sdk.py`:

```
FAILED test_unified_request_uses_anthropic_client - AttributeError: type object 'ModelProvider' has no attribute 'CLAUDE'
FAILED test_unified_request_uses_grok_client      - AttributeError: type object 'ModelProvider' has no attribute 'GROK'
= 2 failed, 7081 passed =
```

(`build`, `guards`, `lint-frontend`, `lint-python` are all green — only this Python `test` job is broken.)

## Root cause — enum drift

`src/unified_ai_sdk/__init__.py` re-exports `ModelProvider` from **`rate_limiter.py`**, whose enum defined only:

```python
OPENAI = "openai"
ANTHROPIC = "anthropic"
GEMINI = "gemini"
```

But the rest of the package — and the tests — reference members that were never defined:

- `UnifiedAISDK._rate_limit_provider()` returns `ModelProvider.CLAUDE` and `ModelProvider.GROK`.
- The test suite constructs requests with `provider=ModelProvider.CLAUDE` / `ModelProvider.GROK`.

Repo-wide, `ModelProvider.CLAUDE` is referenced **6×**, `ModelProvider.GROK` **6×**, while `ModelProvider.ANTHROPIC` has **0** references anywhere in `src/` or `tests/`. The enum simply drifted out of sync with its consumers.

## Change

`src/unified_ai_sdk/rate_limiter.py` — one enum:

```diff
     OPENAI = "openai"
-    ANTHROPIC = "anthropic"
+    CLAUDE = "claude"
     GEMINI = "gemini"
+    GROK = "grok"
```

Defines the members the code actually uses. The rate limiter keys its token buckets by `provider.value` (a string), so it does not depend on the member *names*; the value `"claude"` matches the SDK's own provider normalization (`_provider_for` maps both `"anthropic"` and `"claude"` → `"claude"`, and the anthropic test asserts `result.provider == "claude"`).

## Verification

```
$ PYTHONPATH=src pytest tests/unit/test_unified_ai_sdk.py -o addopts=""
14 passed
```

Both previously-failing tests now pass; the other 12 in the module are unaffected. No other module references the removed `ANTHROPIC` member (`AIProvider.ANTHROPIC` in `real_ai_processor.py` is an unrelated enum).

## Scope

One-line-net enum change; no behavioural change to provider routing or rate limiting. Branched fresh from current `main` (`c491730a`).

---
_Generated by [Claude Code](https://claude.ai/code/session_016HYpgJfPRRRogHKNKXoXMx)_