### PR TITLE
fix(ci): restore .vscode IDE self-identifier guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,18 @@ jobs:
             exit 1
           fi
           echo "No conflict markers found."
+      - name: No IDE self-identifiers in shared .vscode config
+        run: |
+          # VS Code forks (Antigravity, Cursor, Windsurf) write their own
+          # extension IDs into workspace settings; those IDs resolve to
+          # nothing in stock VS Code and fail silently. Mirrors the
+          # vscode-ide-self-reference pre-commit hook, which not every
+          # committer has installed.
+          if git grep -nE 'google\.antigravity|anysphere\.|codeium\.windsurf' -- .vscode/; then
+            echo "::error::IDE self-identifier found in shared .vscode/ config (see matches above)."
+            exit 1
+          fi
+          echo "No IDE self-identifiers found."
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"

--- a/.gitignore
+++ b/.gitignore
@@ -113,7 +113,11 @@ workflow_results/
 .poc-venv/
 .poc-runtime.db
 .venv_prod_verify/
-.vscode/
+# Shared editor config is versioned by exception; everything else in
+# .vscode/ (mcp.json, tasks.json, IDE-fork state) stays local.
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
 .webassets-cache
 .yarn/
 Desktop.ini

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,10 @@ workflow_results/
 .vscode/*
 !.vscode/settings.json
 !.vscode/extensions.json
+# Agent-IDE skill caches materialized into the working tree (Antigravity/dak
+# plugin skills under .agents/). Same drift class as the .vscode rule above:
+# tool state, not project source — never commit.
+.agents/
 .webassets-cache
 .yarn/
 Desktop.ini

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,19 @@
 #   Run all:  pre-commit run --all-files
 #
 # gitleaks blocks commits that introduce secrets (API keys, tokens, private keys).
+#
+# vscode-ide-self-reference blocks VS Code forks (Antigravity, Cursor, Windsurf)
+# from committing their own extension IDs into shared .vscode/ config, where they
+# resolve to nothing in stock VS Code. Mirrored by the guards job in ci.yml.
 repos:
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.18.4
     hooks:
       - id: gitleaks
+  - repo: local
+    hooks:
+      - id: vscode-ide-self-reference
+        name: No IDE self-identifiers in shared .vscode config
+        language: pygrep
+        entry: 'google\.antigravity|anysphere\.|codeium\.windsurf'
+        files: ^\.vscode/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "googlecloudtools.firebase-dataconnect-vscode"
+        "googlecloudtools.firebase-dataconnect-vscode",
+        "ms-python.black-formatter"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,6 @@
         "*test.py"
     ],
     "python.testing.pytestEnabled": false,
-    "python.testing.unittestEnabled": true
+    "python.testing.unittestEnabled": true,
+    "notebook.defaultFormatter": "ms-python.black-formatter"
 }


### PR DESCRIPTION
## Canonical issue

Closes #1097 — "Restore .vscode IDE self-identifier guardrails in CI".

(Originally pointed at #1093, which has since been closed; repointed to the open canonical issue so the delivery-contract gate can resolve exactly one live issue.)

Background: #1057 ("Fix/auth harden google signin") was a 235-file merge that happened to carry the reviewed `.vscode` drift fix and its three guard layers. #1061 then reverted #1057 wholesale on governance grounds — correct in scope, but it took the guards out as collateral. `google.antigravity` has reached `main` before (`b49ac3416`, `ddebd5d5c`), so the recurrence risk is demonstrated, not hypothetical.

## Outcome

Re-lands **only** the guard subset from #1057 (none of the other ~230 files), so IDE-fork self-identifiers (`google.antigravity`, `anysphere.*`, `codeium.windsurf`) can no longer silently land in shared `.vscode` config on `main`:

- `.gitignore` — version `.vscode/settings.json` and `.vscode/extensions.json` by exception; `mcp.json`, `tasks.json` and IDE-fork state stay local.
- `.pre-commit-config.yaml` — local pygrep hook `vscode-ide-self-reference` fails any `.vscode/` change matching `google\.antigravity|anysphere\.|codeium\.windsurf`.
- `.github/workflows/ci.yml` — the same regex as a `git grep` step in the `guards` job, as a backstop for committers without pre-commit installed.
- `.vscode/settings.json` / `.vscode/extensions.json` — restore `notebook.defaultFormatter` to `ms-python.black-formatter` so the setting points at a formatter that resolves.

36 insertions, 3 deletions, 5 files.

## Risk

- Risk level: low — additive guardrails plus a config-only, 5-file diff; no application code paths touched.
- Failure mode: a false-positive block on a legitimate `.vscode` change that legitimately contains one of the guarded identifiers; mitigated because the regex is narrow and both layers print the offending line so the author sees exactly what tripped.
- Rollback: revert this PR's merge commit — the guards disappear and behaviour returns to current `main` (bug absent but unguarded).

## Verification

Both enforcement layers tested in each direction at head `7eb4dbee01a7d5def4ee0a0552815c4fe16ef7ec`:

- CI `git grep` step: clean tree → guard passes; injected `"notebook.defaultFormatter": "google.antigravity"` → `.vscode/settings.json:27` matched, guard fails.
- pre-commit hook (pre-commit 4.6.1): clean tree → `No IDE self-identifiers in shared .vscode config...Passed`; injected bad value → `Failed`, exit code 1, offending line printed.
- `.vscode/*.json` parse as valid JSON (missing trailing newline preserved so the diff stays minimal); `ci.yml` and `.pre-commit-config.yaml` parse as valid YAML.
- `git check-ignore` confirms the whitelist: `settings.json`/`extensions.json` visible, `mcp.json`/`tasks.json` ignored.

## Production evidence

Not applicable to a production runtime surface — this PR changes only repository tooling (`.gitignore`, `.pre-commit-config.yaml`, `.github/workflows/ci.yml`, `.vscode/*.json`); it ships no application code and has no Vercel/Cloud Run deployment footprint. The production surface here is CI enforcement itself: the `guards` job on this PR exercises the new `git grep` step against the exact head SHA above and passes.

## Note

This deliberately does not re-land anything else from #1057. If any other part of that merge should return, it should come back on its own reviewed PR.