### PR TITLE
test(web): cover formatApiError stack-trace safety (supports #942)

### DIFF
--- a/apps/web/src/lib/__tests__/error-handling-stack-safety.test.ts
+++ b/apps/web/src/lib/__tests__/error-handling-stack-safety.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { formatApiError } from '@/lib/error-handling';
+
+/**
+ * Security regression coverage for #945 / PR #942.
+ *
+ * `formatApiError` must never surface stack-derived implementation details in
+ * the client-visible error payload. These tests pin that boundary so the
+ * general web suite cannot pass while a regression re-exposes `Error.stack`.
+ */
+describe('formatApiError stack-trace safety', () => {
+  const STACK_MARKER = 'SECRET_STACK_FRAME at /srv/app/internal/secret.ts:42:13';
+
+  it('returns only the public message for an Error and never leaks the stack', () => {
+    const error = new Error('Something failed publicly');
+    error.stack = `Error: Something failed publicly\n    ${STACK_MARKER}`;
+
+    const result = formatApiError(error);
+
+    expect(result).toEqual({ message: 'Something failed publicly' });
+    // The serialized payload is what reaches the client — assert the whole
+    // shape is free of any stack-derived detail, not just the known keys.
+    expect(JSON.stringify(result)).not.toContain(STACK_MARKER);
+    expect(JSON.stringify(result)).not.toContain('secret.ts');
+    expect(result).not.toHaveProperty('stack');
+    expect(result.details).toBeUndefined();
+  });
+
+  it('falls back to the default message when an Error has an empty message', () => {
+    const error = new Error('');
+    error.stack = `Error\n    ${STACK_MARKER}`;
+
+    const result = formatApiError(error, 'An error occurred');
+
+    expect(result).toEqual({ message: 'An error occurred' });
+    expect(JSON.stringify(result)).not.toContain(STACK_MARKER);
+  });
+
+  it('formats the non-Error object shape without exposing extra internals', () => {
+    const result = formatApiError({
+      message: 'Upstream rejected',
+      code: 'E_UPSTREAM',
+      stack: STACK_MARKER,
+    });
+
+    expect(result).toEqual({ message: 'Upstream rejected', code: 'E_UPSTREAM' });
+    expect(JSON.stringify(result)).not.toContain(STACK_MARKER);
+    expect(result).not.toHaveProperty('stack');
+    expect(result.details).toBeUndefined();
+  });
+
+  it('handles primitive errors with only the public string or default', () => {
+    expect(formatApiError('plain failure')).toEqual({ message: 'plain failure' });
+    expect(formatApiError('', 'fallback message')).toEqual({ message: 'fallback message' });
+  });
+});

--- a/apps/web/src/lib/error-handling.ts
+++ b/apps/web/src/lib/error-handling.ts
@@ -138,7 +138,7 @@ export function formatApiError(
   if (error instanceof Error) {
     return {
       message: error.message || defaultMessage,
-      details: error.stack?.split('\n')[1]?.trim(),
+      // Removed stack trace exposure for security
     };
   }
 


### PR DESCRIPTION
## Summary

Adds focused regression coverage for the security boundary that PR #942 fixes in `apps/web/src/lib/error-handling.ts`: `formatApiError` must never surface `Error.stack` (or other stack-derived internals) in the client-visible error payload.

This resolves the `copilot-pull-request-reviewer` request on #942 ("no test references `formatApiError` or verifies that a supplied `Error.stack` cannot appear in the formatted response"). It is the #942 analogue of the #944 → #963 coverage PR.

`formatApiError` is a pure function, so this is a **behavioral** test (no jsdom needed, consistent with the web suite's `node` vitest environment). It:
- assigns a distinctive `Error.stack` and asserts the serialized result contains only the public message (no stack marker, no source path);
- covers the empty-message default fallback, the non-`Error` object shape (`{message, code}`), and primitive inputs.

**To land on #942:** cherry-pick `9ea44c3` onto `sentinel/fix-stack-trace-exposure-18263776375929233502`. It only adds a new test file, so it applies cleanly. Kept here because I can only push to my designated branch, not the PR head.

## Linked issue

Supports #945 (coverage gap) / PR #942. Does not close #945 on its own.

## Verification

- [x] Focused tests — 4 cases / 13 assertions, validated against the exact `formatApiError` logic (local vitest deps are not provisioned in this environment; assertions were run through a standalone Node harness reproducing the function).
- [ ] Required CI — this branch is subject to the repo's fail-closed `agent-completion` gates (see note below).
- [ ] Review threads resolved — n/a (this PR adds the coverage the #942 thread requested).

## Agent provenance

Authored by Claude Code on the owner's session. This is a supporting test PR; it **intentionally does not** supply an `agent-lock-manifest` — the `agent-completion` truth-gate and enforcement gates are fail-closed by design (`.github/agent-lock/trusted-publishers.json` allowlists are empty pending human provisioning of a verified trusted GitHub App), and manufacturing agent-lock evidence to satisfy them would defeat that control.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP6PXv8Pwc67jRovSz8X6h)_