### PR TITLE
fix(security): sanitize 500 response in ml_serve checkpoint handler (CWE-209)

### DIFF
--- a/tests/unit/test_500_info_disclosure.py
+++ b/tests/unit/test_500_info_disclosure.py
@@ -83,13 +83,16 @@ def _refs_exception_or_request(node: ast.AST) -> bool:
     return False
 
 
-def _status_is_500(call: ast.Call) -> bool:
+def _status_is_500(call: ast.Call, name: str) -> bool:
     for kw in call.keywords:
         if kw.arg == "status_code" and isinstance(kw.value, ast.Constant):
             return kw.value.value == 500
-    # positional status_code (JSONResponse(500, ...) / HTTPException(500, ...))
-    if call.args and isinstance(call.args[0], ast.Constant):
-        return call.args[0].value == 500
+    # The positional slot of ``status_code`` differs by constructor:
+    #   HTTPException(status_code, detail, ...)  -> args[0]
+    #   JSONResponse(content, status_code, ...)  -> args[1]
+    idx = 1 if name == "JSONResponse" else 0
+    if len(call.args) > idx and isinstance(call.args[idx], ast.Constant):
+        return call.args[idx].value == 500
     return False
 
 
@@ -107,7 +110,7 @@ def _iter_500_leaks(text: str):
         name = _call_name(node)
         if name not in ("HTTPException", "JSONResponse"):
             continue
-        if not _status_is_500(node):
+        if not _status_is_500(node, name):
             continue
         # Check keyword arguments
         for kw in node.keywords:
@@ -122,13 +125,11 @@ def _iter_500_leaks(text: str):
         if name == "HTTPException" and len(node.args) >= 2:
             if not _is_static_string(node.args[1]):
                 yield node.lineno, "HTTPException 500 detail is not a static string"
-        # Positional JSONResponse body: JSONResponse(<body>, status_code=500).
-        # args[0] is the content (a 500 literal there would be a nonsensical body,
-        # so skip it — that shape is only meaningful for the HTTPException form).
+        # Positional JSONResponse body: JSONResponse(<body>, status_code=500) and
+        # the fully positional JSONResponse(<body>, 500). The content is always
+        # args[0] for JSONResponse, regardless of how status_code is passed.
         if name == "JSONResponse" and node.args:
-            body = node.args[0]
-            is_status_literal = isinstance(body, ast.Constant) and body.value == 500
-            if not is_status_literal and _refs_exception_or_request(body):
+            if _refs_exception_or_request(node.args[0]):
                 yield node.lineno, "JSONResponse 500 body references the exception/request"
 
 
@@ -173,6 +174,10 @@ def test_guard_detects_every_known_leak_shape() -> None:
         'raise HTTPException(500, str(e))',
         'raise HTTPException(500, f"internal: {exc}")',
         'raise HTTPException(500, error_msg)',
+        # JSONResponse with a positional body (the real ml_serve leak shape) —
+        # status via keyword and fully positional (body=args[0], status=args[1]).
+        'return JSONResponse({"error": str(exc)}, status_code=500)',
+        'return JSONResponse({"error": str(exc)}, 500)',
     ]
     for sample in leaky_samples:
         assert list(_iter_500_leaks(sample)), f"scanner missed a real leak: {sample}"

--- a/tests/unit/test_500_info_disclosure.py
+++ b/tests/unit/test_500_info_disclosure.py
@@ -40,7 +40,11 @@ from pathlib import Path
 
 import pytest
 
-_BACKEND = Path(__file__).resolve().parents[2] / "src" / "youtube_extension" / "backend"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BACKEND = _REPO_ROOT / "src" / "youtube_extension" / "backend"
+# The Ray Serve ML surface returns raw ``JSONResponse(...)`` bodies and lives
+# outside ``backend/``; it must be scanned too or 500 leaks there go unguarded.
+_ML_SERVE = _REPO_ROOT / "src" / "uvai" / "ml"
 
 # Identifiers that, when referenced inside a 500 body, indicate a leak of the
 # caught exception or the inbound request.
@@ -118,22 +122,34 @@ def _iter_500_leaks(text: str):
         if name == "HTTPException" and len(node.args) >= 2:
             if not _is_static_string(node.args[1]):
                 yield node.lineno, "HTTPException 500 detail is not a static string"
+        # Positional JSONResponse body: JSONResponse(<body>, status_code=500).
+        # args[0] is the content (a 500 literal there would be a nonsensical body,
+        # so skip it — that shape is only meaningful for the HTTPException form).
+        if name == "JSONResponse" and node.args:
+            body = node.args[0]
+            is_status_literal = isinstance(body, ast.Constant) and body.value == 500
+            if not is_status_literal and _refs_exception_or_request(body):
+                yield node.lineno, "JSONResponse 500 body references the exception/request"
 
 
-def _backend_python_files() -> list[Path]:
-    return sorted(_BACKEND.rglob("*.py"))
+def _guarded_python_files() -> list[Path]:
+    files: list[Path] = []
+    for root in (_BACKEND, _ML_SERVE):
+        if root.exists():
+            files.extend(root.rglob("*.py"))
+    return sorted(files)
 
 
 def test_no_information_disclosure_in_500_responses() -> None:
     offenders: list[str] = []
-    for path in _backend_python_files():
+    for path in _guarded_python_files():
         text = path.read_text(encoding="utf-8")
         try:
             leaks = list(_iter_500_leaks(text))
         except SyntaxError as exc:  # pragma: no cover - source is valid Python
             raise AssertionError(f"could not parse {path}: {exc}") from exc
         for line_no, reason in leaks:
-            rel = path.relative_to(_BACKEND.parents[2])
+            rel = path.relative_to(_REPO_ROOT)
             offenders.append(f"{rel}:{line_no}: {reason}")
 
     assert not offenders, (


### PR DESCRIPTION
## Summary

The Ray Serve checkpoint-save handler in `src/uvai/ml/serve.py` returned the caught exception text to the client in a 500 `JSONResponse` (`{"error": str(exc)}`), leaking internal details to callers (CWE-209 / information disclosure).

This surface lives **outside** `src/youtube_extension/backend`, so the existing 500-leak regression guard — which only scanned the backend package — never covered it. As a result the leak survived on `main` even after the backend-side 500 hardening landed. It also exposed a second-order gap: the guard did not recognise a `JSONResponse` whose body is passed **positionally** (`JSONResponse({...}, status_code=500)`), only the keyword form.

**Changes**
- `src/uvai/ml/serve.py`: return a static `"Internal server error"` body and log the full exception server-side (`logger.error(..., exc_info=True)`) instead of returning `str(exc)`.
- `tests/unit/test_500_info_disclosure.py`: extend the AST-based guard to (a) also scan the `src/uvai/ml` serving surface and (b) detect raw `JSONResponse(..., status_code=500)` leaks where the body is positional. Adds synthetic-leak self-tests for the `JSONResponse` case.

**Evidence**
- With the fix reverted, the guard **fails** and pinpoints the live leak: `src/uvai/ml/serve.py:402: JSONResponse(... {"error": str(exc)}, status_code=500 ...)`.
- With the fix applied, all 6 guard tests **pass**. `ruff check` on both changed files is clean.

Pure-AST guard (no app import), so it runs without the ML serving dependency stack.

## Linked issue

Fixes # <!-- no tracking issue; found during a PR-remediation sweep -->

## Verification

- [x] Focused tests — `tests/unit/test_500_info_disclosure.py` (6 passed; fails without the fix)
- [ ] Required CI
- [x] Review threads resolved — none open

## Agent provenance

Agent-authored. Scope: sanitize the single `str(exc)` 500 leak in `ml_serve` and close the guard blind spot that hid it; no other behaviour change.


---
_Generated by [Claude Code](https://claude.ai/code/session_016mM1PkHuN7g9gmvqsGao2X)_