### PR TITLE
fix(cost): restore Gemini 1.5 Flash output pricing

### DIFF
--- a/src/youtube_extension/backend/services/api_cost_monitor.py
+++ b/src/youtube_extension/backend/services/api_cost_monitor.py
@@ -167,7 +167,7 @@ class APICostMonitor:
             "gemini-3-pro": {"input": 0.000875, "output": 0.0035},
             "gemini-3-flash": {"input": 0.000052, "output": 0.00021},
             "gemini-1.5-pro": {"input": 0.00125, "output": 0.005},
-            "gemini-1.5-flash": {"input": 0.000075, "output": 0.003},
+            "gemini-1.5-flash": {"input": 0.000075, "output": 0.0003},
         },
         "youtube": {
             "search": 100,  # quota units per request

--- a/tests/unit/test_api_cost_monitor.py
+++ b/tests/unit/test_api_cost_monitor.py
@@ -76,6 +76,12 @@ class TestCalculateCost:
         expected = (1000 / 1000) * 0.0025 + (1000 / 1000) * 0.01
         assert pytest.approx(cost, rel=1e-6) == expected
 
+    def test_google_gemini_15_flash_cost(self, monitor):
+        cost = monitor.calculate_cost(
+            "google", "gemini-1.5-flash", input_tokens=1000, output_tokens=1000
+        )
+        assert pytest.approx(cost, rel=1e-6) == 0.000075 + 0.0003
+
     def test_youtube_quota_cost(self, monitor):
         cost = monitor.calculate_cost("youtube", "search", input_tokens=100)
         assert pytest.approx(cost, rel=1e-6) == 100 * 0.0001


### PR DESCRIPTION
## What changed

- restore the Gemini 1.5 Flash output rate from `0.003` to the prior intended `0.0003` per 1K output tokens
- add an exact-cost regression test covering both input and output pricing

## Root cause

The SQLAlchemy/outbox rewrite changed this unrelated pricing constant by 10×. That inflated recorded cost and could trigger false budget alerts.

## Validation

Test-first verification on the current `main` files:

- before fix: targeted regression test failed with `0.003075` observed vs `0.000375` expected
- after fix: targeted regression test passed
- full APICostMonitor suite: `86 passed in 1.89s`

This PR intentionally excludes webhook/outbox and cleanup changes.