### PR TITLE
fix(main): unbreak CI — remove orphaned AUDIT.md marker + fix Looker test isolation

### DIFF
--- a/.github/workflows/AUDIT.md
+++ b/.github/workflows/AUDIT.md
@@ -21,7 +21,6 @@ concrete reason, verified against the actual repository tree.
 | `dependency-review.yml` | KEEP | PR dependency review with documented allow-lists. |
 | `deploy-cloud-run.yml` | KEEP | The real deployment path (GCP Cloud Run); manual dispatch. |
 | `deploy.yml` | **DELETE** | References a non-existent `deployments/` tree (manifests/terraform); actual infra is `infrastructure/`. The validate job hard-`exit 1`s on missing manifests. Generic multi-cloud (AWS+Azure+Slack) scaffold that duplicates `deploy-cloud-run.yml`. |
-<<<<<<< HEAD
 | `e2e-tests.yml` | **FIX** | Resolve the PR's Vercel preview deployment via the GitHub Deployments API before E2E runs, and skip the PR-comment step for forked `pull_request` runs where `GITHUB_TOKEN` is read-only (`Resource not accessible by integration`). Same-repo PRs still get comments. |
 | `emergency-stop.yml` | KEEP | Manual operational kill-switch with typed confirmation. |
 | `issue-triage.yml` | KEEP | Keyword auto-labeling + triage comment on new issues. |

--- a/tests/unit/test_looker_security.py
+++ b/tests/unit/test_looker_security.py
@@ -10,6 +10,16 @@ except ImportError:
     mock_pydantic = MagicMock()
     sys.modules["pydantic"] = mock_pydantic
 
+# Another unit-test module (tests/unit/test_cloud_routes.py) installs a
+# MagicMock stub at sys.modules["src.integration.looker_embedded"] at import
+# time and never restores it. When pytest collects that module first, this
+# suite would otherwise import the stub instead of the real service and fail
+# (DID NOT RAISE / MagicMock attributes). Drop any stubbed leaf modules so we
+# bind to the real implementations under test.
+for _stubbed in ("src.integration.looker_embedded", "src.integration.looker_embed"):
+    if isinstance(sys.modules.get(_stubbed), MagicMock):
+        del sys.modules[_stubbed]
+
 from src.integration.looker_embedded import LookerEmbeddedService
 from src.integration.looker_embed import LookerEmbedService
 


### PR DESCRIPTION
## What this delivers

`main`'s CI has **two** independent red jobs (both surfaced while this PR was in review; neither is caused by this branch's original skills work, which #636 already landed on `main`). This PR fixes both, and nothing else. Net diff vs current `main`: **2 files, +10 / −1**.

### 1. `guards` job → `.github/workflows/AUDIT.md` (−1)

`main` carried a **single orphaned `<<<<<<< HEAD` marker** (line 24, no matching `=======`/`>>>>>>>`) between two valid decision-matrix rows. The `guards` job greps `^(<<<<<<<|>>>>>>>) ` across all tracked files, so this lone line kept it red. Removed it. *(Also independently fixed by Copilot's #796, which merged into this branch — same one-line result.)*

### 2. `test` job → `tests/unit/test_looker_security.py` (+10)

The `test` job failed with **2 failures** in `test_looker_security.py` (added by #636): `DID NOT RAISE RuntimeError` and a `MagicMock` `looker_secret`. **Root cause is cross-test pollution, not a product bug:** `tests/unit/test_cloud_routes.py` installs a module-level `MagicMock` at `sys.modules["src.integration.looker_embedded"]` via `setdefault()` with no teardown. pytest collects it before `test_looker_security.py` (alphabetical), so that suite's top-level import binds to the stub instead of the real class, and the real constructor's secret-validation never runs.

Fix: drop any `MagicMock` stub for the two looker leaf modules before importing, so the suite binds to the real implementations. The guard is a no-op when the real module is already loaded (`isinstance` check), so it doesn't affect normal runs. The real `LookerEmbeddedService`/`LookerEmbedService` already raise `RuntimeError` on a missing secret and set the secret attribute exactly as the tests assert.

## Verification

- ✅ Zero conflict markers tree-wide.
- ✅ `python -m compileall src/` exits 0; `mcp_ecosystem_coordinator.py` imports without error.
- ✅ Simulated the exact `sys.modules` pollution and confirmed the guard removes the stub so the real modules load (full pytest run deferred to CI — sandbox lacks `pydantic`).

## Notes

- The earlier revisions of this branch (20-file skills resolution + a coordinator dead-code cleanup) are **dropped**: #636 already resolved the skills files identically, and the coordinator cleanup introduced an import-time `NameError` (caught by Devin/Copilot) — it's out of scope here and can be a separate, import-tested follow-up.
- Remaining pre-merge warnings (Copilot APPROVED review; AI unit tests) are repo-policy gates for the human maintainer.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)