### PR TITLE
fix: honor declared picomatch override in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10120,9 +10120,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -11682,19 +11682,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
@@ -12222,19 +12209,6 @@
         }
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/vitest": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
@@ -12446,19 +12420,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/web-streams-polyfill": {


### PR DESCRIPTION
## Problem

The root `package.json` declares:

```json
"overrides": { "picomatch": "^4.0.5" }
```

…but the lockfile did not honor it. `picomatch` resolved to **4.0.4** at the root, while three *redundant* nested **4.0.5** copies were carried under `tinyglobby`, `vite` and `vitest`.

`npm ls --all` flagged the root node as `invalid`.

Found while verifying the security work in #1100 / #1101 / #1102.

## Why `npm ci` did not catch this

`npm ci` only checks that the **declared ranges** in the manifest match those recorded in the lockfile — and they did. The defect is in the lockfile's **resolved node versions**, which violate the declared override. That is only surfaced by `npm ls`, never by `npm ci`.

Worth knowing on its own: it means CI is structurally blind to this class of drift.

## Change

Lockfile-only. Hoist `picomatch` to a single `4.0.5` node and drop the three duplicate nested copies.

**No manifest files are touched.**

```
package-lock.json | 45 +++++----------------------------
1 file changed, 3 insertions(+), 42 deletions(-)
```

## Verification

| check | result |
|---|---|
| `npm ci --legacy-peer-deps` | exit 0 |
| `npm run build:web` | exit 0 |
| `apps/web` → `npm run lint` | exit 0 |
| picomatch glob-matching behaviour | 4/4 cases pass |
| `npm ls --all` reports picomatch invalid | no longer |

Behavioural check run against the installed node — glob matching is picomatch's entire job, and `vite` / `vitest` / `tinyglobby` are the consumers:

```
version: 4.0.5
PASS  src/**/*.ts   <- src/a/b/c.ts  => true
PASS  *.js          <- a.js          => true
PASS  *.js          <- a/b.js        => false
PASS  **/{a,b}.txt  <- x/a.txt       => true
```

## Scope

This does **not** fix the six pre-existing `apps/web` drift markers, which are a separate and larger problem:

```
@opentelemetry/api@1.9.0    invalid: "1.9.1"
@sentry/nextjs@10.65.0      invalid: "^10.66.0"
@stripe/stripe-js@9.9.0     invalid: "^9.10.0"
@tailwindcss/postcss@4.3.2  invalid: "^4.3.3"
autoprefixer@10.5.2         invalid: "^10.5.4"
tailwindcss@4.3.2           invalid: "^4.3.3"
```

Those need a full lockfile regeneration rather than a surgical edit, so they are filed separately rather than bundled in here.

## Risk

Low. Lockfile-only, no manifests changed, and it brings the tree *into* compliance with an already-declared override rather than introducing a new constraint. 4.0.5 was already installed in three places in this same tree.
