### PR TITLE
fix(ci): unblock main — drop stray conflict marker + make Looker security test hermetic

### DIFF
--- a/.github/workflows/AUDIT.md
+++ b/.github/workflows/AUDIT.md
@@ -21,7 +21,6 @@ concrete reason, verified against the actual repository tree.
 | `dependency-review.yml` | KEEP | PR dependency review with documented allow-lists. |
 | `deploy-cloud-run.yml` | KEEP | The real deployment path (GCP Cloud Run); manual dispatch. |
 | `deploy.yml` | **DELETE** | References a non-existent `deployments/` tree (manifests/terraform); actual infra is `infrastructure/`. The validate job hard-`exit 1`s on missing manifests. Generic multi-cloud (AWS+Azure+Slack) scaffold that duplicates `deploy-cloud-run.yml`. |
-<<<<<<< HEAD
 | `e2e-tests.yml` | **FIX** | Resolve the PR's Vercel preview deployment via the GitHub Deployments API before E2E runs, and skip the PR-comment step for forked `pull_request` runs where `GITHUB_TOKEN` is read-only (`Resource not accessible by integration`). Same-repo PRs still get comments. |
 | `emergency-stop.yml` | KEEP | Manual operational kill-switch with typed confirmation. |
 | `issue-triage.yml` | KEEP | Keyword auto-labeling + triage comment on new issues. |

--- a/tests/unit/test_looker_security.py
+++ b/tests/unit/test_looker_security.py
@@ -2,6 +2,8 @@ import os
 import pytest
 from unittest.mock import MagicMock
 import sys
+import importlib.util
+from pathlib import Path
 
 # Mock pydantic if it's not available
 try:
@@ -10,8 +12,30 @@ except ImportError:
     mock_pydantic = MagicMock()
     sys.modules["pydantic"] = mock_pydantic
 
-from src.integration.looker_embedded import LookerEmbeddedService
-from src.integration.looker_embed import LookerEmbedService
+# These security tests must exercise the REAL Looker services, not a mock.
+# Other unit-test modules (test_backend_main, test_cloud_routes) install a
+# MagicMock at "src.integration.looker_embedded" in sys.modules at import time,
+# and test_backend_main does not remove it. Depending on pytest's collection
+# order that stale stub would otherwise make LookerEmbeddedService resolve to a
+# MagicMock here (the class would no longer raise on a missing secret). Load
+# the modules directly from their source files under private names so this test
+# is hermetic regardless of sys.modules state.
+_SRC = Path(__file__).resolve().parents[2] / "src"
+
+
+def _load_real(module_name: str, rel_path: str):
+    spec = importlib.util.spec_from_file_location(module_name, _SRC / rel_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+LookerEmbeddedService = _load_real(
+    "_real_looker_embedded", "integration/looker_embedded.py"
+).LookerEmbeddedService
+LookerEmbedService = _load_real(
+    "_real_looker_embed", "integration/looker_embed.py"
+).LookerEmbedService
 
 
 def test_looker_embedded_service_no_secret():


### PR DESCRIPTION
## Why

CI on `main` (`d79af055`) is currently **red** — two independent jobs fail on every push. Neither is a real conflict/regression; both are stale artifacts. This PR turns both green.

## What's failing (verified against run 29386645390 on `main`)

| Job | Failing step | Root cause |
|-----|--------------|------------|
| `guards` | *No committed merge-conflict markers* | `.github/workflows/AUDIT.md:24` has a single dangling `<<<<<<< HEAD` sentinel left over from a merge. The guard greps the whole tree for `^(<<<<<<<\|>>>>>>>) ` and `exit 1`s, even though no real conflict remains. |
| `test` | `tests/unit/test_looker_security.py` (2 cases) | `LookerEmbeddedService` resolves to a `MagicMock`. `tests/unit/test_backend_main.py` installs a `MagicMock()` at `src.integration.looker_embedded` in `sys.modules` at import time and never removes it (unlike `test_cloud_routes.py`, which cleans up after itself). By pytest collection order the stub leaks into the security test. |

The remaining 7146 tests pass; the `src/skills` conflict-marker breakage was already resolved on `main` by #786.

## Changes

- **`.github/workflows/AUDIT.md`** — remove the stray `<<<<<<< HEAD` line. The audit table is otherwise intact.
- **`tests/unit/test_looker_security.py`** — load the real `LookerEmbeddedService` / `LookerEmbedService` from their source files under private module names, so the security test is hermetic regardless of `sys.modules` pollution and collection order. The service source is correct (it raises `RuntimeError` when `LOOKER_EMBED_SECRET` is unset); only the test's import was fragile. No production code changed.

## Verification

- `git grep -nE '^(<<<<<<<|>>>>>>>) ' -- . ':(exclude).github/workflows/ci.yml'` → empty (guard passes).
- `python -m compileall -q src/` → clean.
- Hermetic loader confirmed to return the real class (not a mock) and preserve raise-on-missing-secret behavior even with the stub pre-installed in `sys.modules`.

## Not in scope

The underlying `sys.modules` leak in `test_backend_main.py` is left in place (it also stubs `src` / `src.integration` for its own run); the hermetic import makes the security test immune without risking that module's setup. Flagging it for a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEsiyBDPfEDcxQ7mYZ7KgM)_