### PR TITLE
fix(security): sanitize global 500 exception handler (CWE-209) — minimal, single-sink

### DIFF
--- a/src/youtube_extension/backend/main.py
+++ b/src/youtube_extension/backend/main.py
@@ -454,14 +454,20 @@ async def global_exception_handler(request, exc):
     """Global exception handler.
 
     Returns a static body only. The exception type, message, traceback, and
-    request URL are recorded server-side via ``logger.error(..., exc_info=True)``
+    request *path* are recorded server-side via ``logger.error(..., exc_info=True)``
     and never returned to the client, closing a CWE-209 information-disclosure
     leak (the previous body echoed ``str(exc)``, ``exc.__class__.__name__``, and
     the request URL).
+
+    The log line uses only ``request.url.path`` and the method — never the full
+    URL/query string, which can carry secrets (e.g. ``?token=...``) that must not
+    be persisted to centralized (Cloud Run) logs.
     """
-    request_path = str(request.url) if hasattr(request, "url") else "unknown"
+    url = getattr(request, "url", None)
+    request_path = getattr(url, "path", None) or "unknown"
+    method = getattr(request, "method", "unknown")
     logger.error(
-        f"Unhandled exception on {request_path}: {exc}", exc_info=True
+        f"Unhandled exception on {method} {request_path}: {exc}", exc_info=True
     )
 
     return JSONResponse(

--- a/src/youtube_extension/backend/main.py
+++ b/src/youtube_extension/backend/main.py
@@ -451,22 +451,27 @@ async def value_error_handler(request, exc):
 
 @app.exception_handler(Exception)
 async def global_exception_handler(request, exc):
-    """Global exception handler with enhanced error details"""
-    logger.error(f"Unhandled exception: {exc}", exc_info=True)
+    """Global exception handler.
 
-    error_detail = {
-        "error": "Internal server error",
-        "detail": str(exc),
-        "timestamp": datetime.now().isoformat(),
-        "path": str(request.url) if hasattr(request, "url") else "unknown",
-        "version": "2.0.0",
-        "architecture": "service-oriented",
-    }
+    Returns a static body only. The exception type, message, traceback, and
+    request URL are recorded server-side via ``logger.error(..., exc_info=True)``
+    and never returned to the client, closing a CWE-209 information-disclosure
+    leak (the previous body echoed ``str(exc)``, ``exc.__class__.__name__``, and
+    the request URL).
+    """
+    request_path = str(request.url) if hasattr(request, "url") else "unknown"
+    logger.error(
+        f"Unhandled exception on {request_path}: {exc}", exc_info=True
+    )
 
-    if hasattr(exc, "__class__"):
-        error_detail["error_type"] = exc.__class__.__name__
-
-    return JSONResponse(status_code=500, content=error_detail)
+    return JSONResponse(
+        status_code=500,
+        content={
+            "error": "Internal server error",
+            "detail": "Internal server error",
+            "timestamp": datetime.now().isoformat(),
+        },
+    )
 
 
 # Application lifecycle events

--- a/tests/unit/test_backend_main.py
+++ b/tests/unit/test_backend_main.py
@@ -617,6 +617,38 @@ class TestExceptionHandlers:
         assert "hunter2" not in raw
         assert "secret-internal-path" not in raw
 
+    async def test_global_exception_handler_log_omits_query_string(self):
+        """CWE-209: the server-side log line must record only the route path and
+        method, never the full URL/query string (which can carry secrets such as
+        ``?token=...`` that would then persist in centralized/Cloud Run logs).
+        Guards against a regression to ``str(request.url)`` while keeping
+        ``exc_info=True`` so the traceback is still captured."""
+        from unittest.mock import patch
+
+        class _URL:
+            path = "/api/process"
+
+            def __str__(self):  # what str(request.url) would leak
+                return "http://test/api/process?token=SECRET123"
+
+        class _Req:
+            url = _URL()
+            method = "POST"
+
+        with patch.object(main_module, "logger") as mock_logger:
+            response = await main_module.global_exception_handler(
+                _Req(), Exception("boom")
+            )
+
+        assert response.status_code == 500
+        mock_logger.error.assert_called_once()
+        args, kwargs = mock_logger.error.call_args
+        logged = " ".join(str(a) for a in args)
+        assert "SECRET123" not in logged
+        assert "token=" not in logged
+        assert "/api/process" in logged  # the bare path is safe to log
+        assert kwargs.get("exc_info") is True
+
     async def test_global_exception_handler_request_without_url(self):
         """Handler should not crash if request has no .url attribute."""
         mock_req = MagicMock(spec=[])  # no attributes

--- a/tests/unit/test_backend_main.py
+++ b/tests/unit/test_backend_main.py
@@ -590,23 +590,32 @@ class TestExceptionHandlers:
         response = await main_module.global_exception_handler(mock_req, RuntimeError("crash"))
         assert response.status_code == 500
 
-    async def test_global_exception_handler_includes_error_type(self):
+    async def test_global_exception_handler_does_not_leak_exception_type(self):
+        """CWE-209: the 500 body must not disclose the exception class name."""
         import json as _json
 
         mock_req = MagicMock()
         mock_req.url = "http://test/api"
         response = await main_module.global_exception_handler(mock_req, RuntimeError("crash"))
         body = _json.loads(response.body)
-        assert body["error_type"] == "RuntimeError"
+        assert "error_type" not in body
+        assert "RuntimeError" not in response.body.decode()
 
-    async def test_global_exception_handler_includes_version(self):
+    async def test_global_exception_handler_body_is_static(self):
+        """CWE-209: the 500 body must not echo the exception message or request URL."""
         import json as _json
 
         mock_req = MagicMock()
-        mock_req.url = "http://test/api"
-        response = await main_module.global_exception_handler(mock_req, Exception("e"))
+        mock_req.url = "http://test/secret-internal-path?token=abc"
+        response = await main_module.global_exception_handler(
+            mock_req, Exception("db password is hunter2")
+        )
         body = _json.loads(response.body)
-        assert body["version"] == "2.0.0"
+        assert body["error"] == "Internal server error"
+        assert body["detail"] == "Internal server error"
+        raw = response.body.decode()
+        assert "hunter2" not in raw
+        assert "secret-internal-path" not in raw
 
     async def test_global_exception_handler_request_without_url(self):
         """Handler should not crash if request has no .url attribute."""


### PR DESCRIPTION
## Summary

Closes the **one** HTTP-500 information-disclosure sink (CWE-209) still live on `main`: the global `Exception` handler in `backend/main.py`. On any unhandled error it returned a `JSONResponse` whose body echoed `str(exc)`, `exc.__class__.__name__`, and `str(request.url)` to the client.

The per-route `HTTPException(status_code=500, detail=...)` sinks were already sanitized on `main`. This handler is different: it leaks via `JSONResponse(status_code=500, content={...})`.

## Why this leak survived ~15 green PRs (root cause)

The repo currently has a cluster of ~15 open PRs all attempting the same 500-hardening (#804, #807, #810, #814–#821, #826, #827, #831, #832, #834), each claiming to be "the consolidation." Every one passed the guard `tests/unit/test_500_info_disclosure.py` — yet the leak persisted. The reason is a structural blind spot in that guard:

1. It only inspects `HTTPException(...)` calls; it never looks at the `JSONResponse(status_code=500, content=...)` form the global handler uses.
2. `main.py` isn't even in its `_GUARDED_FILES` tuple.

So the guard is structurally incapable of seeing this sink. That is why the cluster kept regenerating without ever fixing the actual remaining leak.

## Changes (2 files)

- **`backend/main.py`** — `global_exception_handler` now returns a static body `{"error"/"detail": "Internal server error", "timestamp"}`. The exception (type, message, traceback) and request path are logged **server-side only** via `logger.error(..., exc_info=True)`. The 4xx `ValueError` handler is intentionally left unchanged (4xx echoes client-supplied input, not an internal-disclosure vector).
- **`tests/unit/test_backend_main.py`** — replaces the two tests that asserted the *leaky* contract (`error_type`, `version`) with regression guards that exercise the handler and prove the 500 body is static and never echoes the exception message, class name, or request URL.

## Verification

`pytest`/`fastapi` are not installable in the ephemeral session sandbox without pulling the heavy google-cloud/ML stack, so this was verified by exercising the **real handler source** directly (extracted via AST, executed against a stub `JSONResponse`/`logger`):

- 500 body contains no exception text, class name, or URL — while the full error is still logged server-side.
- The no-`.url` request path does not crash.
- The `ValueError` handler still returns `400`.

## Relationship to the duplicate cluster

This is deliberately **minimal and merge-clean on current `main`** (single production file, 2 files total), unlike the cluster: e.g. #834 targets the same handler but is now `mergeable_state: dirty` (conflicted) and touches 9 files. Recommendation for the maintainer: land this, then close the redundant cluster (#804, #807, #810, #814–#821, #826, #827, #831, #832, #834). A follow-up could widen the AST guard to cover the `JSONResponse` 500 form and add `main.py` to `_GUARDED_FILES` so this class of sink can't hide again.

Left as **draft** — targets protected `main`; not auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kZayBH8HUEt4ys7ofaH52

---
_Generated by [Claude Code](https://claude.ai/code/session_016kZayBH8HUEt4ys7ofaH52)_