### PR TITLE
ci(dependency-review): allow caniuse-lite's CC-BY-4.0 data license

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,10 +28,14 @@ jobs:
           # PR #295: vite/vitest tree (BlueOak-1.0.0, MPL-2.0 lightningcss), type-fest (CC0-1.0),
           # rollup@4.x compound SPDX (0BSD AND ISC AND MIT).
           # FSL-1.1-MIT is not a valid SPDX id for allow-licenses — exclude @sentry/* via purls.
+          # caniuse-lite ships MIT code but a CC-BY-4.0 dataset; the scanner reports the data
+          # license, which is not code we redistribute. It updates on nearly every browserslist
+          # refresh, so allow it by purl rather than adding CC-BY-4.0 to the global allow-licenses.
           allow-licenses: >-
             MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, Python-2.0,
             BlueOak-1.0.0, MPL-2.0, CC0-1.0, 0BSD
           allow-dependencies-licenses: >-
+            pkg:npm/caniuse-lite,
             pkg:npm/@sentry/nextjs,
             pkg:npm/@sentry/cli,
             pkg:npm/@sentry/cli-darwin,


### PR DESCRIPTION
## Summary

The `dependency-review` gate fails on **every** Dependabot npm bump that refreshes `caniuse-lite`, blocking otherwise-clean dependency PRs. Observed on PR #881 (head `147cb07`), where the check failed while the scan explicitly reported **no vulnerabilities**:

```
Dependency review did not detect any vulnerable packages with severity level "moderate" or higher.
The following dependencies have incompatible licenses:
package-lock.json » caniuse-lite@1.0.30001806 – License: CC-BY-4.0
##[error]Dependency review detected incompatible licenses.
```

`caniuse-lite` ships MIT-licensed **code**; only its browser-compatibility **dataset** is CC-BY-4.0, and that data is not code we redistribute. The bump moved it `1.0.30001799 → 1.0.30001806`, which re-triggers the license evaluation. Because caniuse-lite updates on nearly every browserslist refresh (pulled transitively via browserslist / autoprefixer / tailwind), this is a recurring false positive on the license gate.

This change allowlists `pkg:npm/caniuse-lite` in `allow-dependencies-licenses` — the same per-purl mechanism the workflow already uses for `@sentry/*` — rather than broadening the global `allow-licenses` list to include `CC-BY-4.0`. Vulnerability enforcement (`fail-on-severity: moderate`) is unchanged.

## Linked issue

N/A — CI-hygiene fix surfaced by the failing check on #881.

## Verification

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dependency-review.yml'))"`)
- [x] Root cause confirmed from the `dependency-review` job log on #881 head `147cb07` (license-only failure, zero vulnerabilities)
- [ ] Required CI — will run on this PR; the same action re-evaluating this diff is the real end-to-end check
- [ ] Review threads resolved

## Notes

Scoped to the license false positive only. The other two red checks on #881 (`validate`, `agent-completion/truth-gate`) are the repo's agent-completion policy gates, which a Dependabot-authored PR cannot satisfy by design — out of scope here and a separate policy decision.


---
_Generated by [Claude Code](https://claude.ai/code/session_016U6QJimZShor41DG3XhoqX)_