### PR TITLE
fix(ci): unbreak main's conflict-marker guard + finish dead-code cleanup safely

### DIFF
--- a/.github/workflows/AUDIT.md
+++ b/.github/workflows/AUDIT.md
@@ -21,7 +21,6 @@ concrete reason, verified against the actual repository tree.
 | `dependency-review.yml` | KEEP | PR dependency review with documented allow-lists. |
 | `deploy-cloud-run.yml` | KEEP | The real deployment path (GCP Cloud Run); manual dispatch. |
 | `deploy.yml` | **DELETE** | References a non-existent `deployments/` tree (manifests/terraform); actual infra is `infrastructure/`. The validate job hard-`exit 1`s on missing manifests. Generic multi-cloud (AWS+Azure+Slack) scaffold that duplicates `deploy-cloud-run.yml`. |
-<<<<<<< HEAD
 | `e2e-tests.yml` | **FIX** | Resolve the PR's Vercel preview deployment via the GitHub Deployments API before E2E runs, and skip the PR-comment step for forked `pull_request` runs where `GITHUB_TOKEN` is read-only (`Resource not accessible by integration`). Same-repo PRs still get comments. |
 | `emergency-stop.yml` | KEEP | Manual operational kill-switch with typed confirmation. |
 | `issue-triage.yml` | KEEP | Keyword auto-labeling + triage comment on new issues. |

--- a/src/agents/mcp_ecosystem_coordinator.py
+++ b/src/agents/mcp_ecosystem_coordinator.py
@@ -4,13 +4,14 @@ MCP Ecosystem Coordinator
 Unified hub for coordinating all MCP servers in the YouTube extension ecosystem
 """
 
+from __future__ import annotations
+
 import abc
 import asyncio
 import importlib
 import json
 import logging
 import os
-import sys
 from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 # REMOVED: sys.path.append removed
 
 logger = logging.getLogger(__name__)
-SKILLS_LOCK_FILE = Path(__file__).resolve().parents[2] / "skills-lock.json"
+
 
 class BaseMCPServer(abc.ABC):
     """Abstract base class for all MCP servers."""
@@ -164,44 +165,6 @@ class MCPYouTubeAPIProxyServer(BaseMCPServer):
         return {"status": "healthy", "server": self.name}
 
 
-class SkillRegistry:
-    """Registry for EventRelay GTM skills defined in skills-lock.json."""
-
-    def __init__(self, lock_file: Path = SKILLS_LOCK_FILE):
-        self.lock_file = Path(lock_file)
-        self._skills: list[dict[str, Any]] = []
-        self._load()
-
-    def _load(self) -> None:
-        if not self.lock_file.exists():
-            self._skills = []
-            return
-
-        data = json.loads(self.lock_file.read_text())
-        candidates = [
-            data.get("eventrelay_skills"),
-            data.get("skills"),
-            data.get("skills", {}).get("eventrelay_skills")
-            if isinstance(data.get("skills"), dict)
-            else None,
-        ]
-        for candidate in candidates:
-            if isinstance(candidate, list):
-                self._skills = candidate
-                return
-        self._skills = []
-
-    def list_skills(self, trigger: str | None = None) -> list[dict[str, Any]]:
-        if not trigger:
-            return list(self._skills)
-        return [s for s in self._skills if trigger in s.get("triggers", [])]
-
-    def get_skill(self, skill_id: str) -> dict[str, Any] | None:
-        for skill in self._skills:
-            if skill.get("id") == skill_id:
-                return skill
-        return None
-
 class MCPEcosystemCoordinator:
     """Coordinates multiple MCP servers, routing requests and managing capabilities."""
 
@@ -249,77 +212,16 @@ class MCPEcosystemCoordinator:
         return all_capabilities
 
     async def invoke_skill(
-        self,
-        skill_id: str,
-        payload: dict[str, Any],
-        env_vars: dict[str, str] | None = None,
+        self, skill_id: str, payload: dict[str, Any]
     ) -> dict[str, Any]:
-        """Invoke a configured skill as a subprocess with explicit env pass-through."""
-        skill = self.skill_registry.get_skill(skill_id)
-        if not skill:
-            return {"status": "error", "message": f"Skill '{skill_id}' not found"}
+        """Invoke a GTM skill via the class-based SkillRegistry.
 
-        entry_point = skill.get("entry_point")
-        if not entry_point:
-            return {"status": "error", "message": f"Skill '{skill_id}' has no entry_point"}
-        entry_path = Path(entry_point)
-        if not entry_path.is_absolute():
-            entry_path = Path(__file__).resolve().parents[2] / entry_path
-
-        required_env_vars = skill.get("required_env_vars", [])
-        explicit_env = self._build_skill_env(required_env_vars, env_vars or {})
-        missing_env_vars = [
-            var_name for var_name in required_env_vars if var_name not in explicit_env
-        ]
-        if missing_env_vars:
-            return {
-                "status": "error",
-                "message": f"Missing required env vars for skill '{skill_id}': {missing_env_vars}",
-            }
-
-        try:
-            encoded_payload = json.dumps(payload).encode("utf-8")
-        except TypeError as e:
-            return {"status": "error", "message": f"Failed to serialize skill payload to JSON: {e}"}
-
-        process = await asyncio.create_subprocess_exec(
-            sys.executable,
-            str(entry_path),
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=explicit_env,
-        )
-        stdout, stderr = await process.communicate(encoded_payload)
-
-        if process.returncode != 0:
-            return {
-                "status": "error",
-                "message": stderr.decode("utf-8").strip() or "Skill execution failed",
-            }
-
-        output = stdout.decode("utf-8").strip()
-        if not output:
-            return {"status": "success"}
-        return json.loads(output)
-
-    def _build_skill_env(
-        self, required_env_vars: list[str], env_vars: dict[str, str]
-    ) -> dict[str, str]:
-        explicit_env = {}
-        # Essential system variables needed by Python subprocesses.
-        for var_name in ("PATH", "HOME", "USER", "PYTHONPATH"):
-            var_value = os.getenv(var_name)
-            if var_value:
-                explicit_env[var_name] = var_value
-        for var_name in required_env_vars:
-            if var_name in env_vars:
-                explicit_env[var_name] = env_vars[var_name]
-            else:
-                var_value = os.getenv(var_name)
-                if var_value:
-                    explicit_env[var_name] = var_value
-        return explicit_env
+        Thin delegate to ``SkillRegistry.invoke_skill``, which resolves the
+        skill class from ``skills-lock.json`` and runs it in-process with
+        dependency injection. The registry is the single invocation path used
+        by the tests and callers.
+        """
+        return await self.skill_registry.invoke_skill(skill_id, payload)
 
     async def dispatch_request(self, server_name: str, request: dict) -> dict:
         """Dispatches a request to the specified MCP server."""
@@ -407,8 +309,9 @@ class SkillRegistry:
     """Registry for discovering and invoking GTM skills from skills-lock.json.
 
     Reads skill definitions from the lock file and dynamically loads skill
-    classes for execution. Implements explicit env-var pass-through when
-    spawning skill processes (no reliance on environment inheritance).
+    classes for in-process execution, resolving each skill's declared
+    dependencies via the service container (dependency injection) rather than
+    spawning subprocesses.
     """
 
     _LOCK_FILE = "skills-lock.json"


### PR DESCRIPTION
## Summary

Two small, verified fixes on top of current `main` (rebased clean; the earlier
"resolve 20 files" commit from this branch was dropped because #786 already
resolved those markers on `main`).

### 1. `fix(ci)` — remove dangling `<<<<<<< HEAD` in `.github/workflows/AUDIT.md`
`AUDIT.md` still carried a lone `<<<<<<< HEAD` sentinel (no matching
`=======`/`>>>>>>>`) left over from a hand-resolved merge. The conflict-marker
guard in `ci.yml` greps `^(<<<<<<<|>>>>>>>) ` across the whole tree, excluding
only `ci.yml` itself — so this single line keeps that job **red on `main` right
now**. Removing the stray sentinel preserves all table content.

### 2. `refactor(coordinator)` — finish the dead subprocess-skill cleanup, import-safely
Re-applies the removal of the dead, subprocess-based skill-invocation path in
`src/agents/mcp_ecosystem_coordinator.py` (dead list-based `SkillRegistry`,
`SKILLS_LOCK_FILE`, `_build_skill_env`, the `create_subprocess_exec` body with
zero repo-wide callers) — delegating `invoke_skill` to the class-based
`SkillRegistry`.

**Regression caught & fixed during verification:** deleting the *earlier*
list-based `SkillRegistry` left the surviving dict-based class defined *after*
`MCPEcosystemCoordinator`, whose `__init__(self, skill_registry: SkillRegistry | None)`
annotation is evaluated at class-definition time → `NameError` at import. Fixed
by adding `from __future__ import annotations` (PEP 563 deferred annotations; the
module uses no runtime annotation introspection, so this is safe).

## Verification
- CI conflict-marker guard command (`git grep '^(<<<<<<<|>>>>>>>) ' -- . ':(exclude).github/workflows/ci.yml'`) → **no markers**.
- `python -m py_compile` on the coordinator → OK; module imports and `MCPEcosystemCoordinator()` instantiates with a real `SkillRegistry`.
- `tests/integration/test_skill_di.py` (2) + `tests/test_skills_integration.py` (29) → **31 passed**.

## Notes
This branch was reconciled onto latest `main` (it had no prior PR). Merge is left
to human sign-off per branch policy.


---
_Generated by [Claude Code](https://claude.ai/code/session_015MdGp2KYL9kf6oBAip8Z8s)_