### PR TITLE
fix(web): harden Google OAuth + dashboard auth

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -2,8 +2,11 @@ import type { NextRequest, NextResponse } from 'next/server';
 import { proxy } from '@/proxy';
 
 /**
- * Standard Next.js middleware that activates the rate limiting logic from src/proxy.ts
- * for all /api/* routes. This makes the rate limiter "active" as claimed in runbooks.
+ * Next.js middleware entrypoint.
+ *
+ * Runs login gating + rate limiting from `src/proxy.ts` for:
+ * - /dashboard and nested product routes (session required when NEXTAUTH_SECRET is set)
+ * - /api/* (session required except public allowlist in `@/lib/auth-paths`)
  *
  * See config/agent_network.json (rate-limit-middleware agent) and the confirmed
  * remediation outcome + verification methods for full context.
@@ -17,5 +20,9 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
 }
 
 export const config = {
-  matcher: ['/api/:path*'],
+  matcher: [
+    '/dashboard',
+    '/dashboard/:path*',
+    '/api/:path*',
+  ],
 };

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -3,12 +3,24 @@ import { redirect } from 'next/navigation';
 
 export const metadata: Metadata = {
   title: 'Sign in',
-  description:
-    'UVAI is currently open for use without an account — you go straight to the dashboard.',
-  alternates: { canonical: '/dashboard' },
+  description: 'Sign in to UVAI with Google to open your dashboard.',
+  alternates: { canonical: '/login' },
   robots: { index: false, follow: true },
 };
 
-export default function LoginRedirect() {
-  redirect('/dashboard');
+/**
+ * Canonical product login entry. Middleware already gates /dashboard; this route
+ * funnels marketing "Sign in" links into the NextAuth Google flow with a safe
+ * same-origin callback.
+ */
+export default async function LoginRedirect({
+  searchParams,
+}: {
+  searchParams: Promise<{ callbackUrl?: string }>;
+}) {
+  const params = await searchParams;
+  const raw = params?.callbackUrl ?? '/dashboard';
+  const callback =
+    raw.startsWith('/') && !raw.startsWith('//') ? raw : '/dashboard';
+  redirect(`/api/auth/signin?callbackUrl=${encodeURIComponent(callback)}`);
 }

--- a/apps/web/src/lib/__tests__/auth-paths.test.ts
+++ b/apps/web/src/lib/__tests__/auth-paths.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isPublicApiPath,
+  isProtectedPagePath,
+  needsAuthentication,
+  safeCallbackPath,
+  shouldSkipRateLimit,
+} from '@/lib/auth-paths';
+
+describe('auth path policy', () => {
+  it('keeps NextAuth and Stripe webhook public', () => {
+    expect(isPublicApiPath('/api/auth')).toBe(true);
+    expect(isPublicApiPath('/api/auth/signin/google')).toBe(true);
+    expect(isPublicApiPath('/api/auth/callback/google')).toBe(true);
+    expect(isPublicApiPath('/api/billing/webhook')).toBe(true);
+    expect(isPublicApiPath('/api/billing/status')).toBe(true);
+    expect(isPublicApiPath('/api/billing/checkout')).toBe(true);
+  });
+
+  it('does not treat all billing routes as public', () => {
+    expect(isPublicApiPath('/api/billing/activate')).toBe(false);
+    expect(isPublicApiPath('/api/billing/renew')).toBe(false);
+    expect(needsAuthentication('/api/billing/activate')).toBe(true);
+    expect(needsAuthentication('/api/billing/renew')).toBe(true);
+  });
+
+  it('requires auth for product APIs and dashboard pages', () => {
+    expect(needsAuthentication('/api/chat')).toBe(true);
+    expect(needsAuthentication('/api/pipeline')).toBe(true);
+    expect(needsAuthentication('/api/video')).toBe(true);
+    expect(needsAuthentication('/dashboard')).toBe(true);
+    expect(needsAuthentication('/dashboard/agents')).toBe(true);
+    expect(isProtectedPagePath('/dashboard/agents')).toBe(true);
+  });
+
+  it('does not gate marketing pages', () => {
+    expect(needsAuthentication('/')).toBe(false);
+    expect(needsAuthentication('/pricing')).toBe(false);
+    expect(needsAuthentication('/features')).toBe(false);
+  });
+
+  it('sanitizes callback paths against open redirects', () => {
+    expect(safeCallbackPath('/dashboard')).toBe('/dashboard');
+    expect(safeCallbackPath('/dashboard', '?tab=agents')).toBe('/dashboard?tab=agents');
+    expect(safeCallbackPath('//evil.com')).toBe('/dashboard');
+    expect(safeCallbackPath('https://evil.com')).toBe('/dashboard');
+    expect(safeCallbackPath('/\\evil.com')).toBe('/dashboard');
+  });
+
+  it('skips rate limits for the auth handshake', () => {
+    expect(shouldSkipRateLimit('/api/auth/csrf')).toBe(true);
+    expect(shouldSkipRateLimit('/api/auth/callback/google')).toBe(true);
+    expect(shouldSkipRateLimit('/api/chat')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/auth-paths.ts
+++ b/apps/web/src/lib/auth-paths.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared auth path policy for middleware/proxy and unit tests.
+ * Keep this free of Next.js request types so vitest can import it offline.
+ */
+
+/** API routes that must stay reachable without a session when auth is enabled. */
+const PUBLIC_API_PREFIXES = [
+  '/api/auth', // NextAuth sign-in / callback / csrf / session
+  '/api/health', // ops probes (if present)
+] as const;
+
+/** Exact public API paths (prefix match would over-expose siblings). */
+const PUBLIC_API_EXACT = new Set([
+  // Stripe webhook verifies signature itself — must not require a user session.
+  '/api/billing/webhook',
+  // Free-tier status + acquisition checkout are pre-login surfaces.
+  // Checkout is additionally protected by Turnstile inside the route handler.
+  '/api/billing/status',
+  '/api/billing/checkout',
+]);
+
+/** App routes that require a session when NEXTAUTH_SECRET is configured. */
+const PROTECTED_PAGE_PREFIXES = ['/dashboard'] as const;
+
+export function isPublicApiPath(pathname: string): boolean {
+  if (PUBLIC_API_EXACT.has(pathname)) return true;
+  return PUBLIC_API_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+export function isProtectedPagePath(pathname: string): boolean {
+  return PROTECTED_PAGE_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+export function needsAuthentication(pathname: string): boolean {
+  if (pathname.startsWith('/api/')) {
+    return !isPublicApiPath(pathname);
+  }
+  return isProtectedPagePath(pathname);
+}
+
+/**
+ * Build a same-origin relative callback path for NextAuth.
+ * Rejects protocol-relative and absolute external URLs to prevent open redirects.
+ */
+export function safeCallbackPath(pathname: string, search = ''): string {
+  const candidate = `${pathname}${search}`;
+  if (!candidate.startsWith('/') || candidate.startsWith('//')) {
+    return '/dashboard';
+  }
+  // Block backslash tricks and encoded schemes
+  if (candidate.includes('\\') || /^\/[a-z]+:/i.test(candidate)) {
+    return '/dashboard';
+  }
+  return candidate;
+}
+
+/** Skip rate limiting for auth handshake traffic (csrf, callback, session). */
+export function shouldSkipRateLimit(pathname: string): boolean {
+  return pathname === '/api/auth' || pathname.startsWith('/api/auth/');
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -4,31 +4,126 @@ import type { NextAuthOptions } from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
 
 const allowedDomain = process.env.AUTH_ALLOWED_EMAIL_DOMAIN?.trim().toLowerCase();
+const googleClientId = process.env.GOOGLE_OAUTH_CLIENT_ID?.trim() ?? '';
+const googleClientSecret = process.env.GOOGLE_OAUTH_CLIENT_SECRET?.trim() ?? '';
 
 /**
  * NextAuth configuration (Google OAuth by default).
  *
  * Required env to activate login-gating: NEXTAUTH_SECRET, NEXTAUTH_URL,
  *   GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET.
- * Optional: AUTH_ALLOWED_EMAIL_DOMAIN restricts sign-in to a single domain.
+ * Optional: AUTH_ALLOWED_EMAIL_DOMAIN restricts sign-in to a single domain
+ *   (e.g. `yourcompany.com` → only *@yourcompany.com).
  *
  * To use a different identity provider, swap GoogleProvider here — the gating
- * in middleware.ts is provider-agnostic (it only checks for a valid session).
+ * in proxy.ts is provider-agnostic (it only checks for a valid JWT session).
  */
-export const authOptions: NextAuthOptions = {
-  providers: [
+function buildProviders(): NextAuthOptions['providers'] {
+  if (!googleClientId || !googleClientSecret) {
+    if (process.env.NODE_ENV === 'production') {
+      console.error(
+        '[auth] GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET missing — Google sign-in will fail.',
+      );
+    }
+  }
+
+  return [
     GoogleProvider({
-      clientId: process.env.GOOGLE_OAUTH_CLIENT_ID ?? '',
-      clientSecret: process.env.GOOGLE_OAUTH_CLIENT_SECRET ?? '',
+      clientId: googleClientId,
+      clientSecret: googleClientSecret,
+      authorization: {
+        params: {
+          prompt: 'select_account',
+          access_type: 'online',
+          response_type: 'code',
+        },
+      },
     }),
-  ],
-  session: { strategy: 'jwt' },
+  ];
+}
+
+function emailAllowed(email: string | null | undefined): boolean {
+  if (!allowedDomain) return true;
+  if (!email) return false;
+  const normalized = email.trim().toLowerCase();
+  // Exact domain match only (user@sub.domain.com does NOT match domain.com)
+  return normalized.endsWith(`@${allowedDomain}`);
+}
+
+export const authOptions: NextAuthOptions = {
+  providers: buildProviders(),
+  session: {
+    strategy: 'jwt',
+    maxAge: 30 * 24 * 60 * 60, // 30 days
+    updateAge: 24 * 60 * 60, // refresh session cookie once per day
+  },
   secret: process.env.NEXTAUTH_SECRET,
+  // Use secure cookie names on HTTPS (production / uvai.io)
+  useSecureCookies: process.env.NEXTAUTH_URL?.startsWith('https://') ?? process.env.NODE_ENV === 'production',
+  pages: {
+    // Keep default NextAuth UI for reliability; /login rewrites into this flow.
+    signIn: '/api/auth/signin',
+    error: '/api/auth/error',
+  },
   callbacks: {
-    async signIn({ user }) {
-      if (!allowedDomain) return true;
-      const email = (user.email ?? '').toLowerCase();
-      return email.endsWith('@' + allowedDomain);
+    async signIn({ user, account }) {
+      if (account?.provider === 'google' && !emailAllowed(user.email)) {
+        console.warn(
+          `[auth] sign-in denied for ${user.email ?? '(no email)'} — domain allowlist is @${allowedDomain}`,
+        );
+        return false;
+      }
+      return true;
+    },
+
+    async jwt({ token, user, account }) {
+      if (user) {
+        token.email = user.email;
+        token.name = user.name;
+        token.picture = user.image;
+      }
+      if (account?.provider) {
+        token.provider = account.provider;
+      }
+      return token;
+    },
+
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.email = (token.email as string | undefined) ?? session.user.email;
+        session.user.name = (token.name as string | undefined) ?? session.user.name;
+        session.user.image = (token.picture as string | undefined) ?? session.user.image;
+      }
+      return session;
+    },
+
+    /**
+     * Prevent open redirects after OAuth. Only same-origin absolute URLs or
+     * root-relative paths are allowed; everything else lands on /dashboard.
+     */
+    async redirect({ url, baseUrl }) {
+      try {
+        if (url.startsWith('/')) {
+          // protocol-relative //evil.com
+          if (url.startsWith('//')) return `${baseUrl}/dashboard`;
+          return `${baseUrl}${url}`;
+        }
+        const target = new URL(url);
+        const base = new URL(baseUrl);
+        if (target.origin === base.origin) {
+          return url;
+        }
+      } catch {
+        // fall through
+      }
+      return `${baseUrl}/dashboard`;
+    },
+  },
+  events: {
+    async signIn({ user, account }) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.info(`[auth] signIn ok provider=${account?.provider} email=${user.email ?? '?'}`);
+      }
     },
   },
 };

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import type { Redis } from '@upstash/redis';
 import { getToken } from 'next-auth/jwt';
+import {
+  needsAuthentication,
+  safeCallbackPath,
+  shouldSkipRateLimit,
+} from '@/lib/auth-paths';
 
 /**
  * Frontend proxy (Next.js 16 middleware): rate limiting (always) + login gating
@@ -8,6 +13,8 @@ import { getToken } from 'next-auth/jwt';
  * is set up — safe rollout). When enabled, /dashboard and non-public /api/* require
  * a valid NextAuth session. Server-to-server loopback calls carrying a matching
  * `x-eventrelay-internal` header (INTERNAL_REQUEST_TOKEN) bypass both.
+ *
+ * Path policy lives in `@/lib/auth-paths` so unit tests can cover it offline.
  */
 
 const WINDOW_SECONDS = 60;
@@ -29,8 +36,6 @@ const AI_ROUTE_PREFIXES = [
 const INTERNAL_TOKEN = process.env.INTERNAL_REQUEST_TOKEN;
 const AUTH_SECRET = process.env.NEXTAUTH_SECRET;
 const AUTH_ENABLED = !!AUTH_SECRET;
-// API paths that stay public even when auth is enabled (auth flow + health).
-const PUBLIC_API_PREFIXES = ['/api/auth', '/api/health', '/api/billing'];
 
 type RateLimitResult = {
   allowed: boolean;
@@ -221,31 +226,28 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   }
 
   // Login gating — enforced only when NEXTAUTH_SECRET is set; CORS preflight is exempt.
-  if (AUTH_ENABLED && request.method !== 'OPTIONS') {
-    const isApi = pathname.startsWith('/api/');
-    const isPublicApi = PUBLIC_API_PREFIXES.some(
-      (p) => pathname === p || pathname.startsWith(p + '/'),
-    );
-    const needsAuth =
-      (isApi && !isPublicApi) || pathname === '/dashboard' || pathname.startsWith('/dashboard/');
-    if (needsAuth) {
-      // next-auth resolves `NextRequest` from a second hoisted copy of `next` in this
-      // monorepo; the types are structurally identical, so bridge them.
-      const token = await getToken({ req: request as any, secret: AUTH_SECRET });
-      if (!token) {
-        if (isApi) {
-          return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
-        }
-        const signin = new URL('/api/auth/signin', request.url);
-        signin.searchParams.set('callbackUrl', request.url);
-        return NextResponse.redirect(signin);
+  if (AUTH_ENABLED && request.method !== 'OPTIONS' && needsAuthentication(pathname)) {
+    // next-auth resolves `NextRequest` from a second hoisted copy of `next` in this
+    // monorepo; the types are structurally identical, so bridge them.
+    const token = await getToken({ req: request as any, secret: AUTH_SECRET });
+    if (!token) {
+      if (pathname.startsWith('/api/')) {
+        return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
       }
+      const signin = new URL('/api/auth/signin', request.url);
+      // Relative same-origin path only — blocks open-redirect callback abuse.
+      signin.searchParams.set(
+        'callbackUrl',
+        safeCallbackPath(request.nextUrl.pathname, request.nextUrl.search),
+      );
+      return NextResponse.redirect(signin);
     }
   }
 
   if (
     process.env.UVAI_RATE_LIMIT_DISABLED === '1' ||
-    request.method === 'OPTIONS'
+    request.method === 'OPTIONS' ||
+    shouldSkipRateLimit(pathname)
   ) {
     return NextResponse.next();
   }


### PR DESCRIPTION
## Summary
- **Debug (1):** Confirmed Google OAuth start works in production (POST `/api/auth/signin/google` → 302 to accounts.google.com with PKCE). Hardened NextAuth config for clearer failures, domain allowlist logging, secure cookies, and open-redirect-safe redirects.
- **Harden (2):** Middleware matcher was `/api/*` only while `proxy.ts` intended to gate `/dashboard` — expanded matcher. Narrowed public API allowlist so `/api/billing/*` is no longer fully open (webhook/status/checkout stay public; activate/renew require session). Rate-limit skip for auth handshake. `/login` routes into NextAuth with safe callback.

## Test plan
- [x] `vitest` `auth-paths.test.ts` (6) + `billing-spoofing.test.ts` (3)
- [ ] Preview deploy: unauthenticated `/dashboard` → sign-in
- [ ] Preview: unauthenticated `/api/chat` → 401
- [ ] Preview: unauthenticated `/api/billing/activate` → 401
- [ ] Preview: unauthenticated `/api/billing/status` → 200 free payload
- [ ] Google OAuth full round-trip on preview/production after merge
- [ ] Confirm `NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `GOOGLE_OAUTH_*` set on `v0-uvai`

## Production notes
Live site: `v0-uvai` / `apps/web` / https://uvai.io  
Do **not** merge to main without a quick smoke of Google sign-in (callback URI must remain `https://uvai.io/api/auth/callback/google`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupthinking/eventrelay/pull/780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->