### PR TITLE
fix: unbreak main CI — last conflict marker + looker test-isolation regression

### DIFF
--- a/.github/workflows/AUDIT.md
+++ b/.github/workflows/AUDIT.md
@@ -21,7 +21,6 @@ concrete reason, verified against the actual repository tree.
 | `dependency-review.yml` | KEEP | PR dependency review with documented allow-lists. |
 | `deploy-cloud-run.yml` | KEEP | The real deployment path (GCP Cloud Run); manual dispatch. |
 | `deploy.yml` | **DELETE** | References a non-existent `deployments/` tree (manifests/terraform); actual infra is `infrastructure/`. The validate job hard-`exit 1`s on missing manifests. Generic multi-cloud (AWS+Azure+Slack) scaffold that duplicates `deploy-cloud-run.yml`. |
-<<<<<<< HEAD
 | `e2e-tests.yml` | **FIX** | Resolve the PR's Vercel preview deployment via the GitHub Deployments API before E2E runs, and skip the PR-comment step for forked `pull_request` runs where `GITHUB_TOKEN` is read-only (`Resource not accessible by integration`). Same-repo PRs still get comments. |
 | `emergency-stop.yml` | KEEP | Manual operational kill-switch with typed confirmation. |
 | `issue-triage.yml` | KEEP | Keyword auto-labeling + triage comment on new issues. |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,9 +31,17 @@ if _REPO_ROOT not in sys.path:
 # those setdefault() calls no-ops, keeping `src` a proper package.
 # NOTE: we deliberately do NOT import src.agents — its __init__ is heavy and
 # some tests intentionally stub the src.agents namespace.
+#
+# We also pre-import src.integration.looker_embedded specifically: test_backend_main
+# stubs that submodule as a MagicMock in sys.modules (guarded by `if not in
+# sys.modules`), and it never restores it. Once real test_looker_security started
+# importing the real class, that leaked mock made it fail. Pre-importing the real
+# (cheap) submodule here turns the guarded stub into a no-op. It imports only
+# stdlib + pydantic, so it is safe to load eagerly.
 try:
     import src  # noqa: F401
     import src.integration  # noqa: F401
+    import src.integration.looker_embedded  # noqa: F401
 except Exception:
     pass
 


### PR DESCRIPTION
Two independent breakages on `main`, both keeping CI red. Rebased onto current `main` (`8783920`).

## 1. `guards` job — last committed conflict marker

`.github/workflows/AUDIT.md:24` carried a dangling `<<<<<<< HEAD` (no matching `=======` / `>>>>>>>`) between two valid table rows — the last committed conflict marker in the tree after `#786` resolved the `src/skills/` package. Removed it.

- `git grep -nE '^(<<<<<<< |=======$|>>>>>>> )'` over the whole tree → **empty**.

## 2. `test` job — 2 failing tests in `tests/unit/test_looker_security.py`

Added by `#636` (merged as `d79af05`), these have failed on `main` ever since — `LookerEmbeddedService()` resolved to a `MagicMock`.

**Root cause — cross-test `sys.modules` pollution (deterministic, not flaky):** `tests/unit/test_backend_main.py` stubs `src.integration.looker_embedded` as a `MagicMock` in `sys.modules` (guarded by `if _mod not in sys.modules`) and never restores it. It collects before `test_looker_security` (`b` < `l`), so the later real import received the leaked mock → "DID NOT RAISE RuntimeError" / `MagicMock == 'test_secret'`.

**Fix:** extend the conftest's existing pre-import mitigation (which already does this for `src` / `src.integration`) to the `looker_embedded` submodule, so the guarded stub becomes a no-op and the real class is preserved.

**Verification (run locally):**
- `test_looker_security.py` alone → 5 passed.
- Reproduced the failure: real-conftest run with the polluter first → `MagicMock`, DID NOT RAISE.
- With the fix: stand-in polluter first + `test_looker_security` → **all 5 pass**.
- Safe for `test_backend_main`: `LookerEmbeddedService` is only instantiated inside a per-request FastAPI dependency (`get_looker_service`), never at import time, so loading the real module raises nothing.

## Context for reviewers
- `#787` / `#788` / `#789` / `#790` (conflict-marker PRs) are **redundant** — cut against stale base `b8df87b`, superseded by merged `#786`. Recommend closing.
- Root process gap: the `guards` job is **not an enforced required check** — PRs (e.g. `#571`) have merged into `main` with `guards` red. Making `guards` (and `test`) required in branch protection is the durable fix (repo-admin action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)