### PR TITLE
docs: correct Sentinel MD5 journal entry scope

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,7 +1,7 @@
-## 2024-07-09 - Replace weak MD5 hashing with SHA-256 for caching
+## 2026-07-09 - Replace weak MD5 hashing with SHA-256 for caching
 **Vulnerability:** Weak MD5 hashes were being used for generating cache keys and processing IDs across multiple backend services (e.g., `cache_service.py`, `database_optimizer.py`, etc.).
 **Learning:** This repo frequently uses hashes for non-cryptographic purposes (caching and IDs). However, using MD5 triggers static analysis security warnings (like Bandit rules B324/B303) as the algorithm is vulnerable to collision attacks and considered insecure by modern cryptographic standards.
-**Prevention:** Avoid using `hashlib.md5()` entirely. Default to `hashlib.sha256()` even for non-cryptographic uses to maintain a secure baseline and comply with automated security policies.
+**Prevention:** Avoid using `hashlib.md5()` in the `src/` directory. Default to `hashlib.sha256()` even for non-cryptographic uses to maintain a secure baseline and comply with automated security policies. Archived scripts in `scripts/archive/` are explicitly excluded from this requirement.
 ## 2026-07-15 - Prevent Information Disclosure in 500 Responses
 **Vulnerability:** API routes were returning internal server exceptions and stack traces directly to the client via `HTTPException(..., detail=str(e))`.
 **Learning:** Developers often unintentionally leak sensitive deployment context (e.g., paths, database errors) when relying on generic exception catching blocks.


### PR DESCRIPTION
## What
- correct the Sentinel MD5 migration journal entry date from 2024-07-09 to 2026-07-09
- scope the prevention guidance to `src/`
- explicitly exclude archived scripts in `scripts/archive/`

## Why
The old PR was stale and unsafe to merge. The underlying MD5 migration is already on `main`, but the journal entry still overstated repo-wide policy and had the wrong date.

## Risk
Low. Documentation-only change.

Closes #651.