### PR TITLE
ci(pr-checks): make PR-validation comment best-effort so advisory 403 doesn't fail the check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1669,42 +1669,53 @@ jobs:
               findings.push('⚠️ Large PR detected (' + totalChanges + ' lines changed)');
             }
             const marker = '<!-- pr-validation:v1 -->';
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number, per_page: 100}
-            );
-            const existing = comments.find(comment =>
-              comment.user &&
-              comment.user.login === 'github-actions[bot]' &&
-              comment.body && comment.body.includes(marker)
-            );
-            if (findings.length === 0) {
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: existing.id,
-                  body: marker + '\n## 🔍 PR Validation\n\n' +
-                    '✅ Current validation passed.'
-                });
+            // Posting the advisory comment is best-effort: a comment-API failure
+            // (e.g. token capped to read-only by org policy -> 403 "Resource not
+            // accessible by integration") must not fail the check. The pass/fail
+            // verdict below is driven solely by the findings, never by comment I/O.
+            try {
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                {owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number, per_page: 100}
+              );
+              const existing = comments.find(comment =>
+                comment.user &&
+                comment.user.login === 'github-actions[bot]' &&
+                comment.body && comment.body.includes(marker)
+              );
+              if (findings.length === 0) {
+                if (existing) {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: existing.id,
+                    body: marker + '\n## 🔍 PR Validation\n\n' +
+                      '✅ Current validation passed.'
+                  });
+                }
+              } else {
+                const body = marker + '\n## 🔍 PR Validation\n\n' + findings.join('\n');
+                if (existing) {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: existing.id,
+                    body
+                  });
+                } else {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    body
+                  });
+                }
               }
-              return;
-            }
-            const body = marker + '\n## 🔍 PR Validation\n\n' + findings.join('\n');
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body
-              });
+            } catch (error) {
+              core.warning(
+                'PR validation comment could not be posted (continuing): ' +
+                (error && error.message ? error.message : error)
+              );
             }
             if (findings.some(finding => finding.startsWith('❌'))) {
               core.setFailed('PR validation failed');

--- a/tests/unit/test_agent_completion_gate.py
+++ b/tests/unit/test_agent_completion_gate.py
@@ -3101,6 +3101,94 @@ for (const [name, prior, current, applicable, expected] of rows) {
         )
         self.assertIn("issues.updateComment", validate)
 
+    def test_validation_comment_failure_is_non_fatal(self):
+        """A rejected comment API must warn, not fail; ❌ findings still fail."""
+
+        workflow = self._workflow()
+        validate = workflow[
+            workflow.index("  validate:"):
+            workflow.index("  truth-gate:")
+        ]
+        script = _github_script_bodies(validate)[0]
+
+        harness = (
+            """
+const calls = { warnings: [], failures: [] };
+const core = {
+  warning(message) { calls.warnings.push(String(message)); },
+  setFailed(message) { calls.failures.push(String(message)); },
+};
+function rejectingComment() {
+  const error = new Error('Resource not accessible by integration');
+  error.status = 403;
+  return Promise.reject(error);
+}
+async function runValidate(pr) {
+  calls.warnings.length = 0;
+  calls.failures.length = 0;
+  const context = {
+    repo: { owner: 'o', repo: 'r' },
+    payload: { pull_request: pr },
+  };
+  const github = {
+    paginate: async () => [],
+    rest: { issues: {
+      listComments: () => {},
+      createComment: rejectingComment,
+      updateComment: rejectingComment,
+    } },
+  };
+  await (async () => {
+"""
+            + script
+            + """
+  })();
+  return { warnings: calls.warnings.slice(), failures: calls.failures.slice() };
+}
+(async () => {
+  // Warning-only findings + a rejecting comment API must NOT fail the job,
+  // and the rejection must surface as a warning.
+  const warnOnly = await runValidate({
+    title: 'update the widget rendering path',
+    body: 'This description is comfortably longer than twenty characters.',
+    additions: 12,
+    deletions: 4,
+  });
+  if (warnOnly.failures.length !== 0) {
+    throw new Error(
+      'warning-only validation must not fail when the comment API rejects: '
+      + JSON.stringify(warnOnly));
+  }
+  if (warnOnly.warnings.length === 0) {
+    throw new Error('a rejected comment API must emit a warning');
+  }
+  // An error (❌) finding must still call setFailed, comment rejection notwithstanding.
+  const errorFinding = await runValidate({
+    title: 'short',
+    body: 'This description is comfortably longer than twenty characters.',
+    additions: 12,
+    deletions: 4,
+  });
+  if (errorFinding.failures.length === 0) {
+    throw new Error(
+      'an error finding must still call setFailed even when the comment API rejects: '
+      + JSON.stringify(errorFinding));
+  }
+})().catch((error) => {
+  console.error(error && error.stack ? error.stack : error);
+  process.exit(1);
+});
+"""
+        )
+
+        completed = subprocess.run(
+            ["node", "-e", harness],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
     def test_commented_review_does_not_clear_changes_requested(self):
         workflow = self._workflow()
 


### PR DESCRIPTION
## Summary

The `validate` job in `.github/workflows/pr-checks.yml` is currently **red on every open PR** in the queue. Under `pull_request_target`, its `github-script` step POSTs the `🔍 PR Validation` comment and receives `403 Resource not accessible by integration` — the workflow token is capped to read-only at runtime even though the job declares `issues: write` / `pull-requests: write`. That unhandled rejection fails the job even when the only findings are `⚠️` warnings (no `❌`), so a purely cosmetic comment-post failure blocks the entire open-PR queue.

This change wraps the comment listing/create/update in `try/catch` and logs a `core.warning` on failure. The pass/fail verdict is now driven **solely by the findings** (`❌` → `setFailed`), never by comment I/O.

Evidence (run 29674261400, PR #717):
```
POST /repos/groupthinking/EventRelay/issues/717/comments - 403
RequestError [HttpError]: Resource not accessible by integration
##[error]Unhandled error: HttpError: Resource not accessible by integration
```
The findings for that run were only `⚠️` (conventional-commit title + large-PR), so absent the 403 the job would have passed.

Scope is limited to the `validate` job. No change to the security-sensitive `truth-gate` / agent-completion enforcement logic introduced in #876.

> Note for maintainers: the underlying 403 suggests the Actions token is capped to read-only by org/repo policy for `pull_request_target`. This patch makes the check resilient regardless; separately you may want to review the org "Workflow permissions" setting. Two other queue-wide blockers observed but **not** addressed here: CodeRabbit is non-functional (prepaid credits exhausted + `jules`-label exclusion), and the advisory `agent-completion/truth-gate` status is red across all PRs.

## Linked issue

Fixes #

## Verification

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-checks.yml'))"` — YAML parses
- [x] `node --check` on the extracted `validate` script — JS syntax valid
- [ ] Required CI — will run on this PR
- [ ] Review threads resolved

## Agent provenance

Authored by a Claude Code agent session (model `claude-opus-4-8[1m]`). No trusted-publisher identity is provisioned in `.github/agent-lock/trusted-publishers.json`, so no machine-readable `agent-lock-manifest` / `agent-lock-event` is asserted — this section is left as a human-readable provenance note rather than forged enforcement evidence. Please review before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2FGdCbDQBdDzgeQ1RgRok)_