### PR TITLE
fix(ci): unblock main — align reporting 500 test with sanitized detail

### DIFF
--- a/tests/unit/test_cloud_routes.py
+++ b/tests/unit/test_cloud_routes.py
@@ -1316,7 +1316,11 @@ class TestReportingRoutes:
             }
         )
         assert response.status_code == 500
-        assert "Failed to generate" in response.json()["detail"]
+        # The 500 body must be sanitized (CWE-209): a static message, never the
+        # caught exception text. See reporting_routes.generate_dashboard_url.
+        detail = response.json()["detail"]
+        assert detail == "Internal server error"
+        assert "Looker unavailable" not in detail
 
     def test_generate_dashboard_url_missing_fields(self):
         """Missing required fields return 422."""


### PR DESCRIPTION
## Summary

`main` CI has been **red on the `test` job** since the #805 merge (~2h) — `1 failed, 7163 passed`. The single failure is a stale test, not a code regression:

- `reporting_routes.generate_dashboard_url` already returns a sanitized `HTTPException(status_code=500, detail="Internal server error")` (CWE-209 hardening — merged to `main`).
- But `tests/unit/test_cloud_routes.py::TestReportingRoutes::test_generate_dashboard_url_service_error` still asserted `"Failed to generate" in detail`, which no longer holds → `AssertionError: assert 'Failed to generate' in 'Internal server error'`.

This is a symptom of the 500-hardening work being split across the duplicate-PR cluster: the source-sanitization half landed on `main` while the matching test update lived only in the still-open **#818**.

## Change

Update the assertion to expect the sanitized body and to prove the caught exception text does not leak to the client:

```python
detail = response.json()["detail"]
assert detail == "Internal server error"
assert "Looker unavailable" not in detail
```

This is the same test edit already staged inside #818; landing it directly unblocks `main` without waiting on that PR's consolidation.

## Verification

```
pytest tests/unit/test_cloud_routes.py::TestReportingRoutes::test_generate_dashboard_url_service_error
# 1 passed
```

Source-only test change; no production code touched.

Opened as **draft** for human review — not auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BmkwKENnbsy3v94m1sBid

---
_Generated by [Claude Code](https://claude.ai/code/session_014BmkwKENnbsy3v94m1sBid)_