### PR TITLE
fix(web): transcript fallback race no longer hangs when all providers fail

### DIFF
--- a/apps/web/src/lib/__tests__/transcription-first-non-null.test.ts
+++ b/apps/web/src/lib/__tests__/transcription-first-non-null.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { firstNonNull } from '@/lib/transcription-service';
+
+// Regression guard for the transcript-fallback race: when every provider
+// resolves to null (or rejects), the resolver must SETTLE to null rather than
+// hang. The previous Promise.race()-over-PENDING_FOREVER implementation hung
+// forever in exactly this case, wedging the request.
+
+const defer = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe('firstNonNull', () => {
+  it('resolves null when there are no candidates', async () => {
+    await expect(firstNonNull<string>([])).resolves.toBeNull();
+  });
+
+  it('settles to null (does not hang) when every candidate resolves null', async () => {
+    const result = await firstNonNull<string>([
+      Promise.resolve(null),
+      Promise.resolve(null),
+      Promise.resolve(null),
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it('settles to null when every candidate rejects', async () => {
+    const result = await firstNonNull<string>([
+      Promise.reject(new Error('a')),
+      Promise.reject(new Error('b')),
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it('returns the first non-null result without waiting for slow candidates', async () => {
+    const slow = defer<string | null>();
+    const result = await firstNonNull<string>([
+      Promise.resolve(null),
+      Promise.resolve('winner'),
+      slow.promise,
+    ]);
+    expect(result).toBe('winner');
+    // Slow candidate never settles; the resolver must not have awaited it.
+  });
+
+  it('treats a falsy-but-non-null value as a real result', async () => {
+    const result = await firstNonNull<string>([
+      Promise.resolve(null),
+      Promise.resolve(''),
+    ]);
+    expect(result).toBe('');
+  });
+
+  it('skips a rejecting candidate and returns a later non-null result', async () => {
+    const result = await firstNonNull<string>([
+      Promise.reject(new Error('boom')),
+      Promise.resolve(null),
+      Promise.resolve('ok'),
+    ]);
+    expect(result).toBe('ok');
+  });
+});

--- a/apps/web/src/lib/transcription-service.ts
+++ b/apps/web/src/lib/transcription-service.ts
@@ -17,10 +17,31 @@ const rawBackendUrl = process.env.BACKEND_URL || '';
 const BACKEND_URL = rawBackendUrl.startsWith('http') ? rawBackendUrl : 'http://localhost:8000';
 const BACKEND_AVAILABLE = rawBackendUrl.startsWith('http');
 
-// A never-resolving promise used to skip null candidates in Promise.race():
-// when a candidate resolves to null we swap it for this so the race ignores it
-// and waits for a real result from another candidate.
-const PENDING_FOREVER = new Promise<never>(() => {});
+// Resolve with the first non-null candidate, or null once every candidate has
+// settled (resolved null or rejected). Unlike Promise.race() over null-swapped
+// promises, this always settles — it cannot hang when every candidate fails.
+export function firstNonNull<T>(candidates: Promise<T | null>[]): Promise<T | null> {
+  return new Promise(resolve => {
+    let remaining = candidates.length;
+    if (remaining === 0) {
+      resolve(null);
+      return;
+    }
+    const settle = (value: T | null) => {
+      // Null check, not a truthy check: a falsy-but-valid result (e.g. an empty
+      // string or 0 for other T) must count as a real result, not a failed
+      // candidate. null is the only "no result" sentinel here.
+      if (value !== null) {
+        resolve(value);
+      } else if (--remaining === 0) {
+        resolve(null);
+      }
+    };
+    for (const p of candidates) {
+      p.then(settle, () => settle(null));
+    }
+  });
+}
 
 export interface TranscriptionOptions {
   url?: string;
@@ -236,19 +257,12 @@ ${metadataContext ? `\nKNOWN METADATA:\n${metadataContext}` : ''}`,
 
     if (candidates.length > 0) {
       // Run all candidates concurrently and return the first non-null result.
-      // When a candidate resolves to null (no usable transcript found), we
-      // replace it with PENDING_FOREVER so Promise.race() skips it and waits
-      // for a successful result from another candidate.
-      const winner = await Promise.race(
-        candidates.map(p => p.then(r => r ?? PENDING_FOREVER))
-      ).catch(() => null);
+      // firstNonNull resolves as soon as any candidate yields a usable result,
+      // and resolves null once every candidate has failed — so this never hangs
+      // when all providers return null (a Promise.race() over null-swapped
+      // promises would hang forever in that case).
+      const winner = await firstNonNull(candidates);
       if (winner) return winner;
-      // If the race produced no winner (all candidates resolved to null),
-      // wait for all results and return the first usable one.
-      const results = await Promise.allSettled(candidates);
-      for (const r of results) {
-        if (r.status === 'fulfilled' && r.value) return r.value;
-      }
     }
   }
 


### PR DESCRIPTION
## Problem

The parallel transcript-fallback path in `apps/web/src/lib/transcription-service.ts` can **hang forever** when every transcription provider fails.

The code races candidates and swaps each `null` result for a never-resolving `PENDING_FOREVER` promise:

```ts
const winner = await Promise.race(
  candidates.map(p => p.then(r => r ?? PENDING_FOREVER))
).catch(() => null);
if (winner) return winner;
// intended fallback — but this is unreachable
const results = await Promise.allSettled(candidates);
```

Providers `return null` on failure (they don't reject). So when **all** providers fail, every mapped promise becomes `PENDING_FOREVER`, `await Promise.race(...)` never settles, and the request wedges. The `Promise.allSettled` fallback below it is **dead code** — execution never reaches it. `.catch()` only handles rejections, not the never-settling case.

## Fix

Replace the race with a `firstNonNull` helper that:
- resolves with the **first non-null** candidate as soon as one arrives, and
- resolves `null` once **every** candidate has settled (resolved null or rejected),

so the path can never hang. The sentinel check is a strict `!== null` (not truthy), so a falsy-but-valid result isn't misread as a failure.

## Notes

- This ports the fix cleanly onto current `main`. PR #624 carried the same intent but was built on a stale base and conflicts across all 5 touched files (it would also revert `main`'s later refinements), so it can't merge as-is. This PR is the minimal, conflict-free version. #624 can be closed as superseded.

## Tests

Adds `transcription-first-non-null.test.ts` (vitest) covering: empty input, all-null (the hang case), all-reject, fast-winner-with-a-slow-never-settling-candidate, falsy-but-valid result, and skip-a-rejection-then-succeed.

> Note: in-sandbox execution of the suite wasn't possible (no `node_modules`); the test follows the repo's existing vitest conventions and the aliased `server-only` stub, and runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MAwpdNJWR7BsQmmhus8dM

---
_Generated by [Claude Code](https://claude.ai/code/session_019MAwpdNJWR7BsQmmhus8dM)_