### PR TITLE
fix(deps): realign apps/web lockfile with declared ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,15 +109,6 @@
         "fast-glob": "3.3.1"
       }
     },
-    "apps/web/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "apps/web/node_modules/@opentelemetry/exporter-trace-otlp-http": {
       "version": "0.220.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.220.0.tgz",
@@ -216,619 +207,6 @@
         "node": ">=14"
       }
     },
-    "apps/web/node_modules/@sentry/browser": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.65.0.tgz",
-      "integrity": "sha512-XUDDsx0qxzeIlcOu1fDEqTcDl0eiOqghsgV+ReuuNP4jYjZ9kUQxE3rXWM5mlT1pBi4VaQ4FHqvQZZrRXy+oDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser-utils": "10.65.0",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/feedback": "10.65.0",
-        "@sentry/replay": "10.65.0",
-        "@sentry/replay-canvas": "10.65.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/browser-utils": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.65.0.tgz",
-      "integrity": "sha512-4J0mkfNJAGUOkpg1ZggizyftFTn9N20b+Jl87UnWsDUkNG0Ic1l/FIzMPTVxXrAnhBGu0ULO0TFWMoQ5s3QtZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/conventions": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz",
-      "integrity": "sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "apps/web/node_modules/@sentry/core": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.65.0.tgz",
-      "integrity": "sha512-3aqtmM5NgNGo45BNaaBzi0LPQZAw//NEL4HKS5fXm12pJMa4KEkze8DEKnkTEIrGnWaOJKamecHKlnNg/Mqf/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/conventions": "^0.15.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/feedback": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.65.0.tgz",
-      "integrity": "sha512-ck8h7wgd3F3bYNk0v1OgohmyLBeXcKxqlfBJRtQq4k6KZUq+pXimOG7ckNguVMYjCo3PEfuG+ckKc21yqotKug==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.65.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/nextjs": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-10.65.0.tgz",
-      "integrity": "sha512-9gDKQAAXcWh210fMI/ZNCa7940HYt7dGjnJVP0Tk9ozUR57W4C9vXvHJDTYPJrFxYxTHw7lwxWGervk8a6Tf4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/api": "^1.9.1",
-        "@rollup/plugin-commonjs": "28.0.1",
-        "@sentry/browser-utils": "10.65.0",
-        "@sentry/bundler-plugin-core": "^5.3.0",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/node": "10.65.0",
-        "@sentry/opentelemetry": "10.65.0",
-        "@sentry/react": "10.65.0",
-        "@sentry/vercel-edge": "10.65.0",
-        "@sentry/webpack-plugin": "^5.3.0",
-        "rollup": "^4.60.3",
-        "stacktrace-parser": "^0.1.11"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0"
-      }
-    },
-    "apps/web/node_modules/@sentry/nextjs/node_modules/@opentelemetry/api": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
-      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "apps/web/node_modules/@sentry/node": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.65.0.tgz",
-      "integrity": "sha512-t35dcdyksysVch/m/XdLgGJqGKJhr9eMD30Ctn3TeQ8yMB0wNXySfjPR5Yg93fpjmfaHtzc6iYIXRAvgNVfrvA==",
-      "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/api": "^1.9.1",
-        "@opentelemetry/instrumentation": "^0.220.0",
-        "@opentelemetry/sdk-trace-base": "^2.9.0",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/node-core": "10.65.0",
-        "@sentry/opentelemetry": "10.65.0",
-        "@sentry/server-utils": "10.65.0",
-        "import-in-the-middle": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/node-core": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.65.0.tgz",
-      "integrity": "sha512-U01X9mPT+jZnsLPmPWfBU67Ka+t/Sdd9RGAuvGoKdrI6N47a/9PDkM9oCW+kj0fmZwogZHTgSnzJU5oi3pImgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "@sentry/opentelemetry": "10.65.0",
-        "import-in-the-middle": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
-        "@opentelemetry/instrumentation": ">=0.57.1 <1",
-        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@opentelemetry/core": {
-          "optional": true
-        },
-        "@opentelemetry/exporter-trace-otlp-http": {
-          "optional": true
-        },
-        "@opentelemetry/instrumentation": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/@sentry/node/node_modules/@opentelemetry/api": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
-      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "apps/web/node_modules/@sentry/opentelemetry": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.65.0.tgz",
-      "integrity": "sha512-8C6FPvm3XBvUrkM52dX3Gz0p2H0Ij8t4sahUA+GTiCz0WM0fnyPeQPGC/b6I4jamV9UXyCZRnE1UEEGCoD+c7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
-      }
-    },
-    "apps/web/node_modules/@sentry/react": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.65.0.tgz",
-      "integrity": "sha512-fvHxpuvid0wt9/1N3itcKDyKOjqmYHw3MBSt5Pki3Iz4CL2CmgQp9ZFv/CA7UhMnEvn2Gd+Qc2UKxujZWd8FLg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "10.65.0",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || 17.x || 18.x || 19.x"
-      }
-    },
-    "apps/web/node_modules/@sentry/replay": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.65.0.tgz",
-      "integrity": "sha512-aW988CcQBNArbOMzOFOziipHz6uQyXSa4i5CPWsu+nhVPTJHafosi5Lv9n6NM/icDX5e23VdnX6mZd8SyJuo8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser-utils": "10.65.0",
-        "@sentry/core": "10.65.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/replay-canvas": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.65.0.tgz",
-      "integrity": "sha512-A7X3RVk1Gk+knK8Ip/2EjejckNCLgCfRZo6eGlsy6qyz904KBpYmys1a0o7QkzFRjhIndjHAfcVxwt6jSLJlrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.65.0",
-        "@sentry/replay": "10.65.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/server-utils": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.65.0.tgz",
-      "integrity": "sha512-80toEFD6s+0Le7jrYB6pHWLF703WSg0WyavAWqrBGWG8JkREHgedAxzFYgoY5GlMI756qk6Ea7UzhJTHd2zAXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@apm-js-collab/code-transformer": "^0.15.0",
-        "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
-        "@apm-js-collab/tracing-hooks": "^0.10.1",
-        "@sentry/conventions": "^0.15.1",
-        "@sentry/core": "10.65.0",
-        "magic-string": "~0.30.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/vercel-edge": {
-      "version": "10.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-10.65.0.tgz",
-      "integrity": "sha512-Z1sk2yBHrcsk/QMIzgMRTHitUN1zogzn5eQEc7umWmWwpP6zpDLMDxeeH2F1Cy2vzQFKa53PaWz7HXk4n617eg==",
-      "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/api": "^1.9.1",
-        "@sentry/core": "10.65.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/web/node_modules/@sentry/vercel-edge/node_modules/@opentelemetry/api": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
-      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "apps/web/node_modules/@stripe/stripe-js": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.9.0.tgz",
-      "integrity": "sha512-Vwqe6Q5cU4i82tPyAv2BpaW/fQSNdOSO4/J8EeDLPp5/oIZiMmdB+Hgh863zFH+rtoxpuWGvD1L7QPh8k1Rdvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.16"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/node": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
-      "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "5.21.6",
-        "jiti": "^2.7.0",
-        "lightningcss": "1.32.0",
-        "magic-string": "^0.30.21",
-        "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.2"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
-      "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.2",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.2",
-        "@tailwindcss/oxide-darwin-x64": "4.3.2",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.2",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
-      "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
-      "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
-      "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
-      "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
-      "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
-      "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
-      "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
-      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
-      "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
-      "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
-      "bundleDependencies": [
-        "@napi-rs/wasm-runtime",
-        "@emnapi/core",
-        "@emnapi/runtime",
-        "@tybys/wasm-util",
-        "@emnapi/wasi-threads",
-        "tslib"
-      ],
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.11.1",
-        "@emnapi/runtime": "^1.11.1",
-        "@emnapi/wasi-threads": "^1.2.2",
-        "@napi-rs/wasm-runtime": "^1.1.4",
-        "@tybys/wasm-util": "^0.10.2",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
-      "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
-      "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "apps/web/node_modules/@tailwindcss/postcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.2.tgz",
-      "integrity": "sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.3.2",
-        "@tailwindcss/oxide": "4.3.2",
-        "postcss": "^8.5.15",
-        "tailwindcss": "4.3.2"
-      }
-    },
     "apps/web/node_modules/@types/node": {
       "version": "26.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
@@ -837,77 +215,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
-      }
-    },
-    "apps/web/node_modules/autoprefixer": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
-      "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.28.4",
-        "caniuse-lite": "^1.0.30001799",
-        "fraction.js": "^5.3.4",
-        "picocolors": "^1.1.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "apps/web/node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
-        "update-browserslist-db": "^1.2.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "apps/web/node_modules/eslint-config-next": {
@@ -1015,13 +322,6 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "apps/web/node_modules/tailwindcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
-      "dev": true,
-      "license": "MIT"
     },
     "apps/web/node_modules/zod": {
       "version": "4.4.3",
@@ -1134,9 +434,9 @@
       }
     },
     "node_modules/@apm-js-collab/code-transformer": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.15.0.tgz",
-      "integrity": "sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/estree": "^1.0.8",
@@ -1151,12 +451,12 @@
       }
     },
     "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.5.0.tgz",
-      "integrity": "sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.3.tgz",
+      "integrity": "sha512-qNbPwuMZ8f5ZuGj/ttPeB7a6C/S1bB6tNYaEL5vNiRKydSAxa4AU0gxCWgaP4fVju+AuwhcumSFjrEcGF9Dv7Q==",
       "license": "MIT",
       "dependencies": {
-        "@apm-js-collab/code-transformer": "^0.15.0",
+        "@apm-js-collab/code-transformer": "^0.18.0",
         "es-module-lexer": "^2.1.0",
         "magic-string": "^0.30.21",
         "module-details-from-path": "^1.0.4"
@@ -1166,12 +466,12 @@
       }
     },
     "node_modules/@apm-js-collab/tracing-hooks": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.10.1.tgz",
-      "integrity": "sha512-w2OWXR7FWrKqSziuE9+QclaZrStxO/8+OwbXM635s/zs0Eez1Qo3ivSPdB2WsaPY/iznKTytONPx/PitD7IXcA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apm-js-collab/code-transformer": "^0.15.0",
+        "@apm-js-collab/code-transformer": "^0.18.0",
         "debug": "^4.4.1",
         "module-details-from-path": "^1.0.4"
       }
@@ -3995,6 +3295,36 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@sentry/browser": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.69.0.tgz",
+      "integrity": "sha512-8391tnm96YbR7b8SYfEA/NEIZuyb2r3SZrtAT0bhZtjlujcYWjo7gugQvk8sWLU9cAa/euD00eJoIoJvNfpd7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.69.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0",
+        "@sentry/feedback": "10.69.0",
+        "@sentry/replay": "10.69.0",
+        "@sentry/replay-canvas": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.69.0.tgz",
+      "integrity": "sha512-e/u1Abj0zRPwR/deGZAP3GOULrsx67/XXnM5Skniqs4uxTsdNtPek1Nef0tpxwaQJYxwh6pWdhswLPPbbPOgBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sentry/bundler-plugin-core": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-5.3.0.tgz",
@@ -4190,6 +3520,216 @@
         "node": ">=10"
       }
     },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
+      "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.69.0.tgz",
+      "integrity": "sha512-qrGz5Qaw93/IhMjlFN6uIaXeHwgHDaKGa6FkTAP6PonpkvSbGGqan6xfsENxzj9HUVoli1lZ6tMRDnt2qtSPhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/nextjs": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-10.69.0.tgz",
+      "integrity": "sha512-48eYXezKAmSlSWtBsvwXvdHHHavXRDVIVZ3mI5vidhJwhqSs0ekwG0ZsPG3xNdaJLmnNEmavHEVupSbuuOTZZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@rollup/plugin-commonjs": "28.0.1",
+        "@sentry/browser-utils": "10.69.0",
+        "@sentry/bundler-plugin-core": "^5.3.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0",
+        "@sentry/node": "10.69.0",
+        "@sentry/opentelemetry": "10.69.0",
+        "@sentry/react": "10.69.0",
+        "@sentry/server-utils": "10.69.0",
+        "@sentry/vercel-edge": "10.69.0",
+        "@sentry/webpack-plugin": "^5.3.0",
+        "rollup": "^4.60.3",
+        "stacktrace-parser": "^0.1.11"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.69.0.tgz",
+      "integrity": "sha512-xEXA1YGIiTZbrW6MWV34uS6JGQuQg2ijTI0zed+FsJb9JZKPYel/GZK8Km26vfTVb+yCXFmWZNBesKegNcVdzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0",
+        "@sentry/node-core": "10.69.0",
+        "@sentry/opentelemetry": "10.69.0",
+        "@sentry/server-utils": "10.69.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.69.0.tgz",
+      "integrity": "sha512-IgArHczrZJxkgxoffHscj0NxQrG6kCazgmGQnlf3j58J1ec21YaUu8Tu+7G4Lo5tCiW3teQnwlKW1ttMXSqWRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0",
+        "@sentry/opentelemetry": "10.69.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.69.0.tgz",
+      "integrity": "sha512-3FyWV6YcEJuvLrlaKGE1dHXCI+1YO0a62w7PkwlRg8yp6K6YXkmdwu9GjqaYD+Ju4tm7uC7mHIsGFQMm0M7pqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.69.0.tgz",
+      "integrity": "sha512-f0Il/JMteHjdWPNZQB3rtp1Pcj2Leb3p0KSZuv3rh0EUril9CbWtQVy5zJhoAppi+MWWmgRWa+6BpHbQf+ABQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.69.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.69.0.tgz",
+      "integrity": "sha512-uRhmNhtFGPOlM0iniVmWKAX3KVXI0le41yYK/iKdPjinT9jA3ZrmykO/Fv1v/KI5znOtwa9D6eHRnDTTMRxFrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.69.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.69.0.tgz",
+      "integrity": "sha512-VF6nXvSninHcc7dC1Zme0RjkC7VgRMCixs6jKaQX5zTNeqTW3dZGSefSOVv+ZteRi3hJvVORq985VjUC9Z/0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.69.0",
+        "@sentry/replay": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.69.0.tgz",
+      "integrity": "sha512-0MwHrA8+nNvMIsqf8m3cXwCBlUjr6AS7N6CZvHJtY1DkqEvQqEbD5VIrhzEyHN/KMZIgQ8XeDCQRhjnXFQGRhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0",
+        "meriyah": "^6.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/vercel-edge": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-10.69.0.tgz",
+      "integrity": "sha512-P3IsZyM3j8s4sGuxnGn1+EScVZHABsuzqv0NzIUen61ml0x+c6F6XXobvMhMcRp98fIQe1hZBpzH0VNxc7eCIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sentry/webpack-plugin": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-5.3.0.tgz",
@@ -4210,6 +3750,15 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.12.1.tgz",
+      "integrity": "sha512-KLXPvjA0BfS4dQnW+ddHjwtIXMnIfKYxqmeNMmQCfKjvYog0cSG+Z7ZvK4RH1+bV90GC07nUztWDRWmJLi5HZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.110.7",
@@ -4302,6 +3851,343 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+      "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "postcss": "^8.5.16",
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@turbo/darwin-64": {
@@ -5585,6 +5471,43 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.6",
+        "caniuse-lite": "^1.0.30001806",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -6354,9 +6277,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.6",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11578,6 +11501,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
       }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",


### PR DESCRIPTION
## Canonical issue

Closes #1110

Duplicate report: #1112 (a self-correction of #1110's claim that `npm ci` would reject the lockfile — it does not). Both describe the same defect; #1110 is canonical and #1112 will be closed as a duplicate.

## Outcome

`apps/web` now installs the dependency versions its manifest actually declares. Six packages were silently resolving **below** their declared floors, so every developer, CI run, and production build was shipping older code than the manifest promised — including a Sentry SDK a minor version behind and an `@opentelemetry/api` that violated an exact pin. `npm ls --all` goes from 6 `invalid:` entries to 0, with no manifest edit and no new advisories.

## Scope

- Included: `package-lock.json` only — re-resolution of the six drifted `apps/web` edges plus the four transitive bumps those upgrades require.
- Explicitly excluded: any `package.json` edit (#1110 forbids it), the `brace-expansion` override floors (filed as #1115), the flaky billing test (filed as #1116), and any new CI guard (reasoning below).

## Risk

- Risk level: **low** — one lockfile, no manifest change, no source change; every drifted package moves *up* into its already-declared range, so no consumer contract changes.
- Failure mode: the realistic risk is a runtime regression from `@sentry/nextjs` 10.65.0 → 10.69.0 (the only minor bump) or from the four forced transitive bumps. Mitigated by build + type-check + lint + 244/245 tests + an identical Next.js route table, all green on this head.
- Rollback: revert the single commit (`236b6597f`). The lockfile is self-contained and no other file depends on it, so revert restores the exact previous tree byte-for-byte.

## Verification

Every acceptance criterion in #1110, checked on head `236b6597f`:

- [x] **Focused tests** — `apps/web` suite 244/245 pass; the single failure is proven pre-existing and environmental (see below).
- [x] **Required CI** — `build`, `test`, `lint-frontend`, `lint-python`, `npm-audit`, `dependency-review`, `CodeQL`, `trivy`, `bandit`, `gitleaks`, `guards` all pass on this head.
- [x] **Review threads resolved** — none open.
- [x] **No manifest change** — `package.json` and `apps/web/package.json` SHA-256 verified byte-identical before and after.
- [x] **`npm ls --all` reports zero `invalid:`** — 6 → 0, checked against the real `npm ci`-installed tree, not just a lockfile parse.
- [x] **All root overrides honored** — all 17 override-target copies resolve to identical versions *and paths* as baseline (diff: `IDENTICAL`): `next` 16.2.12, `postcss` 8.5.25/8.5.21, `protobufjs` 7.6.5, `sharp` 0.35.3, `@hono/node-server` 2.0.12, `picomatch` 4.0.5, and both nested `minimatch > brace-expansion` pins (1.1.18 / 2.1.4).
- [x] **Zero new advisories** — `npm audit` 12 high before → 12 high after; set-differenced by advisory key: `NEW advisories introduced: NONE`.
- [x] **`npm ci --legacy-peer-deps`** exit 0
- [x] **`npm run build:web`** exit 0, route table diffed against baseline: identical
- [x] **`apps/web` lint** exit 0
- [x] *(beyond the stated bar, since Sentry moved a minor)* **`tsc --noEmit`** exit 0

## Production evidence

Vercel preview built and deployed successfully from this exact head (`236b6597f`): https://vercel.com/garv1/v0-uvai/45sxaJMDnGTBMi54SzwJuBy8dMHL — `Vercel`, `Vercel Agent Review`, and `Vercel Preview Comments` all report SUCCESS. The Next.js production build emitted a route table byte-identical to the pre-change baseline, so the deployed surface is unchanged; the delta is confined to the versions of the code behind it.

---

## What was wrong

Six `apps/web` dependencies resolved **below** the ranges declared in `apps/web/package.json`. `npm ls --all` flagged each as `invalid`:

| package | declared | locked | now |
|---|---|---|---|
| `@opentelemetry/api` | `1.9.1` (exact) | 1.9.0 | **1.9.1** |
| `@sentry/nextjs` | `^10.66.0` | 10.65.0 | **10.69.0** |
| `@stripe/stripe-js` | `^9.10.0` | 9.9.0 | **9.12.1** |
| `@tailwindcss/postcss` | `^4.3.3` | 4.3.2 | **4.3.3** |
| `tailwindcss` | `^4.3.3` | 4.3.2 | **4.3.3** |
| `autoprefixer` | `^10.5.4` | 10.5.2 | **10.5.4** |

## Root cause (verified, not assumed)

The lockfile's **recorded** ranges under `packages["apps/web"]` are byte-identical to the manifest:

```
pkg                   | manifest  | lock-recorded | lock-resolved
@opentelemetry/api    | 1.9.1     | 1.9.1         | 1.9.0
@sentry/nextjs        | ^10.66.0  | ^10.66.0      | 10.65.0
...
```

npm's sync validation compares *recorded range vs manifest range* only. It never re-checks the **resolved node version** against the range binding it. So the edge looks satisfied, reify leaves the stale node untouched, and a plain `npm install` is a genuine no-op — confirmed by SHA-256: the lockfile was byte-identical after a full `npm install --legacy-peer-deps`. This is exactly why `npm ci` passes while six packages sit below their floors, as #1112 correctly established.

## Approach — surgical, not nuclear

#1110 suggested `rm package-lock.json`, while noting it "carries real risk (it may move many unrelated transitive versions)". Its hard requirements are outcome-based, so I bounded the blast radius instead: evict only the six stale nodes plus their nested subtrees, then let `npm install --package-lock-only` re-resolve exactly those edges.

The resulting semantic delta is confined to the six targets, their dedupe-hoist from `apps/web/node_modules` to the root, and **four transitive bumps that the upgrades require** — each traced to a concrete requirer rather than accepted as churn:

| transitive | change | required by |
|---|---|---|
| `@apm-js-collab/code-transformer` | 0.15.0 → 0.18.1 | the two below want `^0.18.0` |
| `@apm-js-collab/code-transformer-bundler-plugins` | 0.5.0 → 0.7.3 | `@sentry/server-utils@10.69.0` wants `^0.7.3` |
| `@apm-js-collab/tracing-hooks` | 0.10.1 → 0.13.0 | `@sentry/server-utils@10.69.0` wants `^0.13.0` |
| `enhanced-resolve` | 5.21.6 → 5.24.5 | `@tailwindcss/node@4.3.3` wants `^5.24.1` |

The raw diff is 2822 lines, which overstates the change: most of it is dedupe-hoisting (`apps/web/node_modules/X` → `node_modules/X`), not version movement. The semantic delta is 38 nodes added, 43 removed, and only the 4 version bumps above.

> ⚠️ Worth recording for anyone hitting this class of drift again: do **not** reach for `npm install <pkg> -w apps/web`. As #1110 observed, npm *loosens the manifest* rather than updating the tree — it rewrites `@opentelemetry/api` from the exact `1.9.1` to `^1.9.0`, retroactively making the wrong locked version "valid" instead of fixing it.

## The one failing test is pre-existing and environmental

`billing-chat-gating.test.ts > blocks free tier after daily quota` times out at 5000ms locally. I did not assume it was unrelated:

1. Checked out pristine `origin/main` (`abd93326b`) into a separate worktree, ran its own `npm ci`, ran that test file — **fails identically with no changes applied**.
2. Isolated the actual trigger: the free-tier path in `/api/chat` falls through to `generateText()` against the Vercel AI Gateway, which is never mocked (the test mocks only `grok-client`, which covers the Pro path). Route line 124 short-circuits to 503 when no gateway key is present, so the test passes wherever no key is configured and hangs wherever one is:

```
$ npx vitest run .../billing-chat-gating.test.ts                    → 1 failed (5007ms timeout)
$ env -u AI_GATEWAY_API_KEY ... npx vitest run .../same             → 2 passed
```

That is why CI's `test` job passes on this PR — and also why it passes *vacuously*: in CI every loop iteration returns 503, so `expect(res.status).not.toBe(402)` is satisfied by the gateway being unconfigured rather than by free tier actually being served. Filed as #1116; out of scope here, since #1110 requires this be a standalone lockfile change.

## Note on the `brace-expansion` overrides

#1110 asks that the nested `minimatch > brace-expansion` pins be re-verified. They are preserved unchanged and confirmed above (1.1.18 / 2.1.4, identical to baseline).

While verifying them I measured the installed copies against the OOM advisory directly rather than trusting advisory metadata, and found that **the tree is safe but the floors are not**: the 100000-entry expansion cap that remediates GHSA-mh99-v99m-4gvg landed in **1.1.17** and **2.1.3**, whereas the pins are `^1.1.16` and `^2.1.2` — both demonstrably OOM-vulnerable when installed directly. Today the carets float up to safe versions, so the outcome is correct but incidental rather than guaranteed. Raising the floors requires editing root `package.json`, which #1110 forbids here, so it is filed as #1115 with the full per-version measurements and shipped in #1117.

## Guarding against recurrence

Deliberately proposing no CI change here. As #1112 demonstrated, `npm ci` is structurally incapable of catching this class of drift, so adding it as a guard would be cargo cult. The check that *would* catch it is `npm ls --all` grepped for `invalid`, which I'd suggest evaluating on its own merits rather than smuggling into a lockfile fix.

## CI note

`Agent completion enforcement` reports failure with `missing_trusted_publication`. This is repo-wide and pre-existing: it requires a check run named `Agent Lock trusted publication` published by a trusted GitHub App, and that App is not publishing. PRs #1108, #1103 and #1098 all show the same failure with zero such check runs and were merged regardless. Nothing in this PR affects it.
