### PR TITLE
refactor: resolve hardcoded /Users/garvey absolute paths with writable-probe fallbacks

### DIFF
--- a/src/agents/openai_dev_task_manager.py
+++ b/src/agents/openai_dev_task_manager.py
@@ -34,9 +34,17 @@ class OpenAIDevTaskManager:
     """MCP-first dev task manager to operationalize YouTube video capabilities."""
 
     def __init__(self, workspace_root: Optional[str] = None):
-        self.workspace_root = Path(
-            workspace_root or "/Users/garvey/UVAI/src/core/youtube_extension"
-        )
+        default_root = "/Users/garvey/UVAI/src/core/youtube_extension"
+        path_str = workspace_root or os.getenv("WORKSPACE_ROOT")
+        if not path_str:
+            try:
+                candidate = Path(default_root)
+                candidate.mkdir(parents=True, exist_ok=True)
+                path_str = default_root
+            except Exception:
+                path_str = str(Path.cwd() / "workflow_workspace")
+
+        self.workspace_root = Path(path_str)
         self.output_root = self.workspace_root / "workflow_output"
         self.output_root.mkdir(parents=True, exist_ok=True)
 

--- a/src/agents/openai_dev_task_manager.py
+++ b/src/agents/openai_dev_task_manager.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from utils.path_utils import select_writable_dir
+
 
 @dataclass
 class DevTaskResult:
@@ -34,17 +36,16 @@ class OpenAIDevTaskManager:
     """MCP-first dev task manager to operationalize YouTube video capabilities."""
 
     def __init__(self, workspace_root: Optional[str] = None):
-        default_root = "/Users/garvey/UVAI/src/core/youtube_extension"
-        path_str = workspace_root or os.getenv("WORKSPACE_ROOT")
-        if not path_str:
-            try:
-                candidate = Path(default_root)
-                candidate.mkdir(parents=True, exist_ok=True)
-                path_str = default_root
-            except Exception:
-                path_str = str(Path.cwd() / "workflow_workspace")
-
-        self.workspace_root = Path(path_str)
+        explicit = workspace_root or os.getenv("WORKSPACE_ROOT")
+        if explicit:
+            self.workspace_root = Path(explicit)
+        else:
+            # Reuse the legacy dev root only if it already exists and is
+            # writable; otherwise fall back to a runtime workspace under cwd.
+            self.workspace_root = select_writable_dir(
+                "/Users/garvey/UVAI/src/core/youtube_extension",
+                Path.cwd() / "workflow_workspace",
+            )
         self.output_root = self.workspace_root / "workflow_output"
         self.output_root.mkdir(parents=True, exist_ok=True)
 

--- a/src/mcp/mcp_ecosystem_coordinator.py
+++ b/src/mcp/mcp_ecosystem_coordinator.py
@@ -177,7 +177,14 @@ class MCPEcosystemCoordinator:
     """
 
     def __init__(self, config_path: str = None):
-        self.config_path = config_path or "/Users/garvey/UVAI/10_MCP_ECOSYSTEM"
+        default_path = "/Users/garvey/UVAI/10_MCP_ECOSYSTEM"
+        if not config_path:
+            if os.path.exists(default_path):
+                self.config_path = default_path
+            else:
+                self.config_path = str(Path.cwd() / "mcp_ecosystem")
+        else:
+            self.config_path = config_path
         self.coordination_config = self._load_coordination_config()
 
         # MCP node registry

--- a/src/mcp/mcp_ecosystem_coordinator.py
+++ b/src/mcp/mcp_ecosystem_coordinator.py
@@ -17,6 +17,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
+from utils.path_utils import select_writable_dir
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -177,14 +179,18 @@ class MCPEcosystemCoordinator:
     """
 
     def __init__(self, config_path: str = None):
-        default_path = "/Users/garvey/UVAI/10_MCP_ECOSYSTEM"
-        if not config_path:
-            if os.path.exists(default_path):
-                self.config_path = default_path
-            else:
-                self.config_path = str(Path.cwd() / "mcp_ecosystem")
-        else:
+        if config_path:
             self.config_path = config_path
+        else:
+            # The coordinator both reads and writes its config dir, so require
+            # the legacy path to be an existing, writable directory; otherwise
+            # use a runtime dir under cwd that we can persist defaults into.
+            self.config_path = str(
+                select_writable_dir(
+                    "/Users/garvey/UVAI/10_MCP_ECOSYSTEM",
+                    Path.cwd() / "mcp_ecosystem",
+                )
+            )
         self.coordination_config = self._load_coordination_config()
 
         # MCP node registry

--- a/src/mcp/mcp_video_processor.py
+++ b/src/mcp/mcp_video_processor.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-from __future__ import annotations
-
 """
 MCP-Integrated UVAI Real Video Processor
 Production-grade video processing with MCP ecosystem integration
 ENHANCED WITH HANGING PROTECTION & CIRCUIT BREAKERS
 """
+
+from __future__ import annotations
 
 import asyncio
 import json

--- a/src/mcp/mcp_video_processor.py
+++ b/src/mcp/mcp_video_processor.py
@@ -202,10 +202,14 @@ class MCPConfig:
     """Configuration management for MCP video processor"""
 
     def __init__(self, config_path: str = None):
-        self.config_path = (
-            config_path
-            or "/Users/garvey/UVAI/10_MCP_ECOSYSTEM/MCP/mcp_detailed_config.json"
-        )
+        default_path = "/Users/garvey/UVAI/10_MCP_ECOSYSTEM/MCP/mcp_detailed_config.json"
+        if not config_path:
+            if os.path.exists(default_path):
+                self.config_path = default_path
+            else:
+                self.config_path = str(Path.cwd() / "mcp_detailed_config.json")
+        else:
+            self.config_path = config_path
         self.config = self._load_config()
 
     def _load_config(self) -> dict[str, Any]:
@@ -1156,7 +1160,13 @@ class MCPVideoProcessor:
         """Save results with MCP metadata and analytics"""
 
         # Create enhanced results directory
-        results_dir = Path("/Users/garvey/UVAI/10_MCP_ECOSYSTEM/mcp_results")
+        default_dir = "/Users/garvey/UVAI/10_MCP_ECOSYSTEM/mcp_results"
+        try:
+            results_dir = Path(default_dir)
+            results_dir.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            results_dir = Path.cwd() / "mcp_results"
+
         category_dir = results_dir / content["category"]
         category_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/mcp/mcp_video_processor.py
+++ b/src/mcp/mcp_video_processor.py
@@ -19,6 +19,8 @@ from functools import wraps
 from pathlib import Path
 from typing import Any
 
+from utils.path_utils import select_readable_file, select_writable_dir
+
 # MCP integration imports
 try:
     import mcp
@@ -202,14 +204,18 @@ class MCPConfig:
     """Configuration management for MCP video processor"""
 
     def __init__(self, config_path: str = None):
-        default_path = "/Users/garvey/UVAI/10_MCP_ECOSYSTEM/MCP/mcp_detailed_config.json"
-        if not config_path:
-            if os.path.exists(default_path):
-                self.config_path = default_path
-            else:
-                self.config_path = str(Path.cwd() / "mcp_detailed_config.json")
-        else:
+        if config_path:
             self.config_path = config_path
+        else:
+            # Prefer the legacy config file only if it exists and is readable;
+            # otherwise use a runtime file under cwd (loaded by _load_config,
+            # which falls back to built-in defaults if absent).
+            self.config_path = str(
+                select_readable_file(
+                    "/Users/garvey/UVAI/10_MCP_ECOSYSTEM/MCP/mcp_detailed_config.json",
+                    Path.cwd() / "mcp_detailed_config.json",
+                )
+            )
         self.config = self._load_config()
 
     def _load_config(self) -> dict[str, Any]:
@@ -1159,14 +1165,13 @@ class MCPVideoProcessor:
     ) -> dict[str, Any]:
         """Save results with MCP metadata and analytics"""
 
-        # Create enhanced results directory
-        default_dir = "/Users/garvey/UVAI/10_MCP_ECOSYSTEM/mcp_results"
-        try:
-            results_dir = Path(default_dir)
-            results_dir.mkdir(parents=True, exist_ok=True)
-        except Exception:
-            results_dir = Path.cwd() / "mcp_results"
-
+        # Create enhanced results directory. Select a base that is genuinely
+        # writable (the legacy path only if it exists and is writable), so the
+        # category_dir creation below cannot raise PermissionError.
+        results_dir = select_writable_dir(
+            "/Users/garvey/UVAI/10_MCP_ECOSYSTEM/mcp_results",
+            Path.cwd() / "mcp_results",
+        )
         category_dir = results_dir / content["category"]
         category_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,4 +1,14 @@
 """EventRelay utility modules"""
-from .path_utils import get_project_root, resolve_path
+from .path_utils import (
+    get_project_root,
+    resolve_path,
+    select_readable_file,
+    select_writable_dir,
+)
 
-__all__ = ['get_project_root', 'resolve_path']
+__all__ = [
+    'get_project_root',
+    'resolve_path',
+    'select_readable_file',
+    'select_writable_dir',
+]

--- a/src/utils/path_utils.py
+++ b/src/utils/path_utils.py
@@ -7,7 +7,63 @@ Provides project root detection and path resolution utilities.
 Compatible with UVAI configuration.path_utils interface.
 """
 
+import os
 from pathlib import Path
+from typing import Union
+
+PathLike = Union[str, "os.PathLike[str]"]
+
+
+def select_writable_dir(preferred: PathLike, fallback: PathLike) -> Path:
+    """Return a directory that is actually writable, preferring ``preferred``.
+
+    ``preferred`` is chosen only when it *already exists* and is a writable
+    directory. It is never created — this avoids materializing developer- or
+    machine-specific trees (e.g. ``/Users/garvey/...``) in foreign environments
+    such as CI runners or root containers, where a plain ``mkdir`` would
+    otherwise succeed. Existence alone is insufficient because an existing but
+    read-only directory passes ``exists()``/``mkdir(exist_ok=True)`` yet still
+    raises ``PermissionError`` on the first real write.
+
+    When ``preferred`` is unusable, ``fallback`` is created (parents included)
+    and returned, guaranteeing the caller a writable location.
+
+    Args:
+        preferred: The legacy/default directory to reuse when viable.
+        fallback: The runtime directory to create and use otherwise.
+
+    Returns:
+        Path: A writable directory.
+    """
+    candidate = Path(preferred)
+    if candidate.is_dir() and os.access(candidate, os.W_OK):
+        return candidate
+    runtime = Path(fallback)
+    runtime.mkdir(parents=True, exist_ok=True)
+    return runtime
+
+
+def select_readable_file(preferred: PathLike, fallback: PathLike) -> Path:
+    """Return a readable config file, preferring ``preferred``.
+
+    ``preferred`` is chosen only when it exists as a readable file — a bare
+    ``exists()`` check is not enough, since an existing but unreadable file (or
+    a directory at that path) would be selected and then fail to open, silently
+    discarding a perfectly good ``fallback``. When ``preferred`` is unusable the
+    ``fallback`` path is returned as-is (its readability is decided by the
+    caller's own load logic).
+
+    Args:
+        preferred: The legacy/default file to reuse when readable.
+        fallback: The runtime file path to fall back to.
+
+    Returns:
+        Path: The selected file path.
+    """
+    candidate = Path(preferred)
+    if candidate.is_file() and os.access(candidate, os.R_OK):
+        return candidate
+    return Path(fallback)
 
 
 def get_project_root() -> Path:

--- a/src/utils/path_utils.py
+++ b/src/utils/path_utils.py
@@ -89,11 +89,11 @@ def resolve_path(*parts: str) -> Path:
         Path: Absolute path resolved from project root
 
     Examples:
-        >>> resolve_path('logs', 'app.log')
-        PosixPath('/Users/garvey/Dev/OpenAI_Hub/projects/EventRelay/logs/app.log')
+        >>> resolve_path('logs', 'app.log')  # doctest: +SKIP
+        PosixPath('.../EventRelay/logs/app.log')
 
-        >>> resolve_path('temp', 'packaged_projects')
-        PosixPath('/Users/garvey/Dev/OpenAI_Hub/projects/EventRelay/temp/packaged_projects')
+        >>> resolve_path('temp', 'packaged_projects')  # doctest: +SKIP
+        PosixPath('.../EventRelay/temp/packaged_projects')
     """
     return get_project_root().joinpath(*parts)
 


### PR DESCRIPTION
## Summary

Removes hardcoded machine-specific absolute paths (`/Users/garvey/...`) that crash EventRelay in any environment other than the original developer's machine (CI runners, containers, other contributors). Each site now probes for a genuinely usable legacy path and otherwise falls back to a runtime location under `cwd`.

New module `src/utils/path_utils.py` provides two probes:
- `select_writable_dir(preferred, fallback)` — returns `preferred` only when it already exists **and** is writable (never created, so it can't materialize a foreign `/Users/...` tree); otherwise creates and returns `fallback`. Existence alone is insufficient — an existing read-only dir passes `exists()`/`mkdir(exist_ok=True)` yet still raises `PermissionError` on first write.
- `select_readable_file(preferred, fallback)` — returns `preferred` only when it exists as a readable file; otherwise returns `fallback` for the caller's own load logic.

Call sites updated:
- `src/mcp/mcp_video_processor.py` — config path + results dir
- `src/mcp/mcp_ecosystem_coordinator.py` — config dir (read+write)
- `src/agents/openai_dev_task_manager.py` — workspace root (now also honors `WORKSPACE_ROOT` env var)
- `src/utils/__init__.py` — export the new helpers

Incidental cleanup in the touched file `mcp_video_processor.py`: the module docstring sat *after* `from __future__ import annotations`, which flagged every module-level import as `E402`. Restoring the correct order (docstring → `__future__` → imports) drops that file from 14 to 3 ruff errors (the remaining 3 are pre-existing optional-import `F401` and one `B904`, untouched by this change).

## Linked issue

Fixes #

## Verification

- [x] Focused tests — `path_utils` probes exercised directly: writable-preferred returns preferred; unwritable-preferred creates and returns fallback; both behaviors confirmed.
- [ ] Required CI — pending on this PR.
- [ ] Review threads resolved — awaiting review.

Lint: `ruff check` on all five touched files is clean apart from 3 pre-existing errors in `mcp_video_processor.py` that predate this branch. `py_compile` passes on all touched files.

## Agent provenance

Human-authored pull requests may delete this section.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DLmSodq5aowbym27KPtiLc)_