### PR TITLE
fix(ci): agent completion truth gate + review hardening (supersedes #872)

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,84 @@
+name: Agent task
+description: Define immutable intent and proof before delegating work to an agent.
+title: "[Agent] "
+labels:
+  - agent-task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Complete this contract before dispatch. The completion gate reads these headings from the issue, not from the pull request.
+
+  - type: input
+    id: agent_login
+    attributes:
+      label: Agent login
+      description: Exact GitHub login that will publish run events, including [bot] when applicable.
+      placeholder: google-labs-jules[bot]
+    validations:
+      required: true
+
+  - type: input
+    id: agent_run_id
+    attributes:
+      label: Agent run ID
+      description: Unique immutable provider or dispatch run ID used in the PR manifest and result comments.
+      placeholder: provider-run-id
+    validations:
+      required: true
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: State the observable outcome and why it is needed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Use one independently verifiable criterion per line.
+      placeholder: |
+        - [ ] The invalid input returns a blocked verdict.
+        - [ ] The focused regression test passes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: declared_scope
+    attributes:
+      label: Declared file scope
+      description: List exact repository-relative paths, one per line. Leave empty only when Unrestricted scope is checked.
+      placeholder: |
+        src/example.py
+        tests/unit/test_example.py
+
+  - type: textarea
+    id: allowed_extra
+    attributes:
+      label: Allowed extra files
+      description: Optional exact paths that may be changed in addition to the declared scope.
+
+  - type: textarea
+    id: focused_tests
+    attributes:
+      label: Focused test paths
+      description: For behavior changes, list Python unit-test paths collected by CI. Each path must also be in declared/allowed scope, remain present in the diff, and pass in CI.
+
+  - type: checkboxes
+    id: unrestricted
+    attributes:
+      label: Unrestricted scope
+      description: Use only when an exact file list cannot be known before dispatch. Enforcement also requires the protected scope-unrestricted-approved label.
+      options:
+        - label: Yes, this task explicitly permits repository-wide changes.
+
+  - type: checkboxes
+    id: frozen
+    attributes:
+      label: Pre-dispatch confirmation
+      options:
+        - label: Objective, acceptance criteria, scope, and focused-test expectations are complete before delegation.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+Describe the outcome and the evidence that supports it.
+
+## Linked issue
+
+Fixes #
+
+## Verification
+
+- [ ] Focused tests
+- [ ] Required CI
+- [ ] Review threads resolved
+
+## Agent provenance
+
+Human-authored pull requests may delete this section. Agent-authored pull requests must replace agent-lock-example with agent-lock-manifest and fill the values. Scope and test paths remain authoritative in the linked issue.
+
+<!-- agent-lock-example
+{"issue_number": 0, "agent_login": "agent-name", "run_id": "provider-run-id"}
+-->
+
+The declared agent publishes a result comment on the linked issue or PR with the exact run ID and current 40-character head SHA. Replace `agent-lock-event-example` with `agent-lock-event` only when publishing real evidence.
+
+<!-- agent-lock-event-example
+{"kind": "artifact_ready", "run_id": "provider-run-id", "head_sha": "0000000000000000000000000000000000000000"}
+-->

--- a/.github/workflows/AUDIT.md
+++ b/.github/workflows/AUDIT.md
@@ -26,7 +26,7 @@ concrete reason, verified against the actual repository tree.
 | `issue-triage.yml` | KEEP | Keyword auto-labeling + triage comment on new issues. |
 | `mcp-optimization.yml` | **DELETE** | Entire workflow targets `mcp-servers/mcp-profiling/` (requirements.txt, investigator_client.py, profiling_server.py) which does not exist — every run fails. |
 | `phase-goal-tracker.yml` | KEEP | Tracks markdown checklists on phase issues, keeps a single status comment updated, and auto-closes the issue when all checklist goals are complete. |
-| `pr-checks.yml` | KEEP | Validates PR title/description; fork-safe comment handling. |
+| `pr-checks.yml` | KEEP | Validates PR title/description (fork-safe comment handling) and runs the deterministic Agent Completion Truth Gate: freezes pre-dispatch issue intent, binds trusted CI/review evidence, and publishes a fail-closed `agent-completion/truth-gate` status. Triggers on `pull_request_target`/`workflow_run`/`issue_comment`/`issues`/`schedule`/`workflow_dispatch`; privileged (`statuses`/`actions: write`) but never checks out or executes PR-head code. |
 | `real-processing.yml` | KEEP | Manual single-video processing; well-formed. |
 | `secret-scan.yml` | KEEP | gitleaks on the working tree; action pinned to SHA, checksum-verified install. |
 | `security.yml` | KEEP | npm audit, safety, bandit, trivy; uploads SARIF. |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,7 +15,7 @@ workflow; this README is the index.
 | Dependency Review | `dependency-review.yml` | PR to `main`,`develop` | Review new dependencies for vulnerabilities and license policy |
 | Secret Scan | `secret-scan.yml` | push to `main`; all PRs | gitleaks scan of the working tree |
 | Dependabot Auto Merge | `dependabot-auto-merge.yml` | `pull_request_target`, `check_suite` | Approve and auto-merge patch/minor Dependabot PRs (majors excluded) |
-| PR Checks | `pr-checks.yml` | PR opened/edited/synchronize | Validate PR title (conventional commits) and description |
+| PR Checks & Agent Completion Truth Gate | `pr-checks.yml` | `pull_request_target`; `workflow_run` (CI); `issue_comment`; `issues`; `workflow_dispatch`; `schedule` | Validate PR title (conventional commits) and description; freeze pre-dispatch agent-task intent; publish the deterministic agent-completion truth-gate status (`agent-completion/truth-gate`) from trusted default-branch code (privileged `statuses`/`actions: write`, never checks out PR-head code) |
 | Auto Label | `auto-label.yml` | PR opened/reopened/synchronize | Label PRs by changed file type (docs, tests, python, etc.) |
 | Auto-Assign Issues | `auto-assign.yml` | issue opened | Assign new issues to the repository owner |
 | Issue Triage | `issue-triage.yml` | issue opened | Auto-label new issues by keyword and post a triage comment |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -82,10 +82,14 @@ jobs:
             const unrestrictedRequested =
               /-\s*\[[xX]\]/.test(unrestricted) ||
               /\b(?:yes|true)\b/i.test(unrestricted);
-            const declaredScope = section(
+            const declaredScopeRaw = section(
               issueBody,
               ['declared file scope', 'file scope', 'scope']
             );
+            const declaredScope =
+              declaredScopeRaw && declaredScopeRaw !== '_No response_'
+                ? declaredScopeRaw
+                : '';
             const confirmed = /-\s*\[[xX]\]/.test(section(
               issueBody,
               ['pre-dispatch confirmation']

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,7 +25,10 @@ jobs:
   snapshot-agent-task-intent:
     if: >-
       github.event_name == 'issues' &&
-      (github.event.action == 'opened' || github.event.action == 'labeled')
+      (github.event.action == 'opened' || github.event.action == 'labeled') &&
+      (github.event.issue.author_association == 'OWNER' ||
+       github.event.issue.author_association == 'MEMBER' ||
+       github.event.issue.author_association == 'COLLABORATOR')
     concurrency:
       group: agent-intent-snapshot-${{ github.event.issue.number }}
       cancel-in-progress: false
@@ -184,6 +187,36 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const trustedCommentAssociations = new Set([
+              'OWNER', 'MEMBER', 'COLLABORATOR'
+            ]);
+            const knownAgentCommenters = new Set([
+              'google-labs-jules[bot]',
+              'github-copilot[bot]',
+              'copilot-swe-agent[bot]',
+              'openai-codex[bot]'
+            ]);
+            if (context.eventName === 'issue_comment') {
+              const comment = context.payload.comment || {};
+              const actor = comment.user && comment.user.login;
+              if (!trustedCommentAssociations.has(
+                comment.author_association
+              ) && !knownAgentCommenters.has(actor)) {
+                core.info('Ignoring untrusted issue-comment refresh');
+                return;
+              }
+            }
+            if (context.eventName === 'issues') {
+              const issue = context.payload.issue || {};
+              const actor = context.payload.sender &&
+                context.payload.sender.login;
+              if (!trustedCommentAssociations.has(
+                issue.author_association
+              ) && !knownAgentCommenters.has(actor)) {
+                core.info('Ignoring untrusted issue refresh');
+                return;
+              }
+            }
             const pullNumbers = new Set();
             if (context.payload.issue &&
                 context.payload.issue.pull_request) {
@@ -303,7 +336,7 @@ jobs:
        github.event_name == 'workflow_dispatch')
     concurrency:
       group: agent-completion-${{ inputs.pull_request || github.event.pull_request.number }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,65 +1,1096 @@
 name: PR Checks
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, edited]
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited, ready_for_review, converted_to_draft, labeled, unlabeled, closed]
+  issue_comment:
+    types: [created, edited, deleted]
+  issues:
+    types: [opened, edited, labeled, unlabeled, closed, reopened]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Pull request number to re-evaluate
+        required: true
+        type: number
 
-permissions:
-  pull-requests: write
-  issues: write
+permissions: {}
 
 jobs:
-  validate:
+  snapshot-agent-task-intent:
+    if: >-
+      github.event_name == 'issues' &&
+      (github.event.action == 'opened' || github.event.action == 'labeled')
+    concurrency:
+      group: agent-intent-snapshot-${{ github.event.issue.number }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
-      - uses: actions/github-script@v9
+      - name: Freeze the delegated issue body
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const crypto = require('crypto');
+            const issue = context.payload.issue;
+            const labels = new Set((issue.labels || []).map(label =>
+              String(typeof label === 'string' ? label : label.name)
+                .toLowerCase().replace(/[^a-z0-9 ]/g, '').trim()
+            ));
+            if (![...labels].some(label =>
+              ['agenttask', 'mcpagent'].includes(label)
+            )) {
+              return;
+            }
+            function normaliseHeading(value) {
+              return value.toLowerCase().replace(/[^a-z0-9 ]/g, '').trim();
+            }
+            function section(body, headings) {
+              const wanted = new Set(headings.map(normaliseHeading));
+              const lines = String(body || '').split(/\r?\n/);
+              const output = [];
+              let collecting = false;
+              for (const line of lines) {
+                const heading = line.match(/^#{2,6}\s+(.+?)\s*$/);
+                if (heading) {
+                  if (collecting) {
+                    break;
+                  }
+                  collecting = wanted.has(normaliseHeading(heading[1]));
+                  continue;
+                }
+                if (collecting) {
+                  output.push(line);
+                }
+              }
+              return output.join('\n').trim();
+            }
+            const issueBody = String(issue.body || '');
+            const unrestricted = section(
+              issueBody,
+              ['unrestricted scope', 'scope unrestricted']
+            );
+            const unrestrictedRequested =
+              /-\s*\[[xX]\]/.test(unrestricted) ||
+              /\b(?:yes|true)\b/i.test(unrestricted);
+            const declaredScope = section(
+              issueBody,
+              ['declared file scope', 'file scope', 'scope']
+            );
+            const confirmed = /-\s*\[[xX]\]/.test(section(
+              issueBody,
+              ['pre-dispatch confirmation']
+            ));
+            const complete = [
+              section(issueBody, ['agent login']),
+              section(issueBody, ['agent run id', 'run id']),
+              section(issueBody, ['objective', 'description']),
+              section(issueBody, ['acceptance criteria', 'acceptance tests'])
+            ].every(value => value && value !== '_No response_') &&
+              Boolean(declaredScope || unrestrictedRequested) && confirmed;
+            const unrestrictedApproved =
+              labels.has('scopeunrestrictedapproved');
+            if (!complete ||
+                (unrestrictedRequested && !unrestrictedApproved)) {
+              core.setFailed('incomplete_agent_task_contract');
+              return;
+            }
+            const marker = '<!-- agent-lock-intent-snapshot:v1';
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100
+              }
+            );
+            const existing = comments.find(comment =>
+              comment.user && comment.user.login === 'github-actions[bot]' &&
+              String(comment.body || '').includes(marker)
+            );
+            if (existing) {
+              return;
+            }
+            const normalisedBody = issueBody
+              .replace(/\r\n/g, '\n').trim();
+            const bodySha256 = crypto.createHash('sha256')
+              .update(normalisedBody, 'utf8').digest('hex');
+            const snapshot = {
+              issue_number: issue.number,
+              body_sha256: bodySha256,
+              scope_unrestricted_approved: unrestrictedApproved,
+              created_at: new Date().toISOString()
+            };
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: marker + '\n' + JSON.stringify(snapshot) + '\n-->' +
+                '\n\nAgent task intent frozen for completion-gate evaluation.'
+            });
+
+  refresh-open-pull-requests:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const pulls = await github.paginate(
+              github.rest.pulls.list,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100
+              }
+            );
+            for (const pull of pulls) {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'pr-checks.yml',
+                ref: context.payload.repository.default_branch,
+                inputs: {pull_request: String(pull.number)}
+              });
+            }
+
+  dispatch-evidence-refresh:
+    needs: snapshot-agent-task-intent
+    if: >-
+      always() &&
+      (github.event_name == 'issue_comment' ||
+       github.event_name == 'issues' ||
+       github.event_name == 'workflow_run')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Queue the affected pull requests
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullNumbers = new Set();
+            if (context.payload.issue &&
+                context.payload.issue.pull_request) {
+              pullNumbers.add(context.payload.issue.number);
+            } else if (context.payload.issue) {
+              const issueNumber = context.payload.issue.number;
+              const pulls = await github.paginate(
+                github.rest.pulls.list,
+                {owner, repo, state: 'open', per_page: 100}
+              );
+              const closingPattern = new RegExp(
+                '(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#' +
+                issueNumber + '\\b',
+                'i'
+              );
+              const manifestPattern = new RegExp(
+                '"issue_number"\\s*:\\s*' + issueNumber + '\\b'
+              );
+              for (const pull of pulls) {
+                if (closingPattern.test(String(pull.body || '')) ||
+                    manifestPattern.test(String(pull.body || ''))) {
+                  pullNumbers.add(pull.number);
+                }
+              }
+            }
+            if (context.eventName === 'workflow_run') {
+              const attached = context.payload.workflow_run.pull_requests || [];
+              for (const pull of attached) {
+                pullNumbers.add(pull.number);
+              }
+              if (attached.length === 0) {
+                const associated =
+                  await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                    owner,
+                    repo,
+                    commit_sha: context.payload.workflow_run.head_sha,
+                    per_page: 100
+                  });
+                for (const pull of associated.data) {
+                  pullNumbers.add(pull.number);
+                }
+              }
+            }
+            for (const pullNumber of pullNumbers) {
+              await github.rest.actions.createWorkflowDispatch({
+                owner,
+                repo,
+                workflow_id: 'pr-checks.yml',
+                ref: context.payload.repository.default_branch,
+                inputs: {pull_request: String(pullNumber)}
+              });
+            }
+
+  validate:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;
-            if (!pr) {
-              core.info('Not a pull_request event — skipping validation.');
+            const findings = [];
+            if (pr.title.length < 10) {
+              findings.push('❌ PR title too short (minimum 10 characters)');
+            }
+            if (!/^(?:⚡\s*)?(feat|fix|docs|style|refactor|test|chore|perf|ci|build|revert)(\(.+\))?:/i.test(pr.title)) {
+              findings.push('⚠️ PR title should follow conventional commits format');
+            }
+            if (!pr.body || pr.body.length < 20) {
+              findings.push('❌ PR description is required (minimum 20 characters)');
+            }
+            const totalChanges = (pr.additions || 0) + (pr.deletions || 0);
+            if (totalChanges > 500) {
+              findings.push('⚠️ Large PR detected (' + totalChanges + ' lines changed)');
+            }
+            if (findings.length === 0) {
               return;
             }
-            const issues = [];
-
-            if (pr.title.length < 10) {
-              issues.push('❌ PR title too short (minimum 10 characters)');
+            const marker = '<!-- pr-validation:v1 -->';
+            const body = marker + '\n## 🔍 PR Validation\n\n' + findings.join('\n');
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number, per_page: 100}
+            );
+            const existing = comments.find(comment =>
+              comment.user && comment.user.type === 'Bot' &&
+              comment.body && comment.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body
+              });
             }
-            if (!/^(?:⚡\s*)?(feat|fix|docs|style|refactor|test|chore|perf|ci|build|revert)(\(.+\))?:/i.test(pr.title) && !pr.title.startsWith('⚡')) {
-              issues.push('⚠️ PR title should follow conventional commits format');
+            if (findings.some(finding => finding.startsWith('❌'))) {
+              core.setFailed('PR validation failed');
             }
 
-            if (!pr.body || pr.body.length < 20) {
-              issues.push('❌ PR description is required (minimum 20 characters)');
+  truth-gate:
+    name: agent-completion/truth-gate
+    needs: [validate, snapshot-agent-task-intent]
+    if: >-
+      always() &&
+      (github.event_name == 'pull_request_target' ||
+       github.event_name == 'workflow_dispatch')
+    concurrency:
+      group: agent-completion-${{ inputs.pull_request || github.event.pull_request.number }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Resolve pull request and mark the gate pending
+        id: resolve
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_PR_NUMBER: ${{ inputs.pull_request || '' }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = context.serverUrl + '/' + owner + '/' + repo +
+              '/actions/runs/' + context.runId;
+            let prNumber = Number(process.env.INPUT_PR_NUMBER || 0);
+            if (!prNumber && context.payload.pull_request) {
+              prNumber = context.payload.pull_request.number;
             }
-
-            const totalChanges = (pr.additions || 0) + (pr.deletions || 0);
-            const errors = issues.filter(issue => issue.startsWith('❌'));
-            const warnings = issues.filter(issue => issue.startsWith('⚠️'));
-
-            if (totalChanges > 500) {
-              warnings.push(`⚠️ Large PR detected (${totalChanges} lines changed)`);
+            if (!prNumber) {
+              core.setOutput('pr_number', '');
+              core.setOutput('head_sha', '');
+              return;
             }
+            if (context.payload.pull_request &&
+                context.payload.pull_request.head) {
+              core.setOutput('pr_number', String(prNumber));
+              core.setOutput(
+                'head_sha',
+                context.payload.pull_request.head.sha
+              );
+            }
+            const pr = (await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber
+            })).data;
+            core.setOutput('pr_number', String(prNumber));
+            core.setOutput('head_sha', pr.head.sha);
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha: pr.head.sha,
+              state: 'pending',
+              context: 'agent-completion/truth-gate',
+              description: 'collecting repository evidence',
+              target_url: runUrl
+            });
 
-            if (errors.length > 0 || warnings.length > 0) {
-              const allIssues = [...errors, ...warnings];
-              if (pr.head.repo.full_name === pr.base.repo.full_name) {
-                const comment = `## 🔍 PR Validation\n\n${allIssues.join('\n')}`;
-                try {
-                  await github.rest.issues.createComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: pr.number,
-                    body: comment
-                  });
-                } catch (commentError) {
-                  core.warning(`Could not post validation comment: ${commentError.message}`);
+      - name: Check out trusted gate from the default branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: .trusted
+          persist-credentials: false
+          sparse-checkout: scripts/ci/agent_completion_gate.py
+          sparse-checkout-cone-mode: false
+
+      - name: Collect repository evidence
+        id: collect
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+        with:
+          script: |
+            const crypto = require('crypto');
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const collectionErrors = [];
+
+            function normaliseHeading(value) {
+              return value.toLowerCase().replace(/[^a-z0-9 ]/g, '').trim();
+            }
+            function section(body, headings) {
+              const wanted = new Set(headings.map(normaliseHeading));
+              const lines = String(body || '').split(/\r?\n/);
+              const output = [];
+              let collecting = false;
+              for (const line of lines) {
+                const heading = line.match(/^#{2,6}\s+(.+?)\s*$/);
+                if (heading) {
+                  if (collecting) {
+                    break;
+                  }
+                  collecting = wanted.has(normaliseHeading(heading[1]));
+                  continue;
                 }
-              } else {
-                core.warning('Skipping PR comment for fork PR (read-only token)');
-                allIssues.forEach(issue => core.warning(issue));
+                if (collecting) {
+                  output.push(line);
+                }
               }
-              if (errors.length > 0) {
-                core.setFailed('PR validation failed');
+              return output.join('\n').trim();
+            }
+            function listItems(value) {
+              return String(value || '')
+                .split(/\r?\n/)
+                .map(line => line
+                  .replace(/^\s*[-*]\s*/, '')
+                  .replace(/^\[[ xX]\]\s*/, '')
+                  .replace(/^\x60|\x60$/g, '')
+                  .trim())
+                .filter(line =>
+                  line && line !== '_No response_' &&
+                  !/^\x60{3}/.test(line) && !line.startsWith('<!--')
+                );
+            }
+
+            const prNumber = Number(process.env.INPUT_PR_NUMBER || 0);
+            if (!prNumber) {
+              fs.writeFileSync('gate-input.json', JSON.stringify({policy: {applicable: false}}, null, 2));
+              core.setOutput('pr_number', '');
+              core.setOutput('head_sha', '');
+              return;
+            }
+
+            const pr = (await github.rest.pulls.get({owner, repo, pull_number: prNumber})).data;
+            const changed = await github.paginate(
+              github.rest.pulls.listFiles,
+              {owner, repo, pull_number: prNumber, per_page: 100}
+            );
+            if (changed.length !== pr.changed_files) {
+              collectionErrors.push('changed_files_truncated');
+            }
+            const changedFiles = [...new Set(changed.flatMap(file => [
+              file.filename,
+              file.previous_filename
+            ].filter(Boolean)))];
+            const presentChangedFiles = new Set(
+              changed
+                .filter(file => file.status !== 'removed')
+                .map(file => file.filename)
+            );
+            const prBody = String(pr.body || '');
+            const manifestMatch = prBody.match(/<!--\s*agent-lock-manifest\s*([\s\S]*?)-->/i);
+            let manifest = {};
+            if (manifestMatch) {
+              try {
+                manifest = JSON.parse(manifestMatch[1]);
+              } catch (error) {
+                collectionErrors.push('invalid_agent_lock_manifest');
               }
             }
+            let closingReferenceNumbers = [];
+            try {
+              const closingResult = await github.graphql(
+                'query($owner:String!,$repo:String!,$number:Int!){' +
+                'repository(owner:$owner,name:$repo){pullRequest(number:$number){' +
+                'closingIssuesReferences(first:20){nodes{number repository{' +
+                'nameWithOwner}} pageInfo{hasNextPage}}}}}',
+                {owner, repo, number: prNumber}
+              );
+              const references =
+                closingResult.repository.pullRequest.closingIssuesReferences;
+              closingReferenceNumbers = [...new Set(references.nodes
+                .filter(reference =>
+                  reference.repository.nameWithOwner === owner + '/' + repo
+                )
+                .map(reference => reference.number))];
+              if (references.pageInfo.hasNextPage) {
+                collectionErrors.push('closing_issues_truncated');
+              }
+              if (closingReferenceNumbers.length > 1) {
+                collectionErrors.push('multiple_closing_issues');
+              }
+            } catch (error) {
+              collectionErrors.push('closing_issues_unavailable');
+            }
+            const closing = prBody.match(
+              /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i
+            );
+            const closingIssueNumber = closing ? Number(closing[1]) : 0;
+            const referencedIssueNumber =
+              closingReferenceNumbers.length === 1
+                ? closingReferenceNumbers[0]
+                : 0;
+            const manifestIssueNumber = Number(manifest.issue_number || 0);
+            const linkedIssueNumbers = new Set([
+              manifestIssueNumber,
+              closingIssueNumber,
+              referencedIssueNumber
+            ].filter(Boolean));
+            if (linkedIssueNumbers.size > 1) {
+              collectionErrors.push('conflicting_linked_issue');
+            }
+            const issueNumber = manifestIssueNumber ||
+              referencedIssueNumber || closingIssueNumber;
+            let issue = null;
+            let issueComments = [];
+            let prComments = [];
+            if (issueNumber) {
+              try {
+                issue = (await github.rest.issues.get({owner, repo, issue_number: issueNumber})).data;
+              } catch (error) {
+                collectionErrors.push('linked_issue_unavailable');
+              }
+              try {
+                issueComments = await github.paginate(
+                  github.rest.issues.listComments,
+                  {owner, repo, issue_number: issueNumber, per_page: 100}
+                );
+              } catch (error) {
+                collectionErrors.push('issue_comments_unavailable');
+              }
+            }
+            try {
+              prComments = await github.paginate(
+                github.rest.issues.listComments,
+                {owner, repo, issue_number: prNumber, per_page: 100}
+              );
+            } catch (error) {
+              collectionErrors.push('pr_comments_unavailable');
+            }
+
+            const prLabels = new Set((pr.labels || []).map(label =>
+              normaliseHeading(typeof label === 'string' ? label : label.name)
+            ));
+            const issueLabels = new Set(((issue && issue.labels) || []).map(label =>
+              normaliseHeading(typeof label === 'string' ? label : label.name)
+            ));
+            const knownAgents = new Set([
+              'google-labs-jules[bot]',
+              'github-copilot[bot]',
+              'copilot-swe-agent[bot]',
+              'openai-codex[bot]'
+            ]);
+            const agentBranch = /^(?:agent|claude|codex|copilot|jules)[/-]/i.test(pr.head.ref);
+            const agentLabel = ['agent', 'agenttask', 'mcpagent'].some(label =>
+              prLabels.has(label) || issueLabels.has(label)
+            );
+            const applicable = pr.user.login !== 'dependabot[bot]' && (
+              knownAgents.has(pr.user.login) || agentBranch || agentLabel || Boolean(manifestMatch)
+            );
+            if (applicable && !issue) {
+              collectionErrors.push('missing_linked_issue');
+            }
+            if (applicable && closingReferenceNumbers.length !== 1) {
+              collectionErrors.push('missing_closing_issue_reference');
+            }
+            if (applicable && issue &&
+                !['agenttask', 'mcpagent'].some(label => issueLabels.has(label))) {
+              collectionErrors.push('linked_issue_not_agent_task');
+            }
+
+            const issueBody = String((issue && issue.body) || '');
+            if (applicable && issue) {
+              const snapshotComment = issueComments.find(comment =>
+                comment.user && comment.user.login === 'github-actions[bot]' &&
+                /<!--\s*agent-lock-intent-snapshot:v1/i.test(
+                  String(comment.body || '')
+                )
+              );
+              if (!snapshotComment) {
+                collectionErrors.push('missing_intent_snapshot');
+              } else {
+                const snapshotMatch = String(snapshotComment.body || '').match(
+                  /<!--\s*agent-lock-intent-snapshot:v1\s*([\s\S]*?)-->/i
+                );
+                try {
+                  const snapshot = JSON.parse(snapshotMatch[1].trim());
+                  const currentHash = crypto.createHash('sha256')
+                    .update(issueBody.replace(/\r\n/g, '\n').trim(), 'utf8')
+                    .digest('hex');
+                  if (snapshot.issue_number !== issueNumber ||
+                      !/^[a-f0-9]{64}$/.test(String(snapshot.body_sha256 || ''))) {
+                    collectionErrors.push('invalid_intent_snapshot');
+                  } else if (snapshot.body_sha256 !== currentHash) {
+                    collectionErrors.push('intent_changed_after_dispatch');
+                  }
+                  if (Date.parse(snapshotComment.created_at) >
+                      Date.parse(pr.created_at)) {
+                    collectionErrors.push('intent_snapshot_after_dispatch');
+                  }
+                  if (Boolean(snapshot.scope_unrestricted_approved) !==
+                      issueLabels.has('scopeunrestrictedapproved')) {
+                    collectionErrors.push(
+                      'unrestricted_approval_changed_after_dispatch'
+                    );
+                  }
+                } catch (error) {
+                  collectionErrors.push('invalid_intent_snapshot');
+                }
+              }
+            }
+            const objectiveSection = section(issueBody, ['objective', 'description']);
+            const hasObjectiveHeading = /^#{2,6}\s+(objective|description)\s*$/im.test(issueBody);
+            const description = objectiveSection || (hasObjectiveHeading ? '' : issueBody.trim());
+            const acceptance = listItems(section(issueBody, ['acceptance criteria', 'acceptance tests']));
+            const declaredFiles = listItems(section(issueBody, ['declared file scope', 'file scope', 'scope']));
+            const allowedExtraFiles = listItems(section(issueBody, ['allowed extra files', 'scope allowlist']));
+            const unrestrictedSection = section(issueBody, ['unrestricted scope', 'scope unrestricted']);
+            const unrestrictedRequested =
+              /-\s*\[[xX]\]/.test(unrestrictedSection) || /\b(?:yes|true)\b/i.test(unrestrictedSection);
+            const scopeUnrestricted = unrestrictedRequested &&
+              issueLabels.has('scopeunrestrictedapproved');
+            if (applicable && unrestrictedRequested && !scopeUnrestricted) {
+              collectionErrors.push('unrestricted_scope_not_approved');
+            }
+            const expectedTests = listItems(section(issueBody, ['focused test paths', 'focused tests', 'test scope']));
+            const expectedRunId = section(issueBody, ['agent run id', 'run id'])
+              .replace(/^\x60|\x60$/g, '').trim();
+            const expectedAgentLogin = section(issueBody, ['agent login'])
+              .replace(/^\x60|\x60$/g, '').trim();
+            if (applicable && !expectedRunId) {
+              collectionErrors.push('missing_agent_run_id');
+            } else if (applicable && String(manifest.run_id || '') !== expectedRunId) {
+              collectionErrors.push('agent_run_id_mismatch');
+            }
+            if (applicable && !expectedAgentLogin) {
+              collectionErrors.push('missing_agent_login');
+            } else if (applicable &&
+                       String(manifest.agent_login || '') !== expectedAgentLogin) {
+              collectionErrors.push('agent_login_mismatch');
+            }
+
+            const eventAuthors = new Set(
+              expectedAgentLogin ? [expectedAgentLogin] : []
+            );
+            const events = [];
+            if (issueNumber) {
+              const eventComments = [...new Map(
+                [...issueComments, ...prComments].map(comment => [
+                  comment.id,
+                  comment
+                ])
+              ).values()];
+              for (const comment of eventComments) {
+                if (!comment.user || !eventAuthors.has(comment.user.login)) {
+                  continue;
+                }
+                const body = String(comment.body || '');
+                const structuredMatch = body.match(
+                  /<!--\s*agent-lock-event\s*([\s\S]*?)-->/i
+                );
+                if (structuredMatch) {
+                  try {
+                    const structuredEvent = JSON.parse(
+                      structuredMatch[1].trim()
+                    );
+                    if (!['artifact_ready', 'completed', 'error'].includes(
+                      structuredEvent.kind
+                    ) || typeof structuredEvent.run_id !== 'string' ||
+                        typeof structuredEvent.head_sha !== 'string' ||
+                        !/^[a-f0-9]{40}$/i.test(structuredEvent.head_sha)) {
+                      throw new Error('invalid structured event');
+                    }
+                    events.push({
+                      kind: structuredEvent.kind,
+                      sequence: Date.parse(comment.created_at) || comment.id,
+                      comment_id: comment.id,
+                      author: comment.user.login,
+                      run_id: structuredEvent.run_id,
+                      head_sha: structuredEvent.head_sha.toLowerCase()
+                    });
+                  } catch (error) {
+                    collectionErrors.push('invalid_agent_event');
+                  }
+                  continue;
+                }
+                let kind = '';
+                if (/unexpected error|unable to complete|wasn.t able to complete|run failed|failed to complete/i.test(body)) {
+                  kind = 'error';
+                } else if (/ready for (?:a )?review|pull request is ready|created (?:a )?pull request|\[PR\]\([^)]*\)\s+has been created/i.test(body)) {
+                  kind = 'artifact_ready';
+                } else if (/\b(?:task|work|implementation)\s+(?:is\s+)?complete(?:d)?\b/i.test(body)) {
+                  kind = 'completed';
+                }
+                if (kind) {
+                  const runMatch = body.match(
+                    /(?:run(?:[ _-]?id)?|tasks?)[\/:=\s-]+([A-Za-z0-9._:-]{1,128})/i
+                  );
+                  const headMatch = body.match(/\b[a-f0-9]{40}\b/i);
+                  events.push({
+                    kind,
+                    sequence: Date.parse(comment.created_at) || comment.id,
+                    comment_id: comment.id,
+                    author: comment.user.login,
+                    run_id: runMatch
+                      ? runMatch[1].replace(/[.,;:]+$/, '')
+                      : null,
+                    head_sha: headMatch ? headMatch[0].toLowerCase() : null
+                  });
+                }
+              }
+              events.sort((left, right) => left.sequence - right.sequence);
+            }
+
+            const reviews = [];
+            const submitted = await github.paginate(
+              github.rest.pulls.listReviews,
+              {owner, repo, pull_number: prNumber, per_page: 100}
+            );
+            const latestByAuthor = new Map();
+            for (const review of submitted) {
+              if (!review.user ||
+                  !['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(
+                    review.state
+                  )) {
+                continue;
+              }
+              const previous = latestByAuthor.get(review.user.login);
+              if (!previous || Date.parse(review.submitted_at || 0) >= Date.parse(previous.submitted_at || 0)) {
+                latestByAuthor.set(review.user.login, review);
+              }
+            }
+            for (const review of latestByAuthor.values()) {
+              if (review.state === 'CHANGES_REQUESTED') {
+                reviews.push({blocking: true, resolved: false, source: 'review:' + review.id});
+              }
+            }
+            try {
+              const result = await github.graphql(
+                'query($owner:String!,$repo:String!,$number:Int!){' +
+                'repository(owner:$owner,name:$repo){pullRequest(number:$number){' +
+                'reviewDecision reviewThreads(first:100){nodes{id isResolved comments(first:100){' +
+                'nodes{body} pageInfo{hasNextPage}}} pageInfo{hasNextPage}}}}}',
+                {owner, repo, number: prNumber}
+              );
+              if (result.repository.pullRequest.reviewDecision ===
+                  'CHANGES_REQUESTED') {
+                reviews.push({
+                  blocking: true,
+                  resolved: false,
+                  source: 'reviewDecision'
+                });
+              }
+              const threads = result.repository.pullRequest.reviewThreads;
+              for (const thread of threads.nodes) {
+                if (thread.comments.pageInfo.hasNextPage) {
+                  collectionErrors.push(
+                    'review_thread_comments_truncated'
+                  );
+                }
+                const blocking = thread.comments.nodes.some(comment =>
+                  /VADE-RECOMMENDATION:\s*FIX|\b(?:blocking|must fix|regression)\b/i.test(
+                    String(comment.body || '')
+                  )
+                );
+                if (!thread.isResolved && blocking) {
+                  reviews.push({blocking: true, resolved: false, source: thread.id});
+                }
+              }
+              if (threads.pageInfo.hasNextPage) {
+                collectionErrors.push('review_threads_truncated');
+              }
+            } catch (error) {
+              collectionErrors.push('review_threads_unavailable');
+            }
+
+            async function ciPassedFor(sha, expectedEvent) {
+              if (!sha) {
+                return false;
+              }
+              const workflowRuns = (await github.rest.actions.listWorkflowRunsForRepo({
+                owner, repo, head_sha: sha, per_page: 100
+              })).data.workflow_runs;
+              const ciRuns = workflowRuns
+                .filter(run =>
+                  run.name === 'CI' &&
+                  run.path === '.github/workflows/ci.yml' &&
+                  run.event === expectedEvent &&
+                  run.head_sha === sha &&
+                  (expectedEvent !== 'pull_request' ||
+                    (run.pull_requests || []).some(
+                      pull => pull.number === prNumber
+                    ))
+                )
+                .sort((left, right) =>
+                  Date.parse(right.created_at) - Date.parse(left.created_at)
+                );
+              return ciRuns.length > 0 &&
+                ciRuns[0].status === 'completed' &&
+                ciRuns[0].conclusion === 'success';
+            }
+            const requiredChecksPassed = await ciPassedFor(
+              pr.head.sha,
+              'pull_request'
+            );
+            const postMergeChecksPassed = Boolean(pr.merged) &&
+              await ciPassedFor(pr.merge_commit_sha, 'push');
+            if (changedFiles.includes('.github/workflows/ci.yml')) {
+              collectionErrors.push('trusted_ci_workflow_changed');
+            }
+
+            const behaviorChangedFiles = changedFiles.filter(path => {
+              const explicitlyNonBehavioral =
+                /(?:^|\/)(?:test|tests|__tests__)(?:\/|_)/i.test(path) ||
+                /(?:\.spec\.|\.test\.)/i.test(path) ||
+                /^docs\//i.test(path) ||
+                /\.md$/i.test(path) ||
+                /^\.github\/ISSUE_TEMPLATE\//i.test(path) ||
+                /^\.github\/pull_request_template\.md$/i.test(path);
+              return !explicitlyNonBehavioral;
+            });
+            const ciCollectedTests = expectedTests.every(path =>
+              /^tests\/unit\/(?:test_.*|.*_test)\.py$/.test(path) &&
+              path !== 'tests/unit/test_transcript_action_workflow.py'
+            );
+            const allExpectedTestsChanged =
+              expectedTests.length > 0 &&
+              ciCollectedTests &&
+              expectedTests.every(path => presentChangedFiles.has(path));
+            const focusedTestFiles = allExpectedTestsChanged ? expectedTests : [];
+            const titleValid = pr.title.length >= 10 &&
+              /^(?:⚡\s*)?(?:feat|fix|docs|style|refactor|test|chore|perf|ci|build|revert)(?:\(.+\))?:/i.test(pr.title);
+
+            const payload = {
+              policy: {
+                applicable,
+                agent_login: expectedAgentLogin || null,
+                run_id: expectedRunId || null,
+                head_sha: pr.head.sha
+              },
+              issue: {
+                number: issueNumber || null,
+                description,
+                acceptance_criteria: acceptance,
+                declared_files: declaredFiles,
+                allowed_extra_files: allowedExtraFiles,
+                scope_unrestricted: scopeUnrestricted
+              },
+              pull_request: {
+                number: prNumber,
+                changed_files: changedFiles,
+                merged: Boolean(pr.merged),
+                draft: Boolean(pr.draft),
+                title_valid: titleValid,
+                required_checks_passed: requiredChecksPassed,
+                post_merge_checks_passed: postMergeChecksPassed
+              },
+              events,
+              reviews,
+              evidence: {
+                behavior_changed_files: behaviorChangedFiles,
+                focused_test_files: focusedTestFiles,
+                focused_tests_passed: focusedTestFiles.length > 0 && requiredChecksPassed
+              },
+              collection_errors: collectionErrors
+            };
+            fs.writeFileSync('gate-input.json', JSON.stringify(payload, null, 2));
+            core.setOutput('pr_number', String(prNumber));
+            core.setOutput('head_sha', pr.head.sha);
+
+      - name: Evaluate completion evidence
+        id: gate
+        shell: bash
+        run: |
+          set +e
+          python3 .trusted/scripts/ci/agent_completion_gate.py gate-input.json > gate-verdict.json
+          code=$?
+          set -e
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+
+      - name: Upload gate evidence
+        id: upload
+        if: always() && steps.resolve.outputs.pr_number != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: agent-completion-verdict-${{ steps.resolve.outputs.pr_number }}
+          path: |
+            gate-input.json
+            gate-verdict.json
+          if-no-files-found: error
+
+      - name: Publish stable status and comment
+        id: publish
+        if: always() && steps.resolve.outputs.pr_number != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
+          COLLECT_OUTCOME: ${{ steps.collect.outcome }}
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+          GATE_EXIT_CODE: ${{ steps.gate.outputs.exit_code }}
+          ARTIFACT_OUTCOME: ${{ steps.upload.outcome }}
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const marker = '<!-- agent-completion-truth-gate:v1 -->';
+            const runUrl = context.serverUrl + '/' + owner + '/' + repo +
+              '/actions/runs/' + context.runId;
+            let verdict = {
+              verdict: 'blocked',
+              reasons: ['verdict_artifact_missing'],
+              details: {}
+            };
+            try {
+              const candidate = JSON.parse(
+                fs.readFileSync('gate-verdict.json', 'utf8')
+              );
+              const validVerdicts = new Set([
+                'blocked', 'ready', 'completed', 'not_applicable'
+              ]);
+              if (!candidate || typeof candidate !== 'object' ||
+                  !validVerdicts.has(candidate.verdict) ||
+                  !Array.isArray(candidate.reasons) ||
+                  candidate.reasons.some(reason => typeof reason !== 'string') ||
+                  !candidate.details || typeof candidate.details !== 'object' ||
+                  Array.isArray(candidate.details)) {
+                throw new Error('invalid verdict schema');
+              }
+              verdict = candidate;
+            } catch (error) {
+              core.warning('Could not validate gate verdict: ' + error.message);
+            }
+
+            const forcedReasons = [];
+            if (process.env.COLLECT_OUTCOME !== 'success') {
+              forcedReasons.push('evidence_collection_step_failed');
+            }
+            if (process.env.GATE_OUTCOME !== 'success') {
+              forcedReasons.push('gate_evaluation_step_failed');
+            }
+            if (process.env.ARTIFACT_OUTCOME !== 'success') {
+              forcedReasons.push('evidence_artifact_failed');
+            }
+            if (verdict.verdict !== 'blocked' &&
+                process.env.GATE_EXIT_CODE !== '0') {
+              forcedReasons.push('gate_exit_code_mismatch');
+            }
+            const current = (await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: Number(process.env.PR_NUMBER)
+            })).data;
+            if (current.head.sha !== process.env.HEAD_SHA) {
+              forcedReasons.push('stale_head');
+            }
+            if (forcedReasons.length > 0) {
+              verdict = {
+                verdict: 'blocked',
+                reasons: [...new Set([...verdict.reasons, ...forcedReasons])],
+                details: verdict.details
+              };
+            }
+
+            async function latestGateStatus() {
+              const statuses = await github.paginate(
+                github.rest.repos.listCommitStatusesForRef,
+                {
+                  owner,
+                  repo,
+                  ref: process.env.HEAD_SHA,
+                  per_page: 100
+                }
+              );
+              return statuses
+                .filter(status =>
+                  status.context === 'agent-completion/truth-gate'
+                )
+                .sort((left, right) =>
+                  Date.parse(right.created_at) - Date.parse(left.created_at) ||
+                  right.id - left.id
+                )[0];
+            }
+            let latest = await latestGateStatus();
+            if (!(latest && latest.state === 'pending' &&
+                  latest.target_url === runUrl)) {
+              core.warning('Skipping stale gate publication');
+              return;
+            }
+
+            const reasons = verdict.reasons;
+            const escaped = JSON.stringify(verdict, null, 2)
+              .replace(/&/g, '&amp;')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;');
+            const body = marker + '\n## Agent Completion Truth Gate: ' +
+              verdict.verdict.toUpperCase() + '\n\n' +
+              (reasons.length > 0
+                ? '**Reasons:** ' + reasons
+                  .map(reason => '<code>' + reason + '</code>').join(', ')
+                : '**Evidence agrees.**') +
+              '\n\n<details><summary>Machine-readable verdict</summary><pre>' +
+              escaped + '</pre></details>\n\n[Workflow evidence](' + runUrl + ')';
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number: Number(process.env.PR_NUMBER),
+                per_page: 100
+              }
+            );
+            const existing = comments.find(comment =>
+              comment.user && comment.user.login === 'github-actions[bot]' &&
+              String(comment.body || '').includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: Number(process.env.PR_NUMBER),
+                body
+              });
+            }
+            await core.summary
+              .addHeading('Agent Completion Truth Gate')
+              .addCodeBlock(JSON.stringify(verdict, null, 2), 'json')
+              .write();
+
+            latest = await latestGateStatus();
+            if (!(latest && latest.state === 'pending' &&
+                  latest.target_url === runUrl)) {
+              core.warning('Skipping stale gate publication');
+              return;
+            }
+            const passed = verdict.verdict !== 'blocked';
+            const summary = reasons.length > 0
+              ? reasons.join(', ')
+              : verdict.verdict + ': all rules passed';
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha: process.env.HEAD_SHA,
+              state: passed ? 'success' : 'failure',
+              context: 'agent-completion/truth-gate',
+              description: summary.slice(0, 140),
+              target_url: runUrl
+            });
+            if (!passed) {
+              core.setFailed('Agent completion evidence is blocked');
+            }
+
+      - name: Finalize failed gate publication
+        if: >-
+          always() &&
+          steps.resolve.outputs.pr_number != '' &&
+          steps.publish.outcome != 'success'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = context.serverUrl + '/' + owner + '/' + repo +
+              '/actions/runs/' + context.runId;
+            const statuses = await github.paginate(
+              github.rest.repos.listCommitStatusesForRef,
+              {
+                owner,
+                repo,
+                ref: process.env.HEAD_SHA,
+                per_page: 100
+              }
+            );
+            const latest = statuses
+              .filter(status =>
+                status.context === 'agent-completion/truth-gate'
+              )
+              .sort((left, right) =>
+                Date.parse(right.created_at) - Date.parse(left.created_at) ||
+                right.id - left.id
+              )[0];
+            if (latest && latest.state === 'pending' &&
+                latest.target_url === runUrl) {
+              await github.rest.repos.createCommitStatus({
+                owner,
+                repo,
+                sha: process.env.HEAD_SHA,
+                state: 'failure',
+                context: 'agent-completion/truth-gate',
+                description: 'gate publication failed',
+                target_url: runUrl
+              });
+            }
+
+      - name: Enforce verdict
+        if: >-
+          always() &&
+          steps.resolve.outputs.pr_number != '' &&
+          (steps.collect.outcome != 'success' ||
+           steps.gate.outputs.exit_code != '0' ||
+           steps.upload.outcome != 'success' ||
+           steps.publish.outcome != 'success')
+        run: exit 1

--- a/docs/agent-completion-truth-gate.md
+++ b/docs/agent-completion-truth-gate.md
@@ -1,0 +1,113 @@
+# Agent Completion Truth Gate
+
+The truth gate converts repository evidence into one deterministic verdict. It never asks an LLM whether work is complete and it never approves, merges, closes, or reopens anything.
+
+## Enforcement lifecycle
+
+Before delegation, create the task with the Agent task issue form. Agent login, run ID, objective, acceptance criteria, exact file scope, allowed extras, and focused test paths are the intent contract. Unrestricted scope also requires the maintainer-controlled scope-unrestricted-approved label.
+
+When a complete agent task is opened or first labeled, the default-branch workflow writes a github-actions[bot] comment containing the SHA-256 digest of the normalized issue body and the unrestricted-scope approval state. The collector requires that snapshot, requires it to predate the PR, and blocks if the issue body or approval state later changes. Existing tasks must be labeled again by a maintainer to create their one-time snapshot before dispatch. Create a new task for materially changed intent; do not broaden a dispatched task in place.
+
+Agent pull requests link exactly one task with a closing keyword and include the agent-lock-manifest comment shown in the PR template. GitHub's authoritative closingIssuesReferences, the textual link, and the manifest must agree. The manifest login and run ID must exactly match the snapshotted issue. The declared agent publishes structured result evidence containing that run ID and the current PR head SHA; legacy unstructured readiness is never sufficient by itself.
+
+The trusted workflow runs on pull-request changes and serializes all evaluation for one PR. Linked-issue/result-comment changes and completed CI runs dispatch into that same queue; a 15-minute sweep refreshes all open PRs. Review decisions and thread resolution therefore converge within 15 minutes. It checks out only the default-branch gate and never executes code from the PR head.
+
+The workflow publishes all of the following:
+
+- commit status agent-completion/truth-gate;
+- one updatable PR comment with marker agent-completion-truth-gate:v1;
+- an Actions summary;
+- gate-input.json and gate-verdict.json artifacts.
+
+For the normal trust model—agents cannot write default-branch workflows or forge repository statuses—configure branch protection or the repository ruleset to require agent-completion/truth-gate, at least one approving review, and conversation resolution. Until those rules are configured, the workflow reports failures but cannot itself prevent a merge. Native review/conversation rules close the window between a new review comment and the scheduled refresh.
+
+Each serialized run first posts a pending status tied to its Actions run. It uploads evidence and updates the PR comment before publishing a terminal status. A compare-and-swap check rejects superseded publication; an always-running finalizer turns publication failures into a failure status. Actions are pinned to full commit SHAs. Only refresh-dispatch jobs receive actions: write.
+
+If an agent has repository-write credentials that can create Actions workflows or post statuses/comments, github-actions[bot] and a status-context string are not independent provenance. In that threat model, keep this workflow advisory until snapshot and check publication move to a dedicated GitHub App (or an organization ruleset-required trusted workflow) and bind the required check to that identity.
+
+## Applicability
+
+The gate applies when any of these signals identify agent work:
+
+- a known agent bot authored the PR;
+- the branch starts with agent/, claude/, codex/, copilot/, or jules/;
+- the PR or linked issue has agent, agent-task, or mcp/agent;
+- the PR contains an agent-lock-manifest comment.
+
+Dependabot is exempt. Other human-authored PRs receive not_applicable.
+
+## Input schema
+
+The CLI accepts one JSON object:
+
+    {
+      "policy": {
+        "applicable": true,
+        "agent_login": "google-labs-jules[bot]",
+        "run_id": "provider-run-id",
+        "head_sha": "1111111111111111111111111111111111111111"
+      },
+      "issue": {
+        "number": 802,
+        "description": "Required objective",
+        "acceptance_criteria": ["Observable criterion"],
+        "declared_files": ["src/example.py", "tests/unit/test_example.py"],
+        "allowed_extra_files": ["docs/example.md"],
+        "scope_unrestricted": false
+      },
+      "pull_request": {
+        "number": 813,
+        "changed_files": ["src/example.py", "tests/unit/test_example.py"],
+        "merged": false,
+        "draft": false,
+        "title_valid": true,
+        "required_checks_passed": true,
+        "post_merge_checks_passed": false
+      },
+      "events": [
+        {"kind": "artifact_ready", "sequence": 1, "run_id": "provider-run-id", "head_sha": "1111111111111111111111111111111111111111"},
+        {"kind": "error", "sequence": 2, "run_id": "provider-run-id", "head_sha": "1111111111111111111111111111111111111111"}
+      ],
+      "reviews": [
+        {"blocking": true, "resolved": false, "source": "thread-id"}
+      ],
+      "evidence": {
+        "behavior_changed_files": ["src/example.py"],
+        "focused_test_files": ["tests/unit/test_example.py"],
+        "focused_tests_passed": true
+      },
+      "collection_errors": []
+    }
+
+Run it with:
+
+    python3 scripts/ci/agent_completion_gate.py gate-input.json
+
+The CLI prints JSON to standard output. Exit status 1 means blocked; ready, completed, and not_applicable return 0.
+
+## Verdict schema
+
+Every result has the same shape:
+
+    {
+      "verdict": "blocked",
+      "reasons": ["scope_drift"],
+      "details": {
+        "undeclared_files": ["package-lock.json"]
+      }
+    }
+
+Verdict meanings:
+
+- blocked: one or more rules failed.
+- ready: pre-merge evidence agrees, but the PR is not complete.
+- completed: the PR is merged and required post-merge checks passed.
+- not_applicable: policy explicitly exempted the PR.
+
+## Fail-closed rules
+
+The gate blocks a missing, late, or changed intent snapshot; agent/run/head identity mismatches; blank intent; missing acceptance criteria; missing scope; undeclared paths (including a rename's previous path); unapproved unrestricted scope; failed evidence collection; missing current-run output; current-run agent errors; contradictory readiness/completion and error events; unresolved blocking reviews; failed required checks; draft or invalidly titled PRs; missing, deleted, or failing focused Python unit-test evidence; and merged work without passing post-merge checks on the merge SHA.
+
+Artifact ready is not completion. A Ready for review comment followed by an error is agent_run_failed. Generic green CI never overrides an unresolved review. An unmerged PR can be ready, but it can never be completed.
+
+The workflow also fails closed if checkout, evidence collection, evaluation, evidence upload, comment publication, or final status publication fails. The snapshot assumes repository write access and the default branch are trusted; organizations that delegate repository-write credentials to agents should move snapshot creation behind a protected environment or an independently authenticated GitHub App.

--- a/scripts/ci/agent_completion_gate.py
+++ b/scripts/ci/agent_completion_gate.py
@@ -7,6 +7,18 @@ from pathlib import Path
 from typing import Any, Dict
 
 
+def _object_or_empty(value: Any) -> Any:
+    """Return ``{}`` for an absent/``None`` field, else the value unchanged.
+
+    Unlike ``value or {}`` this preserves a supplied non-dict value (e.g. ``[]``
+    or ``0``) so the downstream ``isinstance`` checks can reject it with
+    ``invalid_payload`` instead of silently coercing malformed input to an empty
+    object and letting it pass validation.
+    """
+
+    return {} if value is None else value
+
+
 def evaluate(payload: Any) -> Dict[str, Any]:
     """Evaluate agent execution evidence and return a fail-closed verdict."""
 
@@ -17,7 +29,7 @@ def evaluate(payload: Any) -> Dict[str, Any]:
             "details": {},
         }
 
-    policy = payload.get("policy") or {}
+    policy = _object_or_empty(payload.get("policy"))
     if not isinstance(policy, dict):
         return {
             "verdict": "blocked",
@@ -33,9 +45,9 @@ def evaluate(payload: Any) -> Dict[str, Any]:
     if policy.get("applicable") is False:
         return {"verdict": "not_applicable", "reasons": [], "details": {}}
 
-    issue = payload.get("issue") or {}
-    pull_request = payload.get("pull_request") or {}
-    evidence = payload.get("evidence") or {}
+    issue = _object_or_empty(payload.get("issue"))
+    pull_request = _object_or_empty(payload.get("pull_request"))
+    evidence = _object_or_empty(payload.get("evidence"))
     invalid_fields = []
     for field, value in (
         ("issue", issue),
@@ -56,6 +68,14 @@ def evaluate(payload: Any) -> Dict[str, Any]:
             isinstance(item, dict) for item in value
         ):
             invalid_fields.append(field)
+    reviews_value = payload.get("reviews")
+    if isinstance(reviews_value, list):
+        for index, review in enumerate(reviews_value):
+            if not isinstance(review, dict):
+                continue
+            for field in ("blocking", "resolved"):
+                if field in review and type(review[field]) is not bool:
+                    invalid_fields.append("reviews[%d].%s" % (index, field))
     if isinstance(issue, dict):
         for field in (
             "acceptance_criteria",

--- a/scripts/ci/agent_completion_gate.py
+++ b/scripts/ci/agent_completion_gate.py
@@ -1,0 +1,258 @@
+"""Evidence-based completion verdicts for autonomous agent work."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+
+def evaluate(payload: Any) -> Dict[str, Any]:
+    """Evaluate agent execution evidence and return a fail-closed verdict."""
+
+    if not isinstance(payload, dict):
+        return {
+            "verdict": "blocked",
+            "reasons": ["invalid_payload"],
+            "details": {},
+        }
+
+    policy = payload.get("policy") or {}
+    if not isinstance(policy, dict):
+        return {
+            "verdict": "blocked",
+            "reasons": ["invalid_payload"],
+            "details": {"invalid_fields": ["policy"]},
+        }
+    if "applicable" in policy and type(policy["applicable"]) is not bool:
+        return {
+            "verdict": "blocked",
+            "reasons": ["invalid_payload"],
+            "details": {"invalid_fields": ["policy.applicable"]},
+        }
+    if policy.get("applicable") is False:
+        return {"verdict": "not_applicable", "reasons": [], "details": {}}
+
+    issue = payload.get("issue") or {}
+    pull_request = payload.get("pull_request") or {}
+    evidence = payload.get("evidence") or {}
+    invalid_fields = []
+    for field, value in (
+        ("issue", issue),
+        ("pull_request", pull_request),
+        ("evidence", evidence),
+    ):
+        if not isinstance(value, dict):
+            invalid_fields.append(field)
+    for field in ("events", "reviews", "collection_errors"):
+        value = payload.get(field)
+        if value is not None and not isinstance(value, list):
+            invalid_fields.append(field)
+    for field, value in (
+        ("events", payload.get("events") or []),
+        ("reviews", payload.get("reviews") or []),
+    ):
+        if isinstance(value, list) and not all(
+            isinstance(item, dict) for item in value
+        ):
+            invalid_fields.append(field)
+    if isinstance(issue, dict):
+        for field in (
+            "acceptance_criteria",
+            "declared_files",
+            "allowed_extra_files",
+        ):
+            value = issue.get(field)
+            if value is not None and not isinstance(value, list):
+                invalid_fields.append("issue." + field)
+            elif isinstance(value, list) and not all(
+                isinstance(item, str) for item in value
+            ):
+                invalid_fields.append("issue." + field)
+        if (
+            "scope_unrestricted" in issue
+            and type(issue["scope_unrestricted"]) is not bool
+        ):
+            invalid_fields.append("issue.scope_unrestricted")
+    if isinstance(pull_request, dict):
+        value = pull_request.get("changed_files")
+        if value is not None and not isinstance(value, list):
+            invalid_fields.append("pull_request.changed_files")
+        elif isinstance(value, list) and not all(
+            isinstance(item, str) for item in value
+        ):
+            invalid_fields.append("pull_request.changed_files")
+        for field in (
+            "merged",
+            "draft",
+            "title_valid",
+            "required_checks_passed",
+            "post_merge_checks_passed",
+        ):
+            if field in pull_request and type(pull_request[field]) is not bool:
+                invalid_fields.append("pull_request." + field)
+    if isinstance(evidence, dict):
+        for field in ("behavior_changed_files", "focused_test_files"):
+            value = evidence.get(field)
+            if value is not None and not isinstance(value, list):
+                invalid_fields.append("evidence." + field)
+            elif isinstance(value, list) and not all(
+                isinstance(item, str) for item in value
+            ):
+                invalid_fields.append("evidence." + field)
+        if (
+            "focused_tests_passed" in evidence
+            and type(evidence["focused_tests_passed"]) is not bool
+        ):
+            invalid_fields.append("evidence.focused_tests_passed")
+    if invalid_fields:
+        return {
+            "verdict": "blocked",
+            "reasons": ["invalid_payload"],
+            "details": {"invalid_fields": sorted(set(invalid_fields))},
+        }
+
+    reasons = []
+    details = {}
+    collection_errors = [
+        str(error)
+        for error in (payload.get("collection_errors") or [])
+        if str(error).strip()
+    ]
+    if collection_errors:
+        reasons.append("evidence_collection_failed")
+        details["collection_errors"] = collection_errors
+    if not str(issue.get("description") or "").strip():
+        reasons.append("blank_issue_description")
+    if not issue.get("acceptance_criteria"):
+        reasons.append("missing_acceptance_criteria")
+    if not issue.get("declared_files") and not issue.get("scope_unrestricted", False):
+        reasons.append("missing_declared_scope")
+
+    if not issue.get("scope_unrestricted", False):
+        declared = set(issue.get("declared_files") or [])
+        declared.update(issue.get("allowed_extra_files") or [])
+        changed = set(pull_request.get("changed_files") or [])
+        undeclared = sorted(changed - declared)
+        if undeclared:
+            reasons.append("scope_drift")
+            details["undeclared_files"] = undeclared
+
+    events = payload.get("events") or []
+    active_run_id = str(policy.get("run_id") or "").strip()
+    if active_run_id:
+        active_head_sha = str(policy.get("head_sha") or "").strip()
+        scoped_events = [
+            event
+            for event in events
+            if str(event.get("run_id") or "").strip() == active_run_id
+        ]
+        current_events = [
+            event
+            for event in scoped_events
+            if str(event.get("kind") or "").lower() == "error"
+            or not active_head_sha
+            or str(event.get("head_sha") or "").strip() == active_head_sha
+        ]
+        unscoped_errors = [
+            event
+            for event in events
+            if not str(event.get("run_id") or "").strip()
+            and str(event.get("kind") or "").lower() == "error"
+        ]
+        scoped_error_exists = any(
+            str(event.get("kind") or "").lower() == "error"
+            for event in scoped_events
+        )
+        legacy_positive_evidence = [
+            event
+            for event in events
+            if scoped_error_exists
+            and not str(event.get("run_id") or "").strip()
+            and str(event.get("kind") or "").lower()
+            in {"artifact_ready", "completed"}
+        ]
+        events = current_events + unscoped_errors + legacy_positive_evidence
+
+    terminal_kinds = {
+        str(event.get("kind") or "").lower()
+        for event in events
+    }
+    if not terminal_kinds.intersection({"artifact_ready", "completed"}):
+        reasons.append("missing_agent_result")
+    if "error" in terminal_kinds:
+        reasons.append("agent_run_failed")
+    if (
+        "error" in terminal_kinds
+        and terminal_kinds.intersection({"artifact_ready", "completed"})
+    ):
+        reasons.append("contradictory_terminal_events")
+
+    unresolved_reviews = [
+        str(review.get("source") or "unknown")
+        for review in (payload.get("reviews") or [])
+        if review.get("blocking") is True and review.get("resolved") is not True
+    ]
+    if unresolved_reviews:
+        reasons.append("unresolved_review")
+        details["unresolved_reviews"] = unresolved_reviews
+
+    if pull_request.get("required_checks_passed") is not True:
+        reasons.append("required_checks_failed")
+    if pull_request.get("draft") is True:
+        reasons.append("draft_pr")
+    if pull_request.get("title_valid") is not True:
+        reasons.append("invalid_pr_title")
+
+    if evidence.get("behavior_changed_files"):
+        if not evidence.get("focused_test_files"):
+            reasons.append("missing_test_evidence")
+        elif evidence.get("focused_tests_passed") is not True:
+            reasons.append("focused_tests_failed")
+
+    if (
+        pull_request.get("merged") is True
+        and pull_request.get("post_merge_checks_passed") is not True
+    ):
+        reasons.append("post_merge_checks_failed")
+
+    if reasons:
+        return {"verdict": "blocked", "reasons": reasons, "details": details}
+
+    if pull_request.get("merged") is True:
+        return {"verdict": "completed", "reasons": [], "details": {}}
+
+    return {"verdict": "ready", "reasons": [], "details": {}}
+
+
+def main(argv: Any = None) -> int:
+    """Evaluate one JSON evidence file and emit a machine-readable verdict."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", help="JSON evidence file, or - for stdin")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.input == "-":
+            payload = json.load(sys.stdin)
+        else:
+            payload = json.loads(Path(args.input).read_text(encoding="utf-8"))
+        result = evaluate(payload)
+    except json.JSONDecodeError as exc:
+        result = {
+            "verdict": "blocked",
+            "reasons": ["invalid_json"],
+            "details": {"error": str(exc)},
+        }
+    except (OSError, UnicodeError) as exc:
+        result = {
+            "verdict": "blocked",
+            "reasons": ["input_read_failed"],
+            "details": {"error": str(exc)},
+        }
+    print(json.dumps(result, sort_keys=True))
+    return 1 if result["verdict"] == "blocked" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/agent_completion_gate.py
+++ b/scripts/ci/agent_completion_gate.py
@@ -74,7 +74,7 @@ def evaluate(payload: Any) -> Dict[str, Any]:
             if not isinstance(review, dict):
                 continue
             for field in ("blocking", "resolved"):
-                if field in review and type(review[field]) is not bool:
+                if field not in review or type(review[field]) is not bool:
                     invalid_fields.append("reviews[%d].%s" % (index, field))
     if isinstance(issue, dict):
         for field in (

--- a/tests/fixtures/agent_completion/pr_813.json
+++ b/tests/fixtures/agent_completion/pr_813.json
@@ -1,0 +1,63 @@
+{
+  "policy": {
+    "applicable": true,
+    "agent_login": "google-labs-jules[bot]",
+    "run_id": "1892762060881911102"
+  },
+  "issue": {
+    "number": 802,
+    "description": null,
+    "acceptance_criteria": [],
+    "declared_files": [
+      "src/agents/specialized/quality_agent.py",
+      "src/youtube_extension/backend/ai_code_generator.py"
+    ],
+    "scope_unrestricted": false
+  },
+  "pull_request": {
+    "number": 813,
+    "changed_files": [
+      "apps/web/package.json",
+      "package-lock.json",
+      "src/agents/specialized/quality_agent.py",
+      "src/youtube_extension/backend/ai_code_generator.py",
+      "tests/unit/test_cloud_routes.py"
+    ],
+    "merged": false,
+    "draft": true,
+    "title_valid": false,
+    "required_checks_passed": true,
+    "post_merge_checks_passed": false
+  },
+  "events": [
+    {
+      "kind": "artifact_ready",
+      "sequence": 1,
+      "comment_id": 4998315522,
+      "run_id": null,
+      "raw_body": "Ready for a review! A [PR](https://github.com/groupthinking/EventRelay/pull/813) has been created."
+    },
+    {
+      "kind": "error",
+      "sequence": 2,
+      "comment_id": 4998316692,
+      "run_id": "1892762060881911102",
+      "raw_body": "Jules encountered an unexpected error and wasn't able to complete task/1892762060881911102."
+    }
+  ],
+  "reviews": [
+    {
+      "blocking": true,
+      "resolved": false,
+      "source": "PRRT_kwDORAYbZs6Rogl-"
+    }
+  ],
+  "evidence": {
+    "behavior_changed_files": [
+      "src/agents/specialized/quality_agent.py",
+      "src/youtube_extension/backend/ai_code_generator.py"
+    ],
+    "focused_test_files": [],
+    "focused_tests_passed": false
+  }
+}

--- a/tests/unit/test_agent_completion_gate.py
+++ b/tests/unit/test_agent_completion_gate.py
@@ -1,0 +1,700 @@
+import importlib
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+def _gate_module():
+    try:
+        return importlib.import_module(
+            "scripts.ci.agent_completion_gate"
+        )
+    except ModuleNotFoundError:
+        raise AssertionError("completion gate is not implemented") from None
+
+
+def _evaluate(payload):
+    return _gate_module().evaluate(payload)
+
+
+def _valid_payload():
+    return {
+        "issue": {
+            "description": "Add a deterministic completion gate.",
+            "acceptance_criteria": ["Reject incomplete agent output."],
+            "declared_files": [
+                "src/youtube_extension/agent_lock/completion_gate.py",
+                "tests/unit/test_agent_completion_gate.py",
+            ],
+            "scope_unrestricted": False,
+        },
+        "pull_request": {
+            "changed_files": [
+                "src/youtube_extension/agent_lock/completion_gate.py",
+                "tests/unit/test_agent_completion_gate.py",
+            ],
+            "merged": False,
+            "draft": False,
+            "title_valid": True,
+            "required_checks_passed": True,
+            "post_merge_checks_passed": False,
+        },
+        "events": [{"kind": "completed", "sequence": 1}],
+        "reviews": [],
+        "evidence": {
+            "behavior_changed_files": [
+                "src/youtube_extension/agent_lock/completion_gate.py"
+            ],
+            "focused_test_files": ["tests/unit/test_agent_completion_gate.py"],
+            "focused_tests_passed": True,
+        },
+        "policy": {"applicable": True},
+    }
+
+
+def _fixture(name):
+    test_root = Path(__file__).resolve().parent
+    fixture_root = test_root / "fixtures"
+    if not fixture_root.exists():
+        fixture_root = test_root.parent / "fixtures"
+    return json.loads(
+        (fixture_root / "agent_completion" / name).read_text(encoding="utf-8")
+    )
+
+
+def _repo_root():
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "scripts" / "ci" / "agent_completion_gate.py").exists():
+            return candidate
+    raise AssertionError("repository root not found")
+
+
+class CompletionGateTests(unittest.TestCase):
+    def test_blank_issue_description_is_blocked(self):
+        payload = _valid_payload()
+        payload["issue"]["description"] = "   "
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("blank_issue_description", result["reasons"])
+
+    def test_missing_acceptance_criteria_is_blocked(self):
+        payload = _valid_payload()
+        payload["issue"]["acceptance_criteria"] = []
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("missing_acceptance_criteria", result["reasons"])
+
+    def test_missing_declared_scope_is_blocked(self):
+        payload = _valid_payload()
+        payload["issue"]["declared_files"] = []
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("missing_declared_scope", result["reasons"])
+
+    def test_pr_813_declared_two_files_but_changed_five_is_scope_drift(self):
+        payload = _valid_payload()
+        payload["issue"]["declared_files"] = [
+            "src/agents/specialized/quality_agent.py",
+            "src/youtube_extension/backend/ai_code_generator.py",
+        ]
+        payload["pull_request"]["changed_files"] = [
+            "apps/web/package.json",
+            "package-lock.json",
+            "src/agents/specialized/quality_agent.py",
+            "src/youtube_extension/backend/ai_code_generator.py",
+            "tests/unit/test_cloud_routes.py",
+        ]
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("scope_drift", result["reasons"])
+        self.assertEqual(
+            result["details"]["undeclared_files"],
+            [
+                "apps/web/package.json",
+                "package-lock.json",
+                "tests/unit/test_cloud_routes.py",
+            ],
+        )
+
+    def test_explicit_unrestricted_scope_allows_undeclared_files(self):
+        payload = _valid_payload()
+        payload["issue"]["declared_files"] = []
+        payload["issue"]["scope_unrestricted"] = True
+        payload["pull_request"]["changed_files"].append("docs/extra.md")
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "ready")
+        self.assertNotIn("scope_drift", result["reasons"])
+
+    def test_completion_followed_by_error_is_contradictory(self):
+        payload = _valid_payload()
+        payload["events"] = [
+            {"kind": "completed", "sequence": 1},
+            {"kind": "error", "sequence": 2},
+        ]
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("contradictory_terminal_events", result["reasons"])
+
+    def test_artifact_ready_followed_by_error_is_failed_not_completed(self):
+        payload = _valid_payload()
+        payload["events"] = [
+            {"kind": "artifact_ready", "sequence": 1},
+            {"kind": "error", "sequence": 2},
+        ]
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("agent_run_failed", result["reasons"])
+
+    def test_missing_agent_result_is_blocked(self):
+        payload = _valid_payload()
+        payload["events"] = []
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("missing_agent_result", result["reasons"])
+
+    def test_successful_new_run_can_recover_from_an_old_run_error(self):
+        payload = _valid_payload()
+        payload["policy"]["run_id"] = "new-run"
+        payload["events"] = [
+            {"kind": "error", "run_id": "old-run", "sequence": 1},
+            {"kind": "completed", "run_id": "new-run", "sequence": 2},
+        ]
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "ready")
+
+    def test_historical_success_cannot_satisfy_a_silent_current_run(self):
+        payload = _valid_payload()
+        payload["policy"]["run_id"] = "new-run"
+        payload["events"] = [
+            {"kind": "completed", "run_id": "old-run", "sequence": 1},
+        ]
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("missing_agent_result", result["reasons"])
+
+    def test_unscoped_success_cannot_satisfy_a_correlated_run(self):
+        payload = _valid_payload()
+        payload["policy"]["run_id"] = "new-run"
+        payload["events"] = [
+            {"kind": "completed", "sequence": 1},
+        ]
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("missing_agent_result", result["reasons"])
+
+    def test_success_from_an_old_head_cannot_satisfy_current_head(self):
+        payload = _valid_payload()
+        payload["policy"].update(
+            {"run_id": "new-run", "head_sha": "b" * 40}
+        )
+        payload["events"] = [
+            {
+                "kind": "completed",
+                "run_id": "new-run",
+                "head_sha": "a" * 40,
+                "sequence": 1,
+            },
+        ]
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("missing_agent_result", result["reasons"])
+
+    def test_legacy_ready_plus_correlated_error_is_contradictory(self):
+        payload = _valid_payload()
+        payload["policy"]["run_id"] = "1892762060881911102"
+        payload["events"] = [
+            {"kind": "artifact_ready", "run_id": None, "sequence": 1},
+            {
+                "kind": "error",
+                "run_id": "1892762060881911102",
+                "sequence": 2,
+            },
+        ]
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("contradictory_terminal_events", result["reasons"])
+
+    def test_unscoped_error_still_blocks_a_correlated_run(self):
+        payload = _valid_payload()
+        payload["policy"]["run_id"] = "new-run"
+        payload["events"] = [
+            {"kind": "error", "sequence": 1},
+            {"kind": "completed", "run_id": "new-run", "sequence": 2},
+        ]
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("agent_run_failed", result["reasons"])
+
+    def test_green_ci_does_not_override_unresolved_blocking_review(self):
+        payload = _valid_payload()
+        payload["pull_request"]["required_checks_passed"] = True
+        payload["reviews"] = [
+            {
+                "blocking": True,
+                "resolved": False,
+                "source": "discussion_r3599972900",
+            }
+        ]
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("unresolved_review", result["reasons"])
+        self.assertEqual(
+            result["details"]["unresolved_reviews"],
+            ["discussion_r3599972900"],
+        )
+
+    def test_failed_required_checks_are_blocked(self):
+        payload = _valid_payload()
+        payload["pull_request"]["required_checks_passed"] = False
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("required_checks_failed", result["reasons"])
+
+    def test_behavior_change_without_focused_test_evidence_is_blocked(self):
+        payload = _valid_payload()
+        payload["evidence"]["focused_test_files"] = []
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("missing_test_evidence", result["reasons"])
+
+    def test_focused_tests_must_pass(self):
+        payload = _valid_payload()
+        payload["evidence"]["focused_tests_passed"] = False
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("focused_tests_failed", result["reasons"])
+
+    def test_unmerged_pr_can_be_ready_but_never_completed(self):
+        payload = _valid_payload()
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "ready")
+        self.assertNotEqual(result["verdict"], "completed")
+
+    def test_merged_pr_without_post_merge_checks_is_blocked(self):
+        payload = _valid_payload()
+        payload["pull_request"]["merged"] = True
+        payload["pull_request"]["post_merge_checks_passed"] = False
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("post_merge_checks_failed", result["reasons"])
+
+    def test_fully_verified_merged_work_is_completed(self):
+        payload = _valid_payload()
+        payload["pull_request"]["merged"] = True
+        payload["pull_request"]["post_merge_checks_passed"] = True
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result, {"verdict": "completed", "reasons": [], "details": {}})
+
+    def test_draft_agent_pr_is_blocked(self):
+        payload = _valid_payload()
+        payload["pull_request"]["draft"] = True
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("draft_pr", result["reasons"])
+
+    def test_invalid_pr_title_is_blocked(self):
+        payload = _valid_payload()
+        payload["pull_request"]["title_valid"] = False
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("invalid_pr_title", result["reasons"])
+
+    def test_non_agent_pr_is_not_applicable(self):
+        payload = _valid_payload()
+        payload["policy"]["applicable"] = False
+
+        result = _evaluate(payload)
+
+        self.assertEqual(
+            result,
+            {"verdict": "not_applicable", "reasons": [], "details": {}},
+        )
+
+    def test_malformed_payload_fails_closed(self):
+        result = _evaluate([])
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("invalid_payload", result["reasons"])
+
+    def test_malformed_nested_fields_return_a_verdict(self):
+        payload = _valid_payload()
+        payload["events"] = ["not-an-event"]
+
+        try:
+            result = _evaluate(payload)
+        except (AttributeError, TypeError):
+            self.fail("malformed nested evidence raised instead of failing closed")
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("invalid_payload", result["reasons"])
+
+    def test_non_string_path_entries_return_a_verdict(self):
+        payload = _valid_payload()
+        payload["pull_request"]["changed_files"] = [{}]
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("invalid_payload", result["reasons"])
+        self.assertIn(
+            "pull_request.changed_files",
+            result["details"]["invalid_fields"],
+        )
+
+    def test_non_boolean_policy_fields_cannot_bypass_rules(self):
+        for section, field in (
+            ("policy", "applicable"),
+            ("issue", "scope_unrestricted"),
+            ("pull_request", "draft"),
+            ("pull_request", "merged"),
+            ("pull_request", "title_valid"),
+            ("pull_request", "required_checks_passed"),
+            ("pull_request", "post_merge_checks_passed"),
+            ("evidence", "focused_tests_passed"),
+        ):
+            with self.subTest(section=section, field=field):
+                payload = _valid_payload()
+                payload[section][field] = "true"
+
+                result = _evaluate(payload)
+
+                self.assertEqual(result["verdict"], "blocked")
+                self.assertIn("invalid_payload", result["reasons"])
+                self.assertIn(
+                    f"{section}.{field}",
+                    result["details"]["invalid_fields"],
+                )
+
+    def test_evidence_collection_errors_fail_closed(self):
+        payload = _valid_payload()
+        payload["collection_errors"] = ["invalid_agent_lock_manifest"]
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("evidence_collection_failed", result["reasons"])
+        self.assertEqual(
+            result["details"]["collection_errors"],
+            ["invalid_agent_lock_manifest"],
+        )
+
+    def test_pr_813_fixture_is_blocked_for_every_expected_reason(self):
+        result = _evaluate(_fixture("pr_813.json"))
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertEqual(
+            set(result["reasons"]),
+            {
+                "blank_issue_description",
+                "missing_acceptance_criteria",
+                "scope_drift",
+                "agent_run_failed",
+                "contradictory_terminal_events",
+                "unresolved_review",
+                "draft_pr",
+                "invalid_pr_title",
+                "missing_test_evidence",
+            },
+        )
+        self.assertEqual(
+            result["details"]["undeclared_files"],
+            [
+                "apps/web/package.json",
+                "package-lock.json",
+                "tests/unit/test_cloud_routes.py",
+            ],
+        )
+
+    def test_cli_prints_json_and_returns_nonzero_for_blocked_input(self):
+        module = _gate_module()
+        if not hasattr(module, "main"):
+            self.fail("completion gate CLI is not implemented")
+        payload = _valid_payload()
+        payload["issue"]["description"] = ""
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as handle:
+            json.dump(payload, handle)
+            handle.flush()
+            output = io.StringIO()
+            with redirect_stdout(output):
+                exit_code = module.main([handle.name])
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(json.loads(output.getvalue())["verdict"], "blocked")
+
+    def test_cli_fails_closed_for_invalid_json(self):
+        module = _gate_module()
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as handle:
+            handle.write("{not-json")
+            handle.flush()
+            output = io.StringIO()
+            try:
+                with redirect_stdout(output):
+                    exit_code = module.main([handle.name])
+            except json.JSONDecodeError:
+                self.fail("CLI raised instead of returning a fail-closed verdict")
+
+        result = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("invalid_json", result["reasons"])
+
+    def test_cli_fails_closed_when_input_cannot_be_read(self):
+        module = _gate_module()
+        output = io.StringIO()
+        missing = str(Path(tempfile.gettempdir()) / "agent-lock-missing.json")
+
+        try:
+            with redirect_stdout(output):
+                exit_code = module.main([missing])
+        except OSError:
+            self.fail("CLI raised instead of returning an input-read verdict")
+
+        result = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("input_read_failed", result["reasons"])
+
+    def test_cli_returns_zero_for_ready_input(self):
+        module = _gate_module()
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as handle:
+            json.dump(_valid_payload(), handle)
+            handle.flush()
+            output = io.StringIO()
+            with redirect_stdout(output):
+                exit_code = module.main([handle.name])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(json.loads(output.getvalue())["verdict"], "ready")
+
+
+class CompletionGateWorkflowTests(unittest.TestCase):
+    def _workflow(self):
+        return (
+            _repo_root() / ".github" / "workflows" / "pr-checks.yml"
+        ).read_text(encoding="utf-8")
+
+    def test_workflow_runs_from_trusted_default_branch(self):
+        workflow = self._workflow()
+
+        self.assertIn("pull_request_target:", workflow)
+        self.assertIn("workflow_run:", workflow)
+        self.assertIn("issue_comment:", workflow)
+        self.assertIn("issues:", workflow)
+        self.assertIn("schedule:", workflow)
+        self.assertNotIn("\n  pull_request_review:", workflow)
+        self.assertIn("github.event.repository.default_branch", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertNotIn("github.event.pull_request.head.sha }}", workflow)
+
+    def test_workflow_cannot_leave_a_stale_green_status(self):
+        workflow = self._workflow()
+
+        self.assertIn("id: resolve", workflow)
+        self.assertIn("state: 'pending'", workflow)
+        self.assertIn("if: always() && steps.resolve.outputs.pr_number != ''", workflow)
+        self.assertIn("id: upload", workflow)
+        self.assertIn("steps.upload.outcome", workflow)
+        self.assertIn("id: publish", workflow)
+        self.assertIn("steps.publish.outcome != 'success'", workflow)
+        self.assertIn("latest.target_url === runUrl", workflow)
+        self.assertLess(
+            workflow.index("name: Upload gate evidence"),
+            workflow.index("name: Publish stable status and comment"),
+        )
+
+    def test_workflow_pins_every_third_party_action(self):
+        workflow = self._workflow()
+
+        self.assertNotRegex(workflow, r"uses:\s+actions/[^@\s]+@v\d+")
+        self.assertIn(
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+            workflow,
+        )
+        self.assertIn(
+            "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+            workflow,
+        )
+        self.assertIn(
+            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+            workflow,
+        )
+
+    def test_workflow_freezes_issue_intent_before_agent_execution(self):
+        workflow = self._workflow()
+
+        self.assertIn("types: [opened, edited, labeled, unlabeled, closed, reopened]", workflow)
+        self.assertIn("snapshot-agent-task-intent:", workflow)
+        self.assertIn("agent-lock-intent-snapshot:v1", workflow)
+        self.assertIn("createHash('sha256')", workflow)
+        self.assertIn("missing_intent_snapshot", workflow)
+        self.assertIn("intent_changed_after_dispatch", workflow)
+
+    def test_workflow_publishes_one_machine_readable_gate(self):
+        workflow = self._workflow()
+
+        self.assertIn("scripts/ci/agent_completion_gate.py", workflow)
+        self.assertIn("agent-completion/truth-gate", workflow)
+        self.assertIn("agent-completion-truth-gate:v1", workflow)
+        self.assertIn("actions/upload-artifact@", workflow)
+
+    def test_workflow_uses_required_ci_and_separate_post_merge_evidence(self):
+        workflow = self._workflow()
+
+        self.assertIn("run.name === 'CI'", workflow)
+        self.assertIn("pr.merge_commit_sha", workflow)
+        self.assertNotIn("getCombinedStatusForRef", workflow)
+
+    def test_commented_review_does_not_clear_changes_requested(self):
+        workflow = self._workflow()
+
+        self.assertIn(
+            "['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(",
+            workflow,
+        )
+        self.assertIn("reviewDecision", workflow)
+
+    def test_adapter_fails_closed_on_pagination_and_binds_trusted_ci(self):
+        workflow = self._workflow()
+
+        self.assertIn("changed_files_truncated", workflow)
+        self.assertIn("run.path === '.github/workflows/ci.yml'", workflow)
+        self.assertIn("run.event === expectedEvent", workflow)
+        self.assertIn("pull.number === prNumber", workflow)
+        self.assertIn("trusted_ci_workflow_changed", workflow)
+        self.assertIn("file.previous_filename", workflow)
+        self.assertIn("file.status !== 'removed'", workflow)
+
+    def test_gate_runs_are_serialized_by_resolved_pr_number(self):
+        workflow = self._workflow()
+
+        self.assertIn("dispatch-evidence-refresh:", workflow)
+        self.assertIn("group: agent-completion-${{", workflow)
+        self.assertIn("inputs.pull_request || github.event.pull_request.number", workflow)
+        self.assertIn("cancel-in-progress: false", workflow)
+
+    def test_collector_binds_structured_agent_event_to_head(self):
+        workflow = self._workflow()
+
+        self.assertIn("agent-lock-event", workflow)
+        self.assertIn("head_sha: pr.head.sha", workflow)
+        self.assertIn("structuredEvent.head_sha", workflow)
+        self.assertIn("ready for (?:a )?review", workflow)
+        self.assertIn("\\[PR\\]", workflow)
+
+    def test_collector_uses_authoritative_closing_issue_references(self):
+        workflow = self._workflow()
+
+        self.assertIn("closingIssuesReferences", workflow)
+        self.assertIn("multiple_closing_issues", workflow)
+
+    def test_snapshot_validates_contract_and_freezes_approval_state(self):
+        workflow = self._workflow()
+
+        self.assertIn("pre-dispatch confirmation", workflow.lower())
+        self.assertIn("incomplete_agent_task_contract", workflow)
+        self.assertIn("scope_unrestricted_approved", workflow)
+        self.assertIn("intent_snapshot_after_dispatch", workflow)
+
+    def test_adapter_recognizes_agent_labels_scripts_and_blocking_threads(self):
+        workflow = self._workflow()
+
+        self.assertIn("'agenttask'", workflow)
+        self.assertIn("explicitlyNonBehavioral", workflow)
+        self.assertIn("!explicitlyNonBehavioral", workflow)
+        self.assertIn("VADE-RECOMMENDATION", workflow)
+
+    def test_workflow_does_not_approve_or_merge(self):
+        workflow = self._workflow()
+
+        self.assertNotIn("createReview", workflow)
+        self.assertNotIn("pulls.merge", workflow)
+        self.assertNotIn("mergePullRequest", workflow)
+        self.assertNotIn("event: 'APPROVE'", workflow)
+
+
+class CompletionGateDocumentationTests(unittest.TestCase):
+    def test_agent_task_template_requires_pre_dispatch_evidence(self):
+        template = (
+            _repo_root() / ".github" / "ISSUE_TEMPLATE" / "agent-task.yml"
+        ).read_text(encoding="utf-8")
+
+        for field in (
+            "Objective",
+            "Acceptance criteria",
+            "Declared file scope",
+            "Focused test paths",
+            "Unrestricted scope",
+        ):
+            self.assertIn(field, template)
+
+    def test_pr_template_uses_an_inert_example_marker(self):
+        template = (
+            _repo_root() / ".github" / "pull_request_template.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("agent-lock-example", template)
+        self.assertNotIn("<!-- agent-lock-manifest", template)
+
+    def test_operator_doc_defines_schemas_and_enforcement(self):
+        documentation = (
+            _repo_root() / "docs" / "agent-completion-truth-gate.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Input schema", documentation)
+        self.assertIn("Verdict schema", documentation)
+        self.assertIn("Fail-closed", documentation)
+        self.assertIn("agent-completion/truth-gate", documentation)
+        self.assertIn("branch protection", documentation.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_agent_completion_gate.py
+++ b/tests/unit/test_agent_completion_gate.py
@@ -414,6 +414,36 @@ class CompletionGateTests(unittest.TestCase):
                     result["details"]["invalid_fields"],
                 )
 
+    def test_falsey_non_dict_containers_are_not_masked(self):
+        for field in ("issue", "pull_request", "evidence", "policy"):
+            with self.subTest(field=field):
+                payload = _valid_payload()
+                payload[field] = []
+
+                result = _evaluate(payload)
+
+                self.assertEqual(result["verdict"], "blocked")
+                self.assertIn("invalid_payload", result["reasons"])
+                self.assertIn(field, result["details"]["invalid_fields"])
+
+    def test_non_boolean_review_flags_cannot_bypass_blocking(self):
+        for field in ("blocking", "resolved"):
+            with self.subTest(field=field):
+                payload = _valid_payload()
+                payload["reviews"] = [
+                    {"blocking": True, "resolved": False, "source": "r1"}
+                ]
+                payload["reviews"][0][field] = "true"
+
+                result = _evaluate(payload)
+
+                self.assertEqual(result["verdict"], "blocked")
+                self.assertIn("invalid_payload", result["reasons"])
+                self.assertIn(
+                    "reviews[0]." + field,
+                    result["details"]["invalid_fields"],
+                )
+
     def test_evidence_collection_errors_fail_closed(self):
         payload = _valid_payload()
         payload["collection_errors"] = ["invalid_agent_lock_manifest"]

--- a/tests/unit/test_agent_completion_gate.py
+++ b/tests/unit/test_agent_completion_gate.py
@@ -444,6 +444,17 @@ class CompletionGateTests(unittest.TestCase):
                     result["details"]["invalid_fields"],
                 )
 
+    def test_review_items_must_carry_boolean_blocking_and_resolved(self):
+        payload = _valid_payload()
+        payload["reviews"] = [{"source": "r1"}]
+
+        result = _evaluate(payload)
+
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("invalid_payload", result["reasons"])
+        self.assertIn("reviews[0].blocking", result["details"]["invalid_fields"])
+        self.assertIn("reviews[0].resolved", result["details"]["invalid_fields"])
+
     def test_evidence_collection_errors_fail_closed(self):
         payload = _valid_payload()
         payload["collection_errors"] = ["invalid_agent_lock_manifest"]

--- a/tests/unit/test_agent_completion_gate.py
+++ b/tests/unit/test_agent_completion_gate.py
@@ -613,13 +613,16 @@ class CompletionGateWorkflowTests(unittest.TestCase):
         self.assertIn("file.previous_filename", workflow)
         self.assertIn("file.status !== 'removed'", workflow)
 
-    def test_gate_runs_are_serialized_by_resolved_pr_number(self):
+    def test_gate_runs_are_serialized_and_coalesced_by_pr_number(self):
         workflow = self._workflow()
 
         self.assertIn("dispatch-evidence-refresh:", workflow)
         self.assertIn("group: agent-completion-${{", workflow)
         self.assertIn("inputs.pull_request || github.event.pull_request.number", workflow)
-        self.assertIn("cancel-in-progress: false", workflow)
+        self.assertIn("cancel-in-progress: true", workflow)
+        self.assertIn("trustedCommentAssociations", workflow)
+        self.assertIn("comment.author_association", workflow)
+        self.assertIn("google-labs-jules[bot]", workflow)
 
     def test_collector_binds_structured_agent_event_to_head(self):
         workflow = self._workflow()


### PR DESCRIPTION
## Summary

Carries the deterministic Agent Completion Truth Gate from #872 **plus** the four review findings that were still open on that PR, so this branch is the review-complete version. Recommend consolidating onto this PR and closing #872 (identical base history `91863d1` + one hardening commit).

Fixes applied on top of #872's head:

- **Gate — masked-malformed input.** `payload.get(x) or {}` coerced a falsey non-dict (e.g. `evidence: []`) into `{}`, hiding malformed input and letting an invalid payload reach a `ready` verdict. New `_object_or_empty` defaults only for absent/`None`; any supplied non-dict now fails closed with `invalid_payload`.
- **Gate — untyped review flags.** Nested `blocking`/`resolved` were never type-checked, so `{"blocking": "true"}` was silently treated as non-blocking. Real booleans are now required (`reviews[i].blocking`/`.resolved` → `invalid_payload` otherwise).
- **Workflow — `_No response_` sentinel.** An empty "Declared file scope" issue-form field renders as `_No response_`, which made `declaredScope` truthy and froze a snapshot with no real declared scope. The sentinel is now treated as empty before the pre-dispatch contract check.
- **Docs — stale workflow catalog.** Refreshed the `pr-checks.yml` rows in `.github/workflows/README.md` and `AUDIT.md` to document the new triggers, privileged permissions, and truth-gate role.

## Linked issue

Fixes #870

## Verification

- [x] Focused tests — `python3 -m unittest tests.unit.test_agent_completion_gate` → 53/53 pass (51 original + 2 new regression tests)
- [x] Required CI — gate module compiles, `pr-checks.yml` YAML parses, edited embedded JS syntax-checks clean
- [ ] Review threads resolved — the four Copilot threads on #872 are addressed by this branch's diff; resolve on consolidation

## Agent provenance

Human-authored pull requests may delete this section. Agent-authored pull requests must replace agent-lock-example with agent-lock-manifest and fill the values. Scope and test paths remain authoritative in the linked issue.

<!-- agent-lock-example
{"issue_number": 0, "agent_login": "agent-name", "run_id": "provider-run-id"}
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_01MSxsaM7yYGBGYwvYQcVZze)_