### PR TITLE
fix(ci): unbreak `test` job — stray conflict marker + Looker test-isolation leak

### DIFF
--- a/.github/workflows/AUDIT.md
+++ b/.github/workflows/AUDIT.md
@@ -21,7 +21,6 @@ concrete reason, verified against the actual repository tree.
 | `dependency-review.yml` | KEEP | PR dependency review with documented allow-lists. |
 | `deploy-cloud-run.yml` | KEEP | The real deployment path (GCP Cloud Run); manual dispatch. |
 | `deploy.yml` | **DELETE** | References a non-existent `deployments/` tree (manifests/terraform); actual infra is `infrastructure/`. The validate job hard-`exit 1`s on missing manifests. Generic multi-cloud (AWS+Azure+Slack) scaffold that duplicates `deploy-cloud-run.yml`. |
-<<<<<<< HEAD
 | `e2e-tests.yml` | **FIX** | Resolve the PR's Vercel preview deployment via the GitHub Deployments API before E2E runs, and skip the PR-comment step for forked `pull_request` runs where `GITHUB_TOKEN` is read-only (`Resource not accessible by integration`). Same-repo PRs still get comments. |
 | `emergency-stop.yml` | KEEP | Manual operational kill-switch with typed confirmation. |
 | `issue-triage.yml` | KEEP | Keyword auto-labeling + triage comment on new issues. |

--- a/tests/unit/test_backend_main.py
+++ b/tests/unit/test_backend_main.py
@@ -35,9 +35,14 @@ _STUB_MODULES = [
     "src.integration",
     "src.integration.looker_embedded",
 ]
+# Track only the stubs we actually install here, so cleanup below removes
+# exactly our fakes and never a real module another test already loaded.
+_INSTALLED_STUBS: dict[str, MagicMock] = {}
 for _mod in _STUB_MODULES:
     if _mod not in sys.modules:
-        sys.modules[_mod] = MagicMock()
+        _stub = MagicMock()
+        sys.modules[_mod] = _stub
+        _INSTALLED_STUBS[_mod] = _stub
 
 
 # ---------------------------------------------------------------------------
@@ -45,6 +50,18 @@ for _mod in _STUB_MODULES:
 # ---------------------------------------------------------------------------
 from youtube_extension.backend import main as main_module  # noqa: E402
 from youtube_extension.backend.main import app  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# backend.main now holds its own references to whatever it needed from the
+# stubs above, so remove the import-time stubs from sys.modules. Leaving them
+# in place shadows the REAL leaf modules for other test files that run later
+# in the same session (e.g. test_looker_security.py, which imports the real
+# LookerEmbeddedService and asserts it raises on a missing secret). Only
+# entries that are still exactly the stubs we installed are removed.
+# ---------------------------------------------------------------------------
+for _mod, _stub in _INSTALLED_STUBS.items():
+    if sys.modules.get(_mod) is _stub:
+        del sys.modules[_mod]
 
 # ---------------------------------------------------------------------------
 # Unique-IP generator – each test gets a fresh token-bucket so the


### PR DESCRIPTION
Rebased onto current `main` (`8783920`). Fixes two independent defects that redden the CI **`test`** job on `main` — and therefore on **every** open PR.

## 1. Stray orphan conflict marker in `.github/workflows/AUDIT.md`

`main` contained a lone `<<<<<<< HEAD` (line 24) with **no matching `=======`/`>>>>>>>`** — the only real git-conflict marker in the tree. Removed → tree now has **0** markers (`git grep -lE '^(<<<<<<<|>>>>>>>)'` = 0).

> Note: the "unbreak main" cluster (#737, #787, #788, #789, #790) is stale — the legitimate marker cleanup already merged as **#786**, and those PRs diff against the pre-force-push base `b8df87b`, so merging them would revert good code. They should be **closed**, not merged.

## 2. Looker test-isolation leak (the actual red CI)

`tests/unit/test_looker_security.py` (added by #636) fails **2 assertions** in the full suite:

```
FAILED test_looker_embedded_service_no_secret   - Failed: DID NOT RAISE RuntimeError
FAILED test_looker_embedded_service_with_secret - looker_secret was a MagicMock
```

**Root cause:** `tests/unit/test_backend_main.py` installs `MagicMock` stubs into `sys.modules` for `src`, `src.integration`, and `src.integration.looker_embedded` at import time and **never removes them**. It sorts before `test_looker_security.py`, so the leaked `looker_embedded` stub makes `from src.integration.looker_embedded import LookerEmbeddedService` resolve to a `MagicMock` — the service neither raises on a missing secret nor exposes a real `looker_secret`. Passes in isolation, fails in the 7146-test suite (order-dependent).

**Fix:** track the stubs we install and delete exactly those from `sys.modules` after `backend.main` is imported, so they stop shadowing the real leaf modules for later tests. This mirrors the existing, proven cleanup pattern already in `tests/unit/test_cloud_routes.py` (lines ~101-113).

## Verification

- `python -m py_compile tests/unit/test_backend_main.py` → OK.
- Cleanup only deletes a `sys.modules` entry when it is *still exactly* the stub we installed (`is` check) — never a real module another test loaded.
- The failing `test` job re-runs on this push and is the authoritative check (full pytest suite is not runnable in the authoring sandbox — deps not installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)