### PR TITLE
fix(ci): unblock the `test` job (Looker test isolation) + remove stray conflict marker

### DIFF
--- a/.github/workflows/AUDIT.md
+++ b/.github/workflows/AUDIT.md
@@ -21,7 +21,6 @@ concrete reason, verified against the actual repository tree.
 | `dependency-review.yml` | KEEP | PR dependency review with documented allow-lists. |
 | `deploy-cloud-run.yml` | KEEP | The real deployment path (GCP Cloud Run); manual dispatch. |
 | `deploy.yml` | **DELETE** | References a non-existent `deployments/` tree (manifests/terraform); actual infra is `infrastructure/`. The validate job hard-`exit 1`s on missing manifests. Generic multi-cloud (AWS+Azure+Slack) scaffold that duplicates `deploy-cloud-run.yml`. |
-<<<<<<< HEAD
 | `e2e-tests.yml` | **FIX** | Resolve the PR's Vercel preview deployment via the GitHub Deployments API before E2E runs, and skip the PR-comment step for forked `pull_request` runs where `GITHUB_TOKEN` is read-only (`Resource not accessible by integration`). Same-repo PRs still get comments. |
 | `emergency-stop.yml` | KEEP | Manual operational kill-switch with typed confirmation. |
 | `issue-triage.yml` | KEEP | Keyword auto-labeling + triage comment on new issues. |

--- a/tests/unit/test_looker_security.py
+++ b/tests/unit/test_looker_security.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import types
 from unittest.mock import MagicMock
 import sys
 
@@ -10,8 +11,19 @@ except ImportError:
     mock_pydantic = MagicMock()
     sys.modules["pydantic"] = mock_pydantic
 
-from src.integration.looker_embedded import LookerEmbeddedService
-from src.integration.looker_embed import LookerEmbedService
+# Other unit tests (e.g. test_cloud_routes, test_backend_main) register a
+# MagicMock stand-in for these modules via `sys.modules.setdefault(...)` and
+# never tear it down. When those files are collected before this one, the stale
+# mock leaks in, turning LookerEmbeddedService/LookerEmbedService into MagicMocks
+# so the security assertions below silently pass through a mock instead of the
+# real constructor. Evict any non-module (mock) stand-in so we always import the
+# real implementations, regardless of collection order.
+for _mod_name in ("src.integration.looker_embedded", "src.integration.looker_embed"):
+    if not isinstance(sys.modules.get(_mod_name), types.ModuleType):
+        sys.modules.pop(_mod_name, None)
+
+from src.integration.looker_embedded import LookerEmbeddedService  # noqa: E402
+from src.integration.looker_embed import LookerEmbedService  # noqa: E402
 
 
 def test_looker_embedded_service_no_secret():


### PR DESCRIPTION
Two small, independent CI-hygiene fixes. Rebased onto current `main`.

## 1. Fix red `test` job — Looker security test isolation (the important one)

`main`'s `test` job is currently **red** (`2 failed, 7146 passed`), which fails the test gate on **every open PR**:

```
FAILED tests/unit/test_looker_security.py::test_looker_embedded_service_no_secret - Failed: DID NOT RAISE RuntimeError
FAILED tests/unit/test_looker_security.py::test_looker_embedded_service_with_secret - AssertionError: assert <MagicMock name='mock.LookerEmbeddedService().looker_secret'> == 'test_secret'
```

**Root cause (not a bug in the implementation — it's correct):** PR #636 added `tests/unit/test_looker_security.py`, which imports the real `LookerEmbeddedService` / `LookerEmbedService`. But `test_cloud_routes.py` and `test_backend_main.py` register `MagicMock` stand-ins for those modules via `sys.modules.setdefault("src.integration.looker_embedded", MagicMock())` at module scope with **no teardown**. Those files are collected alphabetically *before* `test_looker_security.py`, so the stale mock leaks in — the constructors resolve to MagicMocks, so "no secret" never raises and `looker_secret` is a mock. The tests pass in isolation but fail in the full suite.

**Fix:** before importing, evict any non-module (mock) stand-in for the two looker modules from `sys.modules`, so the real implementations are always imported regardless of collection order. Blast radius is limited to the new test file (the polluting tests collect earlier and hold their own mock references, so they're unaffected).

**Verification:**
- Reproduced the exact CI failure with a synthetic polluter (`sys.modules.setdefault(..., MagicMock())` collected first) → same 2 failures, same `mock.LookerEmbeddedService()` assertion.
- With the fix: polluter + looker → **6 passed** (was 2 failed); looker in isolation → still **5 passed**.

## 2. Remove stray conflict marker in `.github/workflows/AUDIT.md`

An unbalanced `<<<<<<< HEAD` (no matching separator/closing marker) was left in the AUDIT.md decision-matrix doc. A tree-wide scan confirms it was the only conflict-marker artifact remaining after #786/#790 landed. Removed the stray line; the table (`deploy.yml` → `e2e-tests.yml` rows) is continuous with no content lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdMMTjhuHZbmGXp9yw1svJ