### PR TITLE
fix(security): sanitize Ray-Serve checkpoint 500 body (CWE-209)

### DIFF
--- a/src/uvai/ml/serve.py
+++ b/src/uvai/ml/serve.py
@@ -399,8 +399,11 @@ class UVAIMLRouter:
                         "ranker_samples": ranker_state.get("training_samples", 0),
                     })
                 except Exception as exc:
+                    # Log the full error server-side; return a static body so the
+                    # exception text does not leak to the client (CWE-209).
+                    logger.error("Checkpoint save failed: %s", exc, exc_info=True)
                     return JSONResponse(
-                        {"error": str(exc)},
+                        {"error": "Internal server error"},
                         status_code=500,
                     )
             else:

--- a/tests/unit/test_ml_serve.py
+++ b/tests/unit/test_ml_serve.py
@@ -176,7 +176,9 @@ async def test_checkpoint_post_failure(mock_save, router):
     response = await router(request)
     assert response.status_code == 500
     body = json.loads(response.body)
-    assert body["error"] == "Save failed"
+    # The 500 body must be static; the exception text must not leak (CWE-209).
+    assert body["error"] == "Internal server error"
+    assert "Save failed" not in json.dumps(body)
 
 @pytest.mark.asyncio
 @patch("uvai.ml.serve.load_checkpoint", return_value={"scorer_state": {}, "ranker_state": {}})


### PR DESCRIPTION
## Summary

The `UVAIMLRouter` checkpoint-save handler in `src/uvai/ml/serve.py` returned
`JSONResponse({"error": str(exc)}, status_code=500)`, leaking the raw exception
text to the client — a CWE-209 information-disclosure leak.

This is the **one residual sink** from the #815 effort ("close all HTTP 500
info-disclosure leaks") that never reached `main`. #815 was closed unmerged
(its branch was 150 commits behind and `mergeable_state: dirty`); the rest of
its fixes already landed on `main` in equal-or-better form, but this Ray-Serve
sink did not. Verified against current `main`: `serve.py:403` still leaks.

This PR is a **fresh, minimal change off current `main`** — it deliberately
does *not* resurrect the stale #815 branch, which would have regressed the
already-superior `main.py` global handler and dropped the Prometheus middleware.

Changes:
- `serve.py`: return a static `"Internal server error"` body; log the full
  exception server-side via `logger.error(..., exc_info=True)`.
- `test_ml_serve.py`: `test_checkpoint_post_failure` asserted the *leaking* body
  (`body["error"] == "Save failed"`); now asserts the sanitized body and that the
  exception text is absent.

## Linked issue

Context: supersedes the residual scope of #815 (closed unmerged). No separate issue.

## Verification

- [x] Focused tests — `pytest tests/unit/test_ml_serve.py` → 15 passed; log
  confirms the exception is recorded server-side while the body is sanitized.
- [ ] Required CI — pending on this PR.
- [x] Review threads resolved — n/a (new PR).

## Agent provenance

Automated maintenance change produced by a scheduled Claude Code routine. No
agent-lock manifest is attached — this run has no verifiable provider run ID to
sign into the enforcement manifest, and fabricating one would defeat its purpose.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbLQjP4uJSRfSAoRYFivsB)_