### PR TITLE
fix(deps): raise brace-expansion override floors to the actual backport (1.1.17 / 2.1.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     "sharp": "^0.35.0",
     "@hono/node-server": "^2.0.5",
     "minimatch@3.1.5": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.17"
     },
     "minimatch@9.0.9": {
-      "brace-expansion": "^2.1.2"
+      "brace-expansion": "^2.1.3"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Canonical issue

Closes #1115

## Outcome

The nested `brace-expansion` override floors now sit at or above the release that actually contains the OOM remediation. Previously both floors (`^1.1.16`, `^2.1.2`) were themselves vulnerable, so the tree was safe only by luck of caret resolution — any install that landed on the floor would have been exploitable. This makes the safe outcome *guaranteed by the manifest* rather than incidental.

## Scope

- Included: two version bumps in the root `overrides` block — `^1.1.16` → `^1.1.17`, `^2.1.2` → `^2.1.3`.
- Explicitly excluded: `package-lock.json` (unchanged — resolution already satisfies the new floors), the `npm audit` advisory noise (unfixable by upgrade, see below), and the broader override-floor sweep tracked in #1105.

## Risk

- Risk level: **low** — manifest-only, two characters, zero lockfile movement, and the installed tree is bit-for-bit what it was before this change.
- Failure mode: the only way this could break anything is if some resolution path were pinned *at* 1.1.16 or 2.1.2 and could not float up. Disproven: `npm ci` installs 1.1.18 / 2.1.4 / 5.0.8 with exit 0, and `npm install --package-lock-only` produces no lockfile diff — meaning no edge was constrained to the old floors.
- Rollback: revert the single commit (`3e141b3ae`). Nothing else references these pins and the lockfile never moved, so revert is a pure no-op on the installed tree.

## Verification

Run in a clean worktree off `main` (`abd93326b`), verified on head `3e141b3ae`:

- [x] **Focused tests** — OOM PoC executed against every installed copy in the real `npm ci` tree: 1.1.18, 2.1.4, 5.0.8 all return `len=100000` (capped) under `--max-old-space-size=512`; none OOM.
- [x] **Required CI** — `build`, `test`, `lint-frontend`, `npm-audit`, `dependency-review`, `CodeQL`, `trivy`, `gitleaks`, `guards` on this head.
- [x] **Review threads resolved** — none open.
- [x] `git status --porcelain` → `M package.json` only, **zero lockfile movement**
- [x] `npm install --package-lock-only --legacy-peer-deps` → no lockfile diff (resolution already satisfies the new floors)
- [x] `npm ci --legacy-peer-deps` → exit 0, 719 packages
- [x] `npm run build:web` → exit 0
- [x] `apps/web` lint → exit 0

## Production evidence

Vercel preview built and deployed successfully from this exact head (`3e141b3ae`): https://vercel.com/garv1/v0-uvai/2M2jWgVT8SUDwShk9SydgoEbeAVo — `Vercel`, `Vercel Agent Review`, and `Vercel Preview Comments` all report SUCCESS.

Because the lockfile does not move, the deployed artifact is byte-identical to what `main` produces today. This change constrains what *future* installs are permitted to resolve; it does not alter the currently deployed tree. That is precisely the intent — it removes a latent path to a vulnerable version rather than fixing an active one.

---

## Problem

The root `overrides` block pins nested `brace-expansion` for two `minimatch` versions:

```jsonc
"minimatch@3.1.5": { "brace-expansion": "^1.1.16" },
"minimatch@9.0.9": { "brace-expansion": "^2.1.2" }
```

Both floors are **themselves vulnerable** to the OOM described in GHSA-mh99-v99m-4gvg. The 100000-entry expansion cap was backported in **1.1.17** and **2.1.3** — one patch above each pin. A clean install today happens to resolve 1.1.18 / 2.1.4, but nothing in the manifest *requires* that.

## Why this wasn't obvious

GitHub's advisory record for GHSA-mh99 lists a **single** affected range (`<= 5.0.7`, first patched `5.0.8`) and never enumerates the 1.x / 2.x lines — unlike sibling brace-expansion advisories, which carry per-major ranges. So the metadata gives no hint that a 1.x/2.x backport exists.

Closed issue #1101 read that same metadata and concluded the 1.x/2.x pins were a "false positive — never affected." **That conclusion (tree is safe) was right; the stated mechanism was wrong.** They *were* affected, and they *were* patched.

## Evidence — measured, not inferred

Each version installed standalone and run against two OOM vectors under `--max-old-space-size=512`:

| version | numeric `{1..50000000}` | cartesian `{a,b}`×30 |
|---|---|---|
| 1.1.16 | **OOM** | **OOM** |
| **1.1.17** | OK (capped 100000) | OK (capped 100000) |
| 1.1.18 | OK | OK |
| 2.1.2 | **OOM** | **OOM** |
| **2.1.3** | OK | OK |
| 2.1.4 | OK | OK |
| 5.0.7 / 5.0.8 | OK | OK |

Reproduce (`<v>` = version under test):

```bash
mkdir -p /tmp/be && cd /tmp/be && npm init -y >/dev/null
npm i brace-expansion@<v> >/dev/null
printf 'const m=await import("brace-expansion");const f=typeof m==="function"?m:(m.expand??m.default);console.log("len="+f("{a,b}".repeat(30)).length);' > node_modules/__poc.mjs
node --max-old-space-size=512 node_modules/__poc.mjs   # OOM on 1.1.16 / 2.1.2
```

> Two traps worth documenting: the probe must live **inside** the package dir, because ESM bare-specifier resolution keys off the importing file's URL rather than `process.chdir`. And 5.x is ESM-only with no `index.js`, so a naive `require('.../index.js')` yields a `MODULE_NOT_FOUND` that reads exactly like an OOM crash.

## The change

Two characters. `^1.1.16` → `^1.1.17`, `^2.1.2` → `^2.1.3`.

## `npm audit` stays noisy, and that is expected

Audit still reports the same 12 high advisories. Under semver `1.1.18 <= 5.0.7` is true, so the advisory's single range keeps matching the 1.x/2.x copies regardless of the backport. That noise is **not fixable by upgrading** — no newer 1.x/2.x releases exist — and needs either an upstream advisory-metadata correction or a local waiver. Out of scope here. This PR fixes the *permitted set*, which is the part we control.

## Relationship to other work

- Does **not** conflict with #1114 — that PR touches only `package-lock.json`, this one only `package.json`. Disjoint files, no merge interaction in either order.
- Contributes to #1105 (raise npm transitive override floors); this covers the `brace-expansion` pins specifically.

## CI note

`Agent completion enforcement` reports `missing_trusted_publication`. This is repo-wide and pre-existing: it requires a check run named `Agent Lock trusted publication` published by a trusted GitHub App that is not publishing. PRs #1108, #1103 and #1098 all show the same failure and were merged regardless. Nothing in this PR affects it.
