### PR TITLE
fix(deps): clear @hono/node-server advisory via MCP SDK 1.30.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "tsx": "^4.23.1"
       },
       "devDependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "brace-expansion": "^5.0.8",
         "eslint": "^9.39.5",
         "next": "^16.2.11",
@@ -2138,13 +2138,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2863,13 +2863,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "npm": ">=8.0.0"
   },
   "devDependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "brace-expansion": "^5.0.8",
     "eslint": "^9.39.5",
     "next": "^16.2.11",
@@ -46,6 +46,7 @@
     "picomatch": "^4.0.5",
     "protobufjs": "^7.6.5",
     "sharp": "^0.35.0",
+    "@hono/node-server": "^2.0.5",
     "minimatch@3.1.5": {
       "brace-expansion": "^1.1.16"
     },


### PR DESCRIPTION
## Canonical issue

Closes #1102

> **Stacked on #1098** (which is stacked on #1094). All of these rewrite `package-lock.json`, so branching off `main` would guarantee conflicts. Merge order: #1094 → #1098 → this.

## Outcome

Dependabot **524** (moderate) — `@hono/node-server` path-traversal — is closed. Installed 1.19.14, fix requires 2.0.5. The advisory is cleared by moving the MCP SDK floor to a version that *supports* hono 2.x and adding a `^2.0.5` override, so the resolved `@hono/node-server` is **2.0.12** (≥ 2.0.5) with no `npm ls invalid` marker. `npm audit`'s hono / MCP-SDK moderate entries drop from 2 → 0.

This was originally flagged for a separate breaking-change proposal, since 1.19.14 → 2.0.5 is a major bump. On investigation that framing was wrong, and the reasoning matters more than the diff:

**It is not a direct dependency.** It arrives only through the MCP SDK:

```
eventrelay
└─┬ @modelcontextprotocol/sdk@1.29.0
  └── @hono/node-server@1.19.14
```

`hono` is imported nowhere in `apps/`, `src/` or `packages/` — a repo-wide grep returns nothing. Nothing in this codebase calls the vulnerable API.

**The SDK already supports hono 2.x:**

| SDK version | declared `@hono/node-server` range |
|---|---|
| 1.29.0 | `^1.19.9` |
| **1.30.0** | **`^1.19.9 \|\| ^2.0.5`** |

So on 1.30.0 this is a *supported* configuration, not an override forced against the SDK's own constraints. That is the difference between a safe change and a hopeful one. The root `package.json` already declared `^1.26.0`, which permits 1.30.0 — the lockfile had simply drifted behind at 1.29.0, the same drift pattern documented in #1098.

## Changes

- `@modelcontextprotocol/sdk` floor `^1.26.0` → `^1.30.0`, so the lock cannot drift back onto a version that only accepts hono 1.x
- `overrides` — add `@hono/node-server: ^2.0.5`

11 insertions, 10 deletions across 2 files.

## Risk

- **Risk level: low** — `package.json` floor + `overrides` and the regenerated `package-lock.json` only; no direct dependency added and no application code touched. `hono` is not imported anywhere in the tree.
- **Failure mode:** the MCP SDK failing to accept the bumped hono at runtime. Ruled out by the `npm ls` check below — the SDK's own declared range on the installed 1.30.0 (`^1.19.9 || ^2.0.5`) accepts the resolved 2.0.12, so there is no `invalid` marker.
- **Rollback:** revert the single commit on this branch; the SDK floor and the override return to their prior values and the lockfile regenerates onto hono 1.x.
- **Deliberately not chased to zero:** `npm audit` still reports 12 high, all the `brace-expansion` → `minimatch` cascade characterised in #1098 — a false positive from audit collapsing three per-major-line advisories into one coarse `<= 5.0.7` range; every installed copy is patched. Not chased here.

## Verification

| Check | Result |
|---|---|
| `@modelcontextprotocol/sdk` resolved | **1.30.0** |
| `@hono/node-server` resolved | **2.0.12** (≥ 2.0.5) |
| `npm ls` invalid marker on either | **none** — the SDK genuinely accepts the resolved hono |
| Installed SDK's declared range | `^1.19.9 \|\| ^2.0.5` — read from the installed package, not assumed |
| `npm run build:web` | **exit 0** |
| `cd apps/web && npm run lint` | **exit 0** |
| `npm audit` — hono / MCP SDK entries | **both cleared** (moderate count 2 → 0) |

The `npm ls` check is the one that matters: an override that the parent package does not accept shows up as `invalid`, and this does not.

## Production evidence

Not applicable pre-merge: dependency-constraint / lockfile change only — no schema, config, or API-surface change. Production picks up the patched `@hono/node-server` 2.x at the next Vercel build (`apps/web`) — the branch preview deployed **Ready** (Vercel `v0-uvai`) on this head — and at the next Cloud Run image build. The `npm ls` no-`invalid` result confirms the MCP SDK resolves and accepts the bumped hono on this branch, not just that the declared range permits it.

## Remaining audit noise

`npm audit` still reports 12 high, all the `brace-expansion` → `minimatch` cascade characterised in #1098. That is a false positive from audit collapsing three per-major-line advisories into one coarse `<=5.0.7` range; every installed copy is patched. Not chased here, deliberately.
