### PR TITLE
fix(ci): remove orphaned conflict marker in AUDIT.md that fails the guards job on main

### DIFF
--- a/.github/workflows/AUDIT.md
+++ b/.github/workflows/AUDIT.md
@@ -21,7 +21,6 @@ concrete reason, verified against the actual repository tree.
 | `dependency-review.yml` | KEEP | PR dependency review with documented allow-lists. |
 | `deploy-cloud-run.yml` | KEEP | The real deployment path (GCP Cloud Run); manual dispatch. |
 | `deploy.yml` | **DELETE** | References a non-existent `deployments/` tree (manifests/terraform); actual infra is `infrastructure/`. The validate job hard-`exit 1`s on missing manifests. Generic multi-cloud (AWS+Azure+Slack) scaffold that duplicates `deploy-cloud-run.yml`. |
-<<<<<<< HEAD
 | `e2e-tests.yml` | **FIX** | Resolve the PR's Vercel preview deployment via the GitHub Deployments API before E2E runs, and skip the PR-comment step for forked `pull_request` runs where `GITHUB_TOKEN` is read-only (`Resource not accessible by integration`). Same-repo PRs still get comments. |
 | `emergency-stop.yml` | KEEP | Manual operational kill-switch with typed confirmation. |
 | `issue-triage.yml` | KEEP | Keyword auto-labeling + triage comment on new issues. |


### PR DESCRIPTION
## Summary

Root-cause fix for why the merge queue is jammed. `main`'s `ci.yml` **`guards`** job greps the whole tree for committed `<<<<<<< ` / `>>>>>>> ` merge-conflict markers (excluding only `ci.yml` itself). `.github/workflows/AUDIT.md:24` carried a single **orphaned `<<<<<<< HEAD`** line — no matching `=======`/`>>>>>>>`, just leftover text inside a documentation table.

That one line makes the `guards` job **fail on `main` itself**, and every open PR inherits the red check. With branch protection requiring green checks, this blocks the *entire* backlog of open PRs from merging.

## Why prior fixes missed it

The several "resolve committed conflict markers" PRs (#734/#737/#787/#788/#789/#790) scanned **code** files. This marker lives in a **workflow documentation** file (`.github/workflows/AUDIT.md`), so it survived every prior pass. It is the sole remaining offender:

```
$ git grep -nE '^(<<<<<<<|>>>>>>>) ' -- . ':(exclude).github/workflows/ci.yml'
.github/workflows/AUDIT.md:24:<<<<<<< HEAD   # ← the only match on main
```

## Change

- Delete the orphaned `<<<<<<< HEAD` line (1 line, 1 file). The table rows above and below are already continuous, so removal restores a clean, valid table.

## Verification

- Reproduced the exact `guards`-job command on this branch — returns clean (no markers), so the job goes green:
  ```
  git grep -nE '^(<<<<<<<|>>>>>>>) ' -- . ':(exclude).github/workflows/ci.yml'  →  (no output)
  ```
- Diff is `1 file changed, 1 deletion(-)` — documentation only, no code or workflow-logic change.

## Not auto-merged

Draft, targeting protected `main`. Merging needs human sign-off. Once merged, `main`'s `guards` job turns green and the inherited red check clears from the rest of the open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdTF5JRWGfV3T5fxqoekWm

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdTF5JRWGfV3T5fxqoekWm)_