### PR TITLE
docs(launch): fix dead Stripe price IDs + gate statuses in LAUNCH_CHECKLIST

### DIFF
--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -28,25 +28,45 @@ billing/auth vars go in `apps/web/.env.local` (or your Vercel project settings),
 
 ## 1. Launch-gating blockers (must do)
 
-### 1.1 Stripe products & prices — ✅ DONE (LIVE mode, 2026-07-02)
-Created via the Stripe API on the UVAI account (`acct_1ScN2hAmTgsI2zgN`):
-- Product **EventRelay Pro**: `prod_UoUsOjo63AUHAk`
-- **$19/mo** recurring Price: `price_1Tos02AmTgsI2zgNWx7onroJ`
-- **$180/yr** recurring Price: `price_1Tos0AAmTgsI2zgNSu5lwBv6`
+### 1.1 Stripe products & prices — ⏳ TEST MODE (LIVE prices NOT yet created)
 
-Set in the Vercel project env (Production):
+> **Reality check (verified 2026-07-14):** production checkout runs in Stripe
+> **TEST mode**. The LIVE prices this section used to claim as "DONE" are **DEAD** —
+> Stripe now returns `No such price` for them (evidence:
+> `docs/control-plane/sessions/gate3-reprobe-20260714T2011Z/renew-empty.body`).
+> **DO NOT re-apply `price_1Tos02AmTgsI2zgNWx7onroJ` or
+> `price_1Tos0AAmTgsI2zgNSu5lwBv6`** — they were reverted and will 500 checkout.
+
+**Current production prices (Stripe TEST mode, account `acct_1ScN2hAmTgsI2zgN`):**
+
+- **$19/mo** (test): `price_1TtCZXPPnkyjEyFR8dYmDo52` — produces `cs_test_` sessions
+- **$180/yr** (test): `price_1TtCZYPPnkyjEyFRLMLPjmzE`
+
+The Vercel Production env carries the **env-var names** below (do not hardcode any
+price ID as "done" in this doc — the authoritative IDs live only in Vercel/Stripe):
   ```
-  STRIPE_SECRET_KEY=sk_live_...          # Dashboard → Developers → API keys
-  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_...
-  STRIPE_WEBHOOK_SECRET=whsec_...        # from step 1.2
-  STRIPE_PRICE_PRO_MONTHLY=price_1Tos02AmTgsI2zgNWx7onroJ
-  STRIPE_PRICE_PRO_ANNUAL=price_1Tos0AAmTgsI2zgNSu5lwBv6
+  STRIPE_SECRET_KEY=sk_test_...          # currently TEST; swap to sk_live_ at cutover
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
+  STRIPE_WEBHOOK_SECRET=whsec_...        # from step 1.2 (configured — verified)
+  STRIPE_PRICE_PRO_MONTHLY=<test monthly price id above>
+  STRIPE_PRICE_PRO_ANNUAL=<test annual price id above>
   ```
 - Without the two `STRIPE_PRICE_*` IDs, `requireStripePriceId()` throws and
-  checkout 500s. Price IDs are not secrets (they appear in checkout URLs);
-  the `sk_live_` key and `whsec_` secret are.
+  checkout 500s. Price IDs are not secrets; the `sk_` key and `whsec_` secret are.
 
-### 1.2 Stripe webhook endpoint (manual — 1 minute, live mode)
+**🔴 LIVE cutover (required before real revenue):** create a fresh LIVE-mode
+Product + recurring Prices on `acct_1ScN2hAmTgsI2zgN`, record the NEW live price
+IDs, set them plus `sk_live_` / `pk_live_` / a live `whsec_` in Vercel Production,
+then re-run the gate3 probe and confirm the renew session returns `cs_live_`
+(not `cs_test_`) with no "No such price" error **before** charging real cards.
+
+> **Local drift:** `apps/web/.env.local` (gitignored) currently sets a THIRD
+> divergent pair (`price_1TnYlW…`) matching neither prod nor the dead IDs.
+> Reconcile it to the TEST IDs above for local↔prod parity.
+
+### 1.2 Stripe webhook endpoint — ✅ CONFIGURED (test mode; redo for live at cutover)
+Verified 2026-07-14: unsigned POST → `400 missing_signature` (not 503), bad signature → `400`. `STRIPE_WEBHOOK_SECRET` is live in Vercel Production for endpoint `we_1TtCYr…`. At LIVE cutover, create a new **live-mode** webhook and swap in its `whsec_`.
+Original setup steps (for the live re-do):
 - In Stripe Dashboard (live mode) → Developers → Webhooks, add an endpoint:
   `https://uvai.io/api/billing/webhook`.
 - Subscribe to: `checkout.session.completed`,
@@ -55,9 +75,8 @@ Set in the Vercel project env (Production):
 - The handler (`api/billing/webhook/route.ts`) returns 503 until this is set.
 - (Webhook creation isn't exposed via the Stripe MCP, hence manual.)
 
-### 1.3 Cloudflare Turnstile (checkout bot-gate)
-`/api/billing/checkout` is gated by Turnstile; unset → **every new subscriber
-gets 403**.
+### 1.3 Cloudflare Turnstile (checkout bot-gate) — ✅ LIVE (verified 2026-07-14)
+Live keys are set in Vercel Production and validating: fake token → `403 turnstile_verification_failed` (a configured, working gate — not `turnstile_not_configured`). `/api/billing/checkout` is gated by Turnstile; unset → **every new subscriber gets 403**.
 - Create a Turnstile widget at Cloudflare → get site key + secret.
 - Set in `apps/web/.env.local`:
   ```
@@ -68,8 +87,8 @@ gets 403**.
   `apps/web/.env.example`): site `1x00000000000000000000AA`,
   secret `1x0000000000000000000000000000000AA`.
 
-### 1.4 Upstash Redis (durable entitlements) — use the Vercel integration
-Paid status must survive serverless cold starts / multiple instances. In
+### 1.4 Upstash Redis (durable entitlements) — ⏳ UNVERIFIED in prod
+Code confirms the guard is correct (REST-only: reads `UPSTASH_REDIS_REST_URL/TOKEN` or `KV_REST_API_URL/TOKEN`; no `redis://`/ioredis path), but whether a Vercel integration is actually injecting those REST creds into Production **cannot be confirmed from the repo** (sensitive env). Verify on the integration page, or prove it by completing one paid E2E and checking the entitlement persists. Paid status must survive serverless cold starts / multiple instances. In
 production `assertEntitlementDurability()` **throws on boot** without Upstash.
 - **Easiest path:** install the Upstash integration from the Vercel project's
   Integrations settings (`vercel.com/<team>/<project>/settings/integrations`)
@@ -80,8 +99,8 @@ production `assertEntitlementDurability()` **throws on boot** without Upstash.
 - Manual alternative: create a DB at upstash.com and set the two vars yourself
   in `apps/web/.env.local` / Vercel env.
 
-### 1.5 Google OAuth + NextAuth (sign-in)
-Auth is Google-only and stays **off until `NEXTAUTH_SECRET` is set**.
+### 1.5 Google OAuth + NextAuth (sign-in) — ✅ LIVE (providers 200)
+Verified 2026-07-14: `/api/auth/providers` returns Google and `/api/auth/csrf` returns a token, so `NEXTAUTH_SECRET` + Google creds are set in Production. Auth is Google-only and stays **off until `NEXTAUTH_SECRET` is set**.
 - Create a Google OAuth app (Authorized redirect URI:
   `https://<domain>/api/auth/callback/google`).
 - Set in `apps/web/.env.local`:


### PR DESCRIPTION
Corrects LAUNCH_CHECKLIST §1.1 which claimed '✅ DONE (LIVE mode)' while hardcoding two dead Stripe price IDs (price_1Tos02…/price_1Tos0A…) that Stripe now rejects with 'No such price'. Documents real TEST-mode prices (price_1TtCZX…/price_1TtCZY…), adds a LIVE-cutover step, and marks §1.2 webhook / §1.3 Turnstile / §1.5 OAuth verified-live and §1.4 Redis UNVERIFIED. Docs-only; all statuses confirmed by live probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupthinking/eventrelay/pull/779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->