### PR TITLE
fix(test): unbreak main CI — align api_cost_monitor cleanup test with SQLAlchemy rewrite

### DIFF
--- a/tests/unit/test_misc_services.py
+++ b/tests/unit/test_misc_services.py
@@ -987,11 +987,14 @@ class TestAPICostMonitorCleanup:
         result = await monitor.trigger_manual_cleanup()
         assert isinstance(result, dict)
 
-    async def test_trigger_manual_cleanup_when_unavailable(self, tmp_path):
+    async def test_trigger_manual_cleanup_returns_error_on_failure(self, tmp_path):
         monitor = APICostMonitor(db_path=str(tmp_path / "m2.db"))
-        with patch(
-            "youtube_extension.backend.services.api_cost_monitor.CLEANUP_AVAILABLE",
-            False
+        # The cleanup path was rewritten to use SQLAlchemy sessions directly and
+        # no longer relies on an external cleanup service / CLEANUP_AVAILABLE flag.
+        # Force the session factory to fail and assert the error path still
+        # returns a dict carrying an "error" key rather than raising.
+        with patch.object(
+            monitor, "Session", side_effect=RuntimeError("session unavailable")
         ):
             result = await monitor.trigger_manual_cleanup()
             assert "error" in result


### PR DESCRIPTION
## Summary

`main` is currently **red** on the CI `test` job (latest run: [29571708934](https://github.com/groupthinking/EventRelay/actions/runs/29571708934), commit `80ec83b`, merge of #863). Exactly **1 test failed, 7210 passed**.

The failure:

```
FAILED tests/unit/test_misc_services.py::TestAPICostMonitorCleanup::test_trigger_manual_cleanup_when_unavailable
  AttributeError: module 'youtube_extension.backend.services.api_cost_monitor'
  does not have the attribute 'CLEANUP_AVAILABLE'
```

## Root cause

`api_cost_monitor.py` was rewritten to perform database cleanup **inline via SQLAlchemy sessions**, removing the external `database_cleanup_service` integration and its module-level `CLEANUP_AVAILABLE` flag. The test `test_trigger_manual_cleanup_when_unavailable` was left behind — it still `patch(...)`es the now-removed `api_cost_monitor.CLEANUP_AVAILABLE`, which raises `AttributeError` at patch time.

## Fix

Replace the stale test with `test_trigger_manual_cleanup_returns_error_on_failure`, which matches the current implementation: it forces the SQLAlchemy session factory to raise and asserts that `trigger_manual_cleanup()` still returns a `dict` carrying an `"error"` key (exercising the real `except Exception: return {"error": str(e)}` path) rather than propagating.

This is a test-only change; no production code is touched. The direction is deliberately to align the test with the rewritten module rather than re-introduce the removed `CLEANUP_AVAILABLE` architecture just to satisfy the assertion.

## Verification

```
$ pytest tests/unit/test_misc_services.py::TestAPICostMonitorCleanup
5 passed
```

Local run confirms the error-path log (`Error in manual API cost cleanup: session unavailable`) and the returned `{"error": ...}` dict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017kfXLa9zKbRu6A1opagUvM)_