### PR TITLE
fix(web): resolve PR #780 review findings on Google OAuth + dashboard auth hardening

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -2,8 +2,11 @@ import type { NextRequest, NextResponse } from 'next/server';
 import { proxy } from '@/proxy';
 
 /**
- * Standard Next.js middleware that activates the rate limiting logic from src/proxy.ts
- * for all /api/* routes. This makes the rate limiter "active" as claimed in runbooks.
+ * Next.js middleware entrypoint.
+ *
+ * Runs login gating + rate limiting from `src/proxy.ts` for:
+ * - /dashboard and nested product routes (session required when NEXTAUTH_SECRET is set)
+ * - /api/* (session required except public allowlist in `@/lib/auth-paths`)
  *
  * See config/agent_network.json (rate-limit-middleware agent) and the confirmed
  * remediation outcome + verification methods for full context.
@@ -17,5 +20,9 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
 }
 
 export const config = {
-  matcher: ['/api/:path*'],
+  matcher: [
+    '/dashboard',
+    '/dashboard/:path*',
+    '/api/:path*',
+  ],
 };

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -3,12 +3,24 @@ import { redirect } from 'next/navigation';
 
 export const metadata: Metadata = {
   title: 'Sign in',
-  description:
-    'UVAI is currently open for use without an account — you go straight to the dashboard.',
-  alternates: { canonical: '/dashboard' },
+  description: 'Sign in to UVAI with Google to open your dashboard.',
+  alternates: { canonical: '/login' },
   robots: { index: false, follow: true },
 };
 
-export default function LoginRedirect() {
-  redirect('/dashboard');
+/**
+ * Canonical product login entry. Middleware already gates /dashboard; this route
+ * funnels marketing "Sign in" links into the NextAuth Google flow with a safe
+ * same-origin callback.
+ */
+export default async function LoginRedirect({
+  searchParams,
+}: {
+  searchParams: Promise<{ callbackUrl?: string }>;
+}) {
+  const params = await searchParams;
+  const raw = params?.callbackUrl ?? '/dashboard';
+  const callback =
+    raw.startsWith('/') && !raw.startsWith('//') ? raw : '/dashboard';
+  redirect(`/api/auth/signin?callbackUrl=${encodeURIComponent(callback)}`);
 }

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
+import { safeCallbackPath } from '@/lib/auth-paths';
 
 export const metadata: Metadata = {
   title: 'Sign in',
@@ -16,11 +17,14 @@ export const metadata: Metadata = {
 export default async function LoginRedirect({
   searchParams,
 }: {
-  searchParams: Promise<{ callbackUrl?: string }>;
+  searchParams: Promise<{ callbackUrl?: string | string[] }>;
 }) {
   const params = await searchParams;
-  const raw = params?.callbackUrl ?? '/dashboard';
-  const callback =
-    raw.startsWith('/') && !raw.startsWith('//') ? raw : '/dashboard';
+  // A repeated ?callbackUrl= yields an array at runtime — take the first value.
+  const rawParam = params?.callbackUrl;
+  const raw = Array.isArray(rawParam) ? rawParam[0] : rawParam;
+  // Reuse the shared sanitizer so /login enforces the same open-redirect
+  // protection (backslash + scheme tricks) as the proxy's callback handling.
+  const callback = safeCallbackPath(raw ?? '/dashboard');
   redirect(`/api/auth/signin?callbackUrl=${encodeURIComponent(callback)}`);
 }

--- a/apps/web/src/lib/__tests__/auth-paths.test.ts
+++ b/apps/web/src/lib/__tests__/auth-paths.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isPublicApiPath,
+  isProtectedPagePath,
+  needsAuthentication,
+  safeCallbackPath,
+  shouldSkipRateLimit,
+} from '@/lib/auth-paths';
+
+describe('auth path policy', () => {
+  it('keeps NextAuth and Stripe webhook public', () => {
+    expect(isPublicApiPath('/api/auth')).toBe(true);
+    expect(isPublicApiPath('/api/auth/signin/google')).toBe(true);
+    expect(isPublicApiPath('/api/auth/callback/google')).toBe(true);
+    expect(isPublicApiPath('/api/billing/webhook')).toBe(true);
+    expect(isPublicApiPath('/api/billing/status')).toBe(true);
+    expect(isPublicApiPath('/api/billing/checkout')).toBe(true);
+  });
+
+  it('does not treat all billing routes as public', () => {
+    expect(isPublicApiPath('/api/billing/activate')).toBe(false);
+    expect(isPublicApiPath('/api/billing/renew')).toBe(false);
+    expect(needsAuthentication('/api/billing/activate')).toBe(true);
+    expect(needsAuthentication('/api/billing/renew')).toBe(true);
+  });
+
+  it('requires auth for product APIs and dashboard pages', () => {
+    expect(needsAuthentication('/api/chat')).toBe(true);
+    expect(needsAuthentication('/api/pipeline')).toBe(true);
+    expect(needsAuthentication('/api/video')).toBe(true);
+    expect(needsAuthentication('/dashboard')).toBe(true);
+    expect(needsAuthentication('/dashboard/agents')).toBe(true);
+    expect(isProtectedPagePath('/dashboard/agents')).toBe(true);
+  });
+
+  it('does not gate marketing pages', () => {
+    expect(needsAuthentication('/')).toBe(false);
+    expect(needsAuthentication('/pricing')).toBe(false);
+    expect(needsAuthentication('/features')).toBe(false);
+  });
+
+  it('sanitizes callback paths against open redirects', () => {
+    expect(safeCallbackPath('/dashboard')).toBe('/dashboard');
+    expect(safeCallbackPath('/dashboard', '?tab=agents')).toBe('/dashboard?tab=agents');
+    expect(safeCallbackPath('//evil.com')).toBe('/dashboard');
+    expect(safeCallbackPath('https://evil.com')).toBe('/dashboard');
+    expect(safeCallbackPath('/\\evil.com')).toBe('/dashboard');
+  });
+
+  it('skips rate limits for the auth handshake', () => {
+    expect(shouldSkipRateLimit('/api/auth/csrf')).toBe(true);
+    expect(shouldSkipRateLimit('/api/auth/callback/google')).toBe(true);
+    expect(shouldSkipRateLimit('/api/chat')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/__tests__/auth-paths.test.ts
+++ b/apps/web/src/lib/__tests__/auth-paths.test.ts
@@ -17,11 +17,21 @@ describe('auth path policy', () => {
     expect(isPublicApiPath('/api/billing/checkout')).toBe(true);
   });
 
-  it('does not treat all billing routes as public', () => {
-    expect(isPublicApiPath('/api/billing/activate')).toBe(false);
-    expect(isPublicApiPath('/api/billing/renew')).toBe(false);
-    expect(needsAuthentication('/api/billing/activate')).toBe(true);
-    expect(needsAuthentication('/api/billing/renew')).toBe(true);
+  it('keeps checkout-lifecycle billing routes reachable without a NextAuth session', () => {
+    // activate identifies the payer from the Stripe checkout sessionId and renew
+    // from the signed billing cookie — neither has a NextAuth session at that
+    // point, so middleware must not 401 them.
+    expect(isPublicApiPath('/api/billing/activate')).toBe(true);
+    expect(isPublicApiPath('/api/billing/renew')).toBe(true);
+    expect(needsAuthentication('/api/billing/activate')).toBe(false);
+    expect(needsAuthentication('/api/billing/renew')).toBe(false);
+  });
+
+  it('still gates non-allowlisted billing routes', () => {
+    // A sibling billing route with no explicit exemption stays protected —
+    // guards against prefix-match over-exposure.
+    expect(isPublicApiPath('/api/billing/manage')).toBe(false);
+    expect(needsAuthentication('/api/billing/manage')).toBe(true);
   });
 
   it('requires auth for product APIs and dashboard pages', () => {

--- a/apps/web/src/lib/auth-paths.ts
+++ b/apps/web/src/lib/auth-paths.ts
@@ -17,6 +17,16 @@ const PUBLIC_API_EXACT = new Set([
   // Checkout is additionally protected by Turnstile inside the route handler.
   '/api/billing/status',
   '/api/billing/checkout',
+  // Post-checkout activation: a brand-new payer has no NextAuth session yet.
+  // The route establishes identity from the Stripe checkout sessionId (verified
+  // against Stripe / the checkout store), so gating it behind a NextAuth token
+  // would 401 legitimate first-time activations. It cannot be forged without a
+  // real Stripe session id, so it is safe to keep session-optional here.
+  '/api/billing/activate',
+  // Returning-user renewal: identity comes from the HMAC-signed billing cookie
+  // (or anonymous), not a NextAuth session; it only opens a Stripe checkout, so
+  // it is the same pre-payment surface class as /api/billing/checkout.
+  '/api/billing/renew',
 ]);
 
 /** App routes that require a session when NEXTAUTH_SECRET is configured. */

--- a/apps/web/src/lib/auth-paths.ts
+++ b/apps/web/src/lib/auth-paths.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared auth path policy for middleware/proxy and unit tests.
+ * Keep this free of Next.js request types so vitest can import it offline.
+ */
+
+/** API routes that must stay reachable without a session when auth is enabled. */
+const PUBLIC_API_PREFIXES = [
+  '/api/auth', // NextAuth sign-in / callback / csrf / session
+  '/api/health', // ops probes (if present)
+] as const;
+
+/** Exact public API paths (prefix match would over-expose siblings). */
+const PUBLIC_API_EXACT = new Set([
+  // Stripe webhook verifies signature itself — must not require a user session.
+  '/api/billing/webhook',
+  // Free-tier status + acquisition checkout are pre-login surfaces.
+  // Checkout is additionally protected by Turnstile inside the route handler.
+  '/api/billing/status',
+  '/api/billing/checkout',
+]);
+
+/** App routes that require a session when NEXTAUTH_SECRET is configured. */
+const PROTECTED_PAGE_PREFIXES = ['/dashboard'] as const;
+
+export function isPublicApiPath(pathname: string): boolean {
+  if (PUBLIC_API_EXACT.has(pathname)) return true;
+  return PUBLIC_API_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+export function isProtectedPagePath(pathname: string): boolean {
+  return PROTECTED_PAGE_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+export function needsAuthentication(pathname: string): boolean {
+  if (pathname.startsWith('/api/')) {
+    return !isPublicApiPath(pathname);
+  }
+  return isProtectedPagePath(pathname);
+}
+
+/**
+ * Build a same-origin relative callback path for NextAuth.
+ * Rejects protocol-relative and absolute external URLs to prevent open redirects.
+ */
+export function safeCallbackPath(pathname: string, search = ''): string {
+  const candidate = `${pathname}${search}`;
+  if (!candidate.startsWith('/') || candidate.startsWith('//')) {
+    return '/dashboard';
+  }
+  // Block backslash tricks and encoded schemes
+  if (candidate.includes('\\') || /^\/[a-z]+:/i.test(candidate)) {
+    return '/dashboard';
+  }
+  return candidate;
+}
+
+/** Skip rate limiting for auth handshake traffic (csrf, callback, session). */
+export function shouldSkipRateLimit(pathname: string): boolean {
+  return pathname === '/api/auth' || pathname.startsWith('/api/auth/');
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -58,8 +58,12 @@ export const authOptions: NextAuthOptions = {
     updateAge: 24 * 60 * 60, // refresh session cookie once per day
   },
   secret: process.env.NEXTAUTH_SECRET,
-  // Use secure cookie names on HTTPS (production / uvai.io)
-  useSecureCookies: process.env.NEXTAUTH_URL?.startsWith('https://') ?? process.env.NODE_ENV === 'production',
+  // Force secure cookies in production regardless of NEXTAUTH_URL's scheme so a
+  // stray http:// value cannot silently downgrade cookie security; also enable
+  // them whenever NEXTAUTH_URL is explicitly https (e.g. https previews).
+  useSecureCookies:
+    process.env.NODE_ENV === 'production' ||
+    (process.env.NEXTAUTH_URL?.startsWith('https://') ?? false),
   pages: {
     // Keep default NextAuth UI for reliability; /login rewrites into this flow.
     signIn: '/api/auth/signin',
@@ -67,9 +71,12 @@ export const authOptions: NextAuthOptions = {
   },
   callbacks: {
     async signIn({ user, account }) {
-      if (account?.provider === 'google' && !emailAllowed(user.email)) {
+      // Enforce the domain allowlist for every provider, not just Google, so a
+      // future provider (see comment above buildProviders) cannot bypass it.
+      // emailAllowed() is a no-op when AUTH_ALLOWED_EMAIL_DOMAIN is unset.
+      if (!emailAllowed(user.email)) {
         console.warn(
-          `[auth] sign-in denied for ${user.email ?? '(no email)'} — domain allowlist is @${allowedDomain}`,
+          `[auth] sign-in denied for ${user.email ?? '(no email)'} via ${account?.provider ?? 'unknown'} — domain allowlist is @${allowedDomain}`,
         );
         return false;
       }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -4,31 +4,126 @@ import type { NextAuthOptions } from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
 
 const allowedDomain = process.env.AUTH_ALLOWED_EMAIL_DOMAIN?.trim().toLowerCase();
+const googleClientId = process.env.GOOGLE_OAUTH_CLIENT_ID?.trim() ?? '';
+const googleClientSecret = process.env.GOOGLE_OAUTH_CLIENT_SECRET?.trim() ?? '';
 
 /**
  * NextAuth configuration (Google OAuth by default).
  *
  * Required env to activate login-gating: NEXTAUTH_SECRET, NEXTAUTH_URL,
  *   GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET.
- * Optional: AUTH_ALLOWED_EMAIL_DOMAIN restricts sign-in to a single domain.
+ * Optional: AUTH_ALLOWED_EMAIL_DOMAIN restricts sign-in to a single domain
+ *   (e.g. `yourcompany.com` → only *@yourcompany.com).
  *
  * To use a different identity provider, swap GoogleProvider here — the gating
- * in middleware.ts is provider-agnostic (it only checks for a valid session).
+ * in proxy.ts is provider-agnostic (it only checks for a valid JWT session).
  */
-export const authOptions: NextAuthOptions = {
-  providers: [
+function buildProviders(): NextAuthOptions['providers'] {
+  if (!googleClientId || !googleClientSecret) {
+    if (process.env.NODE_ENV === 'production') {
+      console.error(
+        '[auth] GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET missing — Google sign-in will fail.',
+      );
+    }
+  }
+
+  return [
     GoogleProvider({
-      clientId: process.env.GOOGLE_OAUTH_CLIENT_ID ?? '',
-      clientSecret: process.env.GOOGLE_OAUTH_CLIENT_SECRET ?? '',
+      clientId: googleClientId,
+      clientSecret: googleClientSecret,
+      authorization: {
+        params: {
+          prompt: 'select_account',
+          access_type: 'online',
+          response_type: 'code',
+        },
+      },
     }),
-  ],
-  session: { strategy: 'jwt' },
+  ];
+}
+
+function emailAllowed(email: string | null | undefined): boolean {
+  if (!allowedDomain) return true;
+  if (!email) return false;
+  const normalized = email.trim().toLowerCase();
+  // Exact domain match only (user@sub.domain.com does NOT match domain.com)
+  return normalized.endsWith(`@${allowedDomain}`);
+}
+
+export const authOptions: NextAuthOptions = {
+  providers: buildProviders(),
+  session: {
+    strategy: 'jwt',
+    maxAge: 30 * 24 * 60 * 60, // 30 days
+    updateAge: 24 * 60 * 60, // refresh session cookie once per day
+  },
   secret: process.env.NEXTAUTH_SECRET,
+  // Use secure cookie names on HTTPS (production / uvai.io)
+  useSecureCookies: process.env.NEXTAUTH_URL?.startsWith('https://') ?? process.env.NODE_ENV === 'production',
+  pages: {
+    // Keep default NextAuth UI for reliability; /login rewrites into this flow.
+    signIn: '/api/auth/signin',
+    error: '/api/auth/error',
+  },
   callbacks: {
-    async signIn({ user }) {
-      if (!allowedDomain) return true;
-      const email = (user.email ?? '').toLowerCase();
-      return email.endsWith('@' + allowedDomain);
+    async signIn({ user, account }) {
+      if (account?.provider === 'google' && !emailAllowed(user.email)) {
+        console.warn(
+          `[auth] sign-in denied for ${user.email ?? '(no email)'} — domain allowlist is @${allowedDomain}`,
+        );
+        return false;
+      }
+      return true;
+    },
+
+    async jwt({ token, user, account }) {
+      if (user) {
+        token.email = user.email;
+        token.name = user.name;
+        token.picture = user.image;
+      }
+      if (account?.provider) {
+        token.provider = account.provider;
+      }
+      return token;
+    },
+
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.email = (token.email as string | undefined) ?? session.user.email;
+        session.user.name = (token.name as string | undefined) ?? session.user.name;
+        session.user.image = (token.picture as string | undefined) ?? session.user.image;
+      }
+      return session;
+    },
+
+    /**
+     * Prevent open redirects after OAuth. Only same-origin absolute URLs or
+     * root-relative paths are allowed; everything else lands on /dashboard.
+     */
+    async redirect({ url, baseUrl }) {
+      try {
+        if (url.startsWith('/')) {
+          // protocol-relative //evil.com
+          if (url.startsWith('//')) return `${baseUrl}/dashboard`;
+          return `${baseUrl}${url}`;
+        }
+        const target = new URL(url);
+        const base = new URL(baseUrl);
+        if (target.origin === base.origin) {
+          return url;
+        }
+      } catch {
+        // fall through
+      }
+      return `${baseUrl}/dashboard`;
+    },
+  },
+  events: {
+    async signIn({ user, account }) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.info(`[auth] signIn ok provider=${account?.provider} email=${user.email ?? '?'}`);
+      }
     },
   },
 };

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -247,6 +247,10 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   if (
     process.env.UVAI_RATE_LIMIT_DISABLED === '1' ||
     request.method === 'OPTIONS' ||
+    // Page routes (e.g. /dashboard) are matched only for auth gating above.
+    // They must not be rate-limited: a JSON 429 would render as a raw blob in
+    // the browser and page navigation would burn the shared api:<ip> quota.
+    !pathname.startsWith('/api/') ||
     shouldSkipRateLimit(pathname)
   ) {
     return NextResponse.next();

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import type { Redis } from '@upstash/redis';
 import { getToken } from 'next-auth/jwt';
+import {
+  needsAuthentication,
+  safeCallbackPath,
+  shouldSkipRateLimit,
+} from '@/lib/auth-paths';
 
 /**
  * Frontend proxy (Next.js 16 middleware): rate limiting (always) + login gating
@@ -8,6 +13,8 @@ import { getToken } from 'next-auth/jwt';
  * is set up — safe rollout). When enabled, /dashboard and non-public /api/* require
  * a valid NextAuth session. Server-to-server loopback calls carrying a matching
  * `x-eventrelay-internal` header (INTERNAL_REQUEST_TOKEN) bypass both.
+ *
+ * Path policy lives in `@/lib/auth-paths` so unit tests can cover it offline.
  */
 
 const WINDOW_SECONDS = 60;
@@ -29,8 +36,6 @@ const AI_ROUTE_PREFIXES = [
 const INTERNAL_TOKEN = process.env.INTERNAL_REQUEST_TOKEN;
 const AUTH_SECRET = process.env.NEXTAUTH_SECRET;
 const AUTH_ENABLED = !!AUTH_SECRET;
-// API paths that stay public even when auth is enabled (auth flow + health).
-const PUBLIC_API_PREFIXES = ['/api/auth', '/api/health', '/api/billing'];
 
 type RateLimitResult = {
   allowed: boolean;
@@ -221,31 +226,28 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   }
 
   // Login gating — enforced only when NEXTAUTH_SECRET is set; CORS preflight is exempt.
-  if (AUTH_ENABLED && request.method !== 'OPTIONS') {
-    const isApi = pathname.startsWith('/api/');
-    const isPublicApi = PUBLIC_API_PREFIXES.some(
-      (p) => pathname === p || pathname.startsWith(p + '/'),
-    );
-    const needsAuth =
-      (isApi && !isPublicApi) || pathname === '/dashboard' || pathname.startsWith('/dashboard/');
-    if (needsAuth) {
-      // next-auth resolves `NextRequest` from a second hoisted copy of `next` in this
-      // monorepo; the types are structurally identical, so bridge them.
-      const token = await getToken({ req: request as any, secret: AUTH_SECRET });
-      if (!token) {
-        if (isApi) {
-          return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
-        }
-        const signin = new URL('/api/auth/signin', request.url);
-        signin.searchParams.set('callbackUrl', request.url);
-        return NextResponse.redirect(signin);
+  if (AUTH_ENABLED && request.method !== 'OPTIONS' && needsAuthentication(pathname)) {
+    // next-auth resolves `NextRequest` from a second hoisted copy of `next` in this
+    // monorepo; the types are structurally identical, so bridge them.
+    const token = await getToken({ req: request as any, secret: AUTH_SECRET });
+    if (!token) {
+      if (pathname.startsWith('/api/')) {
+        return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
       }
+      const signin = new URL('/api/auth/signin', request.url);
+      // Relative same-origin path only — blocks open-redirect callback abuse.
+      signin.searchParams.set(
+        'callbackUrl',
+        safeCallbackPath(request.nextUrl.pathname, request.nextUrl.search),
+      );
+      return NextResponse.redirect(signin);
     }
   }
 
   if (
     process.env.UVAI_RATE_LIMIT_DISABLED === '1' ||
-    request.method === 'OPTIONS'
+    request.method === 'OPTIONS' ||
+    shouldSkipRateLimit(pathname)
   ) {
     return NextResponse.next();
   }


### PR DESCRIPTION
## Context

This branch carries the **same content as #780** (`fix/auth-harden-google-signin`, commit `04c6978`) **plus one remediation commit** (`cba4bd4`) that resolves the automated-review findings raised on #780 by Copilot and Devin. I could not push directly to #780's branch (branch policy scopes my writes to `claude/determined-maxwell-kv8xg3`), so the fixes land here.

**Reconcile before merge — pick one:** cherry-pick `cba4bd4` onto `fix/auth-harden-google-signin` to keep #780 as the canonical PR and close this; or merge this and close #780. Do not merge both.

## Review findings resolved

| Severity | Finding | Fix |
|---|---|---|
| 🔴 Regression | Dashboard page navs were rate-limited → raw JSON 429 in browser + burned shared `api:<ip>` quota (matcher now covers `/dashboard`) | `proxy.ts`: skip rate limiting for non-`/api/*` page routes (auth gating still applies) |
| 🔴 Payment break | `/api/billing/activate` & `/renew` now required a NextAuth session, but they identify users via the **Stripe checkout sessionId** / **HMAC-signed billing cookie** — new payers have no NextAuth session → 401 on activation | `auth-paths.ts`: restore both to the public API allowlist (each is protected by its own verified mechanism); tests updated + prefix over-exposure still guarded |
| 🟨 Security | `useSecureCookies` fell to `false` in prod if `NEXTAUTH_URL` was `http://` | `auth.ts`: force secure cookies in production regardless of URL scheme |
| 🟨 Open redirect | `/login` used weaker inline callback validation than the shared util (missed `\` + scheme tricks) | `login/page.tsx`: reuse `safeCallbackPath`; normalize array `callbackUrl` |
| 🟨 Latent | Email domain allowlist enforced only for the Google provider | `auth.ts`: enforce for every provider |

Note: Copilot's `searchParams`-should-be-plain-object finding does **not** apply — this repo is on Next.js 16, where `searchParams` is a `Promise` (the existing typing is correct).

## Verification

- `tsc --noEmit` — clean
- `eslint src middleware.ts` — clean
- `vitest run` — **226/226 pass** (the `billing-chat-gating` timeout under the 5 s default is a pre-existing slow-test flake; passes with headroom, unrelated to these files)

## Not merged

Base is protected `main` and the live site (uvai.io) requires a Google sign-in smoke test before merge, per #780's own production note. Left for human merge approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvZKaZ1TRJYZ1FrgFmg9S9)_