### PR TITLE
fix(mcp): green up MCPOrchestrator._execute_on_server E2E tests (remediates #1038)

### DIFF
--- a/src/youtube_extension/services/mcp/orchestrator.py
+++ b/src/youtube_extension/services/mcp/orchestrator.py
@@ -10,10 +10,11 @@ Consolidates orchestration logic from:
 import asyncio
 import logging
 import uuid
-import aiohttp
 from collections import deque
 from datetime import datetime
 from typing import Any, Optional
+
+import aiohttp
 
 from .registry import MCPServerRegistry, get_registry
 from .types import MCPCapability, MCPTask, MCPTaskStatus
@@ -42,7 +43,7 @@ class MCPOrchestrator:
         """
         self.registry = registry or get_registry()
 
-        self.session = None
+        self.session: Optional[aiohttp.ClientSession] = None
 
         # Task management
         self.tasks: dict[str, MCPTask] = {}
@@ -65,9 +66,6 @@ class MCPOrchestrator:
 
         # Performance metrics
         self.metrics = {
-
-            "total_tasks": 0,
-
             "total_tasks": 0,
             "completed_tasks": 0,
             "failed_tasks": 0,
@@ -390,7 +388,7 @@ class MCPOrchestrator:
                 task.task_type,
                 str(e)
             )
-            raise RuntimeError(f"MCP server execution failed: {e}")
+            raise RuntimeError(f"MCP server execution failed: {e}") from e
         except Exception as e:
             logger.error(
                 "Unexpected error during MCP server execution: server_id=%s, task_type=%s, error=%s",

--- a/src/youtube_extension/services/mcp/orchestrator.py
+++ b/src/youtube_extension/services/mcp/orchestrator.py
@@ -10,6 +10,7 @@ Consolidates orchestration logic from:
 import asyncio
 import logging
 import uuid
+import aiohttp
 from collections import deque
 from datetime import datetime
 from typing import Any, Optional
@@ -41,6 +42,8 @@ class MCPOrchestrator:
         """
         self.registry = registry or get_registry()
 
+        self.session = None
+
         # Task management
         self.tasks: dict[str, MCPTask] = {}
         self.task_queue: deque[str] = deque()
@@ -62,6 +65,9 @@ class MCPOrchestrator:
 
         # Performance metrics
         self.metrics = {
+
+            "total_tasks": 0,
+
             "total_tasks": 0,
             "completed_tasks": 0,
             "failed_tasks": 0,
@@ -338,24 +344,61 @@ class MCPOrchestrator:
     ) -> dict[str, Any]:
         """
         Execute task on a specific server via MCP/JSON-RPC.
-
-        NOTE: Real MCP server communication is not yet implemented.
-        This method raises NotImplementedError to make it clear that the
-        orchestrator must not be used in production until this path is wired up.
         """
         config = self.registry.get_server(server_id)
         if not config:
             raise ValueError(f"Cannot execute task {task.task_id}: MCP server not found: {server_id}")
 
-        logger.error(
-            "MCP server execution is not implemented: server_id=%s, task_type=%s",
-            server_id,
-            task.task_type,
-        )
-        raise NotImplementedError(
-            "MCPOrchestrator._execute_on_server is not implemented. "
-            "Wire up real MCP server communication before using this in production."
-        )
+        headers = {"Content-Type": "application/json"}
+        if config.auth_token:
+            headers["Authorization"] = f"Bearer {config.auth_token}"
+
+        payload = {
+            "jsonrpc": "2.0",
+            "method": task.task_type,
+            "params": task.payload,
+            "id": task.task_id,
+        }
+
+        try:
+            session = self.session if self.session else aiohttp.ClientSession()
+            close_session = self.session is None
+
+            try:
+                async with session.post(
+                    config.endpoint,
+                    json=payload,
+                    headers=headers,
+                    timeout=task.timeout
+                ) as response:
+                    response.raise_for_status()
+                    data = await response.json()
+
+                    if "error" in data:
+                        raise RuntimeError(f"MCP server error: {data['error']}")
+
+                    return data.get("result", data)
+            finally:
+                if close_session:
+                    await session.close()
+
+        except aiohttp.ClientError as e:
+
+            logger.error(
+                "MCP server execution failed: server_id=%s, task_type=%s, error=%s",
+                server_id,
+                task.task_type,
+                str(e)
+            )
+            raise RuntimeError(f"MCP server execution failed: {e}")
+        except Exception as e:
+            logger.error(
+                "Unexpected error during MCP server execution: server_id=%s, task_type=%s, error=%s",
+                server_id,
+                task.task_type,
+                str(e)
+            )
+            raise
 
     async def _check_dependencies(self, task_id: str) -> bool:
         """
@@ -410,9 +453,13 @@ class MCPOrchestrator:
             logger.warning("Orchestration already active")
             return
 
+        if self.session is None:
+            self.session = aiohttp.ClientSession()
+
         self.orchestration_active = True
         self.orchestration_task = asyncio.create_task(self._orchestration_loop())
         logger.info("MCP Orchestration started")
+
 
     async def stop_orchestration(self) -> None:
         """Stop the orchestration loop and cancel all spawned tasks"""
@@ -440,6 +487,10 @@ class MCPOrchestrator:
                 await self.orchestration_task
             except asyncio.CancelledError:
                 pass
+
+        if self.session:
+            await self.session.close()
+            self.session = None
 
         logger.info("MCP Orchestration stopped")
 

--- a/tests/unit/test_mcp_orchestrator.py
+++ b/tests/unit/test_mcp_orchestrator.py
@@ -735,30 +735,11 @@ class TestExecuteTaskWithServer:
 
 
 # ===========================================================================
-# MCPOrchestrator._execute_on_server (lines 346-350)
+# MCPOrchestrator._execute_on_server
 # ===========================================================================
 
 
 class TestExecuteOnServer:
-    async def test_raises_not_implemented_error(self):
-        from youtube_extension.services.mcp.registry import MCPServerRegistry
-        from youtube_extension.services.mcp.types import MCPCapability, MCPTask
-
-        registry = MCPServerRegistry()
-        registry.register_server(
-            "srv", "Srv", "http://localhost:9000", [MCPCapability.AI_INFERENCE]
-        )
-
-        orch = MCPOrchestrator(registry=registry)
-        task = MCPTask(
-            task_id="abc",
-            task_type="test",
-            requirements=[MCPCapability.AI_INFERENCE],
-        )
-
-        with pytest.raises(NotImplementedError):
-            await orch._execute_on_server("srv", task)
-
     async def test_raises_value_error_for_unknown_server(self):
         from youtube_extension.services.mcp.types import MCPCapability, MCPTask
 
@@ -772,6 +753,69 @@ class TestExecuteOnServer:
         with pytest.raises(ValueError, match="MCP server not found"):
             await orch._execute_on_server("unknown_server", task)
 
+    async def test_successful_execution(self):
+        from youtube_extension.services.mcp.registry import MCPServerRegistry
+        from youtube_extension.services.mcp.types import MCPCapability, MCPTask
+        from aioresponses import aioresponses
+
+        registry = MCPServerRegistry()
+        registry.register_server(
+            "srv", "Srv", "http://localhost:9000", [MCPCapability.AI_INFERENCE], auth_token="secret"
+        )
+        orch = MCPOrchestrator(registry=registry)
+        task = MCPTask(
+            task_id="abc",
+            task_type="test",
+            requirements=[MCPCapability.AI_INFERENCE],
+        )
+
+        with aioresponses() as m:
+            m.post("http://localhost:9000", payload={"result": {"status": "success"}})
+            result = await orch._execute_on_server("srv", task)
+
+        assert result == {"status": "success"}
+
+    async def test_execution_failure_http_error(self):
+        from youtube_extension.services.mcp.registry import MCPServerRegistry
+        from youtube_extension.services.mcp.types import MCPCapability, MCPTask
+        from aioresponses import aioresponses
+
+        registry = MCPServerRegistry()
+        registry.register_server(
+            "srv", "Srv", "http://localhost:9000", [MCPCapability.AI_INFERENCE]
+        )
+        orch = MCPOrchestrator(registry=registry)
+        task = MCPTask(
+            task_id="abc",
+            task_type="test",
+            requirements=[MCPCapability.AI_INFERENCE],
+        )
+
+        with aioresponses() as m:
+            m.post("http://localhost:9000", status=500, payload={"error": "Server error"})
+            with pytest.raises(RuntimeError, match="MCP server execution failed"):
+                await orch._execute_on_server("srv", task)
+
+    async def test_execution_failure_jsonrpc_error(self):
+        from youtube_extension.services.mcp.registry import MCPServerRegistry
+        from youtube_extension.services.mcp.types import MCPCapability, MCPTask
+        from aioresponses import aioresponses
+
+        registry = MCPServerRegistry()
+        registry.register_server(
+            "srv", "Srv", "http://localhost:9000", [MCPCapability.AI_INFERENCE]
+        )
+        orch = MCPOrchestrator(registry=registry)
+        task = MCPTask(
+            task_id="abc",
+            task_type="test",
+            requirements=[MCPCapability.AI_INFERENCE],
+        )
+
+        with aioresponses() as m:
+            m.post("http://localhost:9000", payload={"error": {"code": 123, "message": "Bad request"}})
+            with pytest.raises(RuntimeError, match="MCP server error"):
+                await orch._execute_on_server("srv", task)
 
 # ===========================================================================
 # MCPOrchestrator._check_dependent_tasks (lines 388-395)

--- a/tests/unit/test_mcp_orchestrator.py
+++ b/tests/unit/test_mcp_orchestrator.py
@@ -739,6 +739,25 @@ class TestExecuteTaskWithServer:
 # ===========================================================================
 
 
+def _make_response(json_data, raise_for_status_exc=None):
+    """Build a mock aiohttp response usable as an async-context-manager target."""
+    resp = MagicMock(name="ClientResponse")
+    resp.raise_for_status = MagicMock(side_effect=raise_for_status_exc)
+    resp.json = AsyncMock(return_value=json_data)
+    return resp
+
+
+def _make_session(response):
+    """Build a mock aiohttp.ClientSession whose .post() yields ``response``."""
+    ctx = MagicMock(name="post_ctx")
+    ctx.__aenter__ = AsyncMock(return_value=response)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock(name="ClientSession")
+    session.post = MagicMock(return_value=ctx)
+    session.close = AsyncMock()
+    return session
+
+
 class TestExecuteOnServer:
     async def test_raises_value_error_for_unknown_server(self):
         from youtube_extension.services.mcp.types import MCPCapability, MCPTask
@@ -753,69 +772,111 @@ class TestExecuteOnServer:
         with pytest.raises(ValueError, match="MCP server not found"):
             await orch._execute_on_server("unknown_server", task)
 
-    async def test_successful_execution(self):
+    async def test_successful_execution_reuses_pooled_session(self):
+        """When a pooled session exists it is reused (not closed) and a
+        JSON-RPC payload with the auth header is sent."""
         from youtube_extension.services.mcp.registry import MCPServerRegistry
         from youtube_extension.services.mcp.types import MCPCapability, MCPTask
-        from aioresponses import aioresponses
 
         registry = MCPServerRegistry()
         registry.register_server(
             "srv", "Srv", "http://localhost:9000", [MCPCapability.AI_INFERENCE], auth_token="secret"
         )
         orch = MCPOrchestrator(registry=registry)
+        session = _make_session(_make_response({"result": {"status": "success"}}))
+        orch.session = session
         task = MCPTask(
             task_id="abc",
             task_type="test",
             requirements=[MCPCapability.AI_INFERENCE],
         )
 
-        with aioresponses() as m:
-            m.post("http://localhost:9000", payload={"result": {"status": "success"}})
-            result = await orch._execute_on_server("srv", task)
+        result = await orch._execute_on_server("srv", task)
 
         assert result == {"status": "success"}
+        # A pooled session must be reused, never closed by _execute_on_server.
+        session.close.assert_not_awaited()
+        _, kwargs = session.post.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer secret"
+        assert kwargs["json"] == {
+            "jsonrpc": "2.0",
+            "method": "test",
+            "params": task.payload,
+            "id": "abc",
+        }
 
-    async def test_execution_failure_http_error(self):
+    async def test_successful_execution_creates_and_closes_session(self):
+        """With no pooled session a temporary one is created and closed."""
         from youtube_extension.services.mcp.registry import MCPServerRegistry
         from youtube_extension.services.mcp.types import MCPCapability, MCPTask
-        from aioresponses import aioresponses
 
         registry = MCPServerRegistry()
         registry.register_server(
             "srv", "Srv", "http://localhost:9000", [MCPCapability.AI_INFERENCE]
         )
         orch = MCPOrchestrator(registry=registry)
+        session = _make_session(_make_response({"result": {"status": "success"}}))
         task = MCPTask(
             task_id="abc",
             task_type="test",
             requirements=[MCPCapability.AI_INFERENCE],
         )
 
-        with aioresponses() as m:
-            m.post("http://localhost:9000", status=500, payload={"error": "Server error"})
-            with pytest.raises(RuntimeError, match="MCP server execution failed"):
-                await orch._execute_on_server("srv", task)
+        with patch(
+            "youtube_extension.services.mcp.orchestrator.aiohttp.ClientSession",
+            return_value=session,
+        ):
+            result = await orch._execute_on_server("srv", task)
+
+        assert result == {"status": "success"}
+        session.close.assert_awaited_once()
+
+    async def test_execution_failure_http_error(self):
+        import aiohttp
+
+        from youtube_extension.services.mcp.registry import MCPServerRegistry
+        from youtube_extension.services.mcp.types import MCPCapability, MCPTask
+
+        registry = MCPServerRegistry()
+        registry.register_server(
+            "srv", "Srv", "http://localhost:9000", [MCPCapability.AI_INFERENCE]
+        )
+        orch = MCPOrchestrator(registry=registry)
+        http_error = aiohttp.ClientResponseError(
+            MagicMock(), (), status=500, message="Server error"
+        )
+        session = _make_session(_make_response(None, raise_for_status_exc=http_error))
+        orch.session = session
+        task = MCPTask(
+            task_id="abc",
+            task_type="test",
+            requirements=[MCPCapability.AI_INFERENCE],
+        )
+
+        with pytest.raises(RuntimeError, match="MCP server execution failed"):
+            await orch._execute_on_server("srv", task)
 
     async def test_execution_failure_jsonrpc_error(self):
         from youtube_extension.services.mcp.registry import MCPServerRegistry
         from youtube_extension.services.mcp.types import MCPCapability, MCPTask
-        from aioresponses import aioresponses
 
         registry = MCPServerRegistry()
         registry.register_server(
             "srv", "Srv", "http://localhost:9000", [MCPCapability.AI_INFERENCE]
         )
         orch = MCPOrchestrator(registry=registry)
+        session = _make_session(
+            _make_response({"error": {"code": 123, "message": "Bad request"}})
+        )
+        orch.session = session
         task = MCPTask(
             task_id="abc",
             task_type="test",
             requirements=[MCPCapability.AI_INFERENCE],
         )
 
-        with aioresponses() as m:
-            m.post("http://localhost:9000", payload={"error": {"code": 123, "message": "Bad request"}})
-            with pytest.raises(RuntimeError, match="MCP server error"):
-                await orch._execute_on_server("srv", task)
+        with pytest.raises(RuntimeError, match="MCP server error"):
+            await orch._execute_on_server("srv", task)
 
 # ===========================================================================
 # MCPOrchestrator._check_dependent_tasks (lines 388-395)


### PR DESCRIPTION
## Canonical issue

Closes # <!-- No canonical issue is known to this automated run. A maintainer must link the canonical issue for MCPOrchestrator._execute_on_server (the same one #1038 should reference). -->

## Outcome

Makes the `MCPOrchestrator._execute_on_server` end-to-end execution feature (from #1038) actually pass CI. This branch is built on #1038's implementation commit (`8eb9204`) and fixes the code-level CI failure so the E2E execution path is covered by green, dependency-free tests.

## Scope

- **Included:**
  - Rewrote the three `TestExecuteOnServer` tests that imported `aioresponses` (undeclared dev dependency → `ModuleNotFoundError`, 3 failing tests in #1038's CI) to mock the `aiohttp` session with `unittest.mock`. This removes the external dependency entirely — which matters because `aioresponses` 0.7.9 is itself incompatible with `aiohttp` 3.14 (`ClientResponse` now requires `stream_writer`), so merely declaring the dependency would still fail CI.
  - Added coverage for both the pooled-session reuse path and the create-and-close fallback path.
  - Minor cleanups to the orchestrator change introduced in #1038: grouped `import aiohttp` as third-party (ruff `I001`), annotated `self.session: Optional[aiohttp.ClientSession]` (mypy strict), dropped a duplicated `total_tasks` metrics key, and chained the re-raised `RuntimeError` with `from e` (ruff `B904`).
- **Explicitly excluded:** No change to production runtime behavior of `_execute_on_server`; no new dependencies; unrelated pre-existing lint (e.g. `W293` at orchestrator.py:231, present on `main`) left untouched.

## Risk

- Risk level: low
- Failure mode: tests only + import ordering / annotation. No production code-path behavior change.
- Rollback: revert this commit; #1038's original commit is unaffected.

## Verification

Tied to head SHA `265f411`:

- [x] Focused tests — `pytest tests/unit/test_mcp_orchestrator.py` → **87 passed** locally (Python 3.11, aiohttp 3.14.3, no `aioresponses` installed).
- [x] `ruff check src/youtube_extension/services/mcp/orchestrator.py` → clean except the pre-existing `W293:231` that is already on `main`.
- [ ] Required CI — pending on this PR.
- [ ] Review threads resolved — none yet.

## Production evidence

Not applicable — backend unit-test + orchestrator change; no deployable surface. `_execute_on_server` still performs real aiohttp JSON-RPC calls at runtime (no mocks in production code).

## Agent handoff

- [ ] One canonical issue is linked — **needs maintainer:** no canonical issue is available to this run.
- [ ] No competing PR implements the same issue — **needs decision:** #1038 implements the same feature. This branch supersedes/remediates #1038; a maintainer should merge this instead, or port these fixes into #1038 and close one.
- [x] Acceptance criteria are satisfied — the E2E execution tests pass.
- [ ] Required checks pass on the current head — code CI expected green; the repo's agent-governance gates (`agent-completion/truth-gate`, `PR Governance`, `Canonical issue and evidence`) will remain red until the canonical issue + agent-lock provenance are supplied.
- [x] Human decision is requested for the merge (protected `main`) and for the canonical-issue/provenance items above.

## Agent provenance

This automated run has no legitimate `run_id`/`agent_login`/`issue_number` to attest, so the `agent-lock-manifest` is intentionally **not** filled — doing so falsely would only game the truth-gate. A maintainer (or the triggering agent system) must supply real provenance and the canonical issue to satisfy the governance gates.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QdsNW4BxCUySyXJ42PRpJC)_