### PR TITLE
fix(ci): allowlist uv.lock in gitleaks to silence lockfile-hash false positive

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,4 +14,8 @@ paths = [
   '''docs/security/.*''',
   # Test fixtures use obvious dummy keys (e.g. "xai-secret-123"), not real secrets.
   '''tests/.*''',
+  # Dependency lockfile: contains third-party PyPI package hashes (sha256 digests),
+  # not EventRelay credentials. Secret scanners mis-flag these high-entropy digests
+  # (e.g. the square-access-token rule fires on a package hash), so exclude the file.
+  '''(^|/)uv\.lock$''',
 ]


### PR DESCRIPTION
## Canonical issue

Closes # <!-- none: repo-wide CI-hygiene fix, no tracking issue exists -->

## Outcome

The `gitleaks (working tree)` gate stops failing repo-wide. Every PR whose tree
includes `uv.lock` (all of them since the uv migration) currently fails the
secret-scan gate on a false positive; this removes that blocker.

## Scope

- Included: one allowlist entry in `.gitleaks.toml` for `uv.lock`.
- Explicitly excluded: no other lockfiles, no rule changes, no code changes.

## Risk

- Risk level: low
- Failure mode: a real secret committed *inside `uv.lock`* would no longer be
  caught. `uv.lock` holds only public PyPI package digests, so this is not a
  credible vector; all other files remain fully scanned.
- Rollback: revert this one-line commit.

## Verification

Tied to head SHA `7e0d6a530ed243ad2f4c9ffa7a6fcb3f8e6961e1`.

- [x] Reproduced the failure: `gitleaks detect --no-git --config .gitleaks.toml`
  (v8.18.4, the CI version) reports `square-access-token` at `uv.lock:5129` —
  the parso-0.8.7 sdist sha256 digest (`size = 401824`).
- [x] With the allowlist entry the same scan reports **"no leaks found" (exit 0)**.
- [ ] Required CI (will run on this PR)
- [ ] Review threads resolved

## Production evidence

Not applicable — CI configuration only; no runtime or deployment surface.

## Agent handoff

- [ ] One canonical issue is linked — none exists; this is an unsolicited CI-hygiene fix
- [x] No competing PR implements the same issue
- [x] Acceptance criteria are satisfied (scan clean on current head)
- [ ] Required checks pass on the current head (pending CI)
- [x] Human decision is requested for merge to the protected `main` branch

## Agent provenance

Authored by Claude Code running as a scheduled PR-remediation routine. This is
not a Jules/governance-tracked task, so no `agent-lock-manifest` (canonical
issue number / provider run_id) is claimed — the governance truth-gate may
therefore report this PR as lacking a linked canonical issue. Head SHA for
evidence: `7e0d6a530ed243ad2f4c9ffa7a6fcb3f8e6961e1`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011GD58fAYHFPaVfPvReEYj4)_