### PR TITLE
fix: repair one-click deploy paths and production manifests

### DIFF
--- a/infrastructure/k8s/monitoring/monitoring.yaml
+++ b/infrastructure/k8s/monitoring/monitoring.yaml
@@ -16,12 +16,6 @@ data:
       metrics_path: /metrics
       scrape_interval: 10s
       
-    - job_name: 'mcp-server'
-      static_configs:
-      - targets: ['mcp-server:8000']
-      metrics_path: /metrics
-      scrape_interval: 10s
-      
     - job_name: 'kubernetes-pods'
       kubernetes_sd_configs:
       - role: pod

--- a/infrastructure/k8s/production/deployment.yaml
+++ b/infrastructure/k8s/production/deployment.yaml
@@ -29,15 +29,13 @@ spec:
         image: enhanced-framework:latest
         imagePullPolicy: Always
         ports:
-        - containerPort: 3000
+        - containerPort: 8000
           name: http
         env:
-        - name: NODE_ENV
-          value: "production"
         - name: PORT
-          value: "3000"
-        - name: MCP_SERVER_URL
-          value: "http://mcp-server:8000"
+          value: "8000"
+        - name: PYTHONUNBUFFERED
+          value: "1"
         resources:
           requests:
             memory: "256Mi"
@@ -48,15 +46,15 @@ spec:
         livenessProbe:
           httpGet:
             path: /health
-            port: 3000
+            port: 8000
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /ready
-            port: 3000
+            path: /readyz
+            port: 8000
           initialDelaySeconds: 5
           periodSeconds: 5
           timeoutSeconds: 3
@@ -71,84 +69,3 @@ spec:
       securityContext:
         fsGroup: 1001
       restartPolicy: Always
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: mcp-server
-  namespace: production
-  labels:
-    app: mcp-server
-    version: v1.0.0
-    component: mcp-protocol
-spec:
-  replicas: 2
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app: mcp-server
-  template:
-    metadata:
-      labels:
-        app: mcp-server
-        version: v1.0.0
-        component: mcp-protocol
-    spec:
-      containers:
-      - name: mcp-server
-        image: python:3.11-slim
-        command: ["python3", "/app/mcp_server.py"]
-        ports:
-        - containerPort: 8000
-          name: mcp-http
-        env:
-        - name: MCP_HOST
-          value: "0.0.0.0"
-        - name: MCP_PORT
-          value: "8000"
-        - name: MCP_DEBUG
-          value: "false"
-        resources:
-          requests:
-            memory: "128Mi"
-            cpu: "100m"
-          limits:
-            memory: "256Mi"
-            cpu: "200m"
-        volumeMounts:
-        - name: app-code
-          mountPath: /app
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8000
-          initialDelaySeconds: 15
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 3
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 8000
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          timeoutSeconds: 3
-          failureThreshold: 3
-        securityContext:
-          allowPrivilegeEscalation: false
-          runAsNonRoot: true
-          runAsUser: 1001
-          capabilities:
-            drop:
-            - ALL
-      volumes:
-      - name: app-code
-        configMap:
-          name: mcp-server-code
-      securityContext:
-        fsGroup: 1001
-      restartPolicy: Always 

--- a/infrastructure/k8s/production/service.yaml
+++ b/infrastructure/k8s/production/service.yaml
@@ -10,29 +10,11 @@ spec:
   type: ClusterIP
   ports:
   - port: 80
-    targetPort: 3000
+    targetPort: 8000
     protocol: TCP
     name: http
   selector:
     app: enhanced-framework
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: mcp-server
-  namespace: production
-  labels:
-    app: mcp-server
-    component: mcp-protocol
-spec:
-  type: ClusterIP
-  ports:
-  - port: 8000
-    targetPort: 8000
-    protocol: TCP
-    name: mcp-http
-  selector:
-    app: mcp-server
 ---
 apiVersion: v1
 kind: Service
@@ -46,11 +28,11 @@ spec:
   type: LoadBalancer
   ports:
   - port: 80
-    targetPort: 3000
+    targetPort: 8000
     protocol: TCP
     name: http
   - port: 443
-    targetPort: 3000
+    targetPort: 8000
     protocol: TCP
     name: https
   selector:

--- a/scripts/deployment/one-click-deploy.sh
+++ b/scripts/deployment/one-click-deploy.sh
@@ -17,6 +17,14 @@ NAMESPACE="production"
 DEPLOYMENT_NAME="enhanced-framework"
 TIMEOUT=300
 
+# Every path below is relative to the repository root, so anchor there rather
+# than depending on the caller's working directory.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DOCKERFILE="infrastructure/docker/Dockerfile.production"
+PRODUCTION_MANIFESTS="infrastructure/k8s/production"
+MONITORING_MANIFESTS="infrastructure/k8s/monitoring"
+cd "$REPO_ROOT"
+
 # Logging function
 log() {
     echo -e "${BLUE}[$(date +'%Y-%m-%d %H:%M:%S')]${NC} $1"
@@ -65,13 +73,11 @@ success "Kubernetes cluster is accessible"
 
 # Check if required files exist
 REQUIRED_FILES=(
-    "Dockerfile.production"
+    "$DOCKERFILE"
     "package.json"
-    "k8s/production/deployment.yaml"
-    "k8s/production/service.yaml"
-    "k8s/monitoring/monitoring.yaml"
-    "mcp_server.py"
-    "learning_app_processor.py"
+    "$PRODUCTION_MANIFESTS/deployment.yaml"
+    "$PRODUCTION_MANIFESTS/service.yaml"
+    "$MONITORING_MANIFESTS/monitoring.yaml"
 )
 
 for file in "${REQUIRED_FILES[@]}"; do
@@ -85,14 +91,18 @@ success "All required files are present"
 log "Step 2: Running Integration Tests"
 
 if [[ -d "venv" ]]; then
+    # shellcheck disable=SC1091
     source venv/bin/activate
-    if python3 tests/integration/test_runner.py; then
-        success "Integration tests passed"
-    else
-        error "Integration tests failed. Please fix issues before deployment."
-    fi
+fi
+
+if ! command -v python3 &> /dev/null; then
+    warning "python3 is not available. Skipping integration tests."
+elif ! python3 -c "import pytest" &> /dev/null; then
+    warning "pytest is not installed. Skipping integration tests."
+elif PYTHONPATH="src" python3 -m pytest tests/integration -q; then
+    success "Integration tests passed"
 else
-    warning "Virtual environment not found. Skipping integration tests."
+    error "Integration tests failed. Please fix issues before deployment."
 fi
 
 # Step 3: Build Docker Image
@@ -101,7 +111,7 @@ log "Step 3: Building Docker Image"
 DOCKER_TAG="enhanced-framework:$(date +%Y%m%d-%H%M%S)"
 LATEST_TAG="enhanced-framework:latest"
 
-if docker build -f Dockerfile.production -t "$DOCKER_TAG" -t "$LATEST_TAG" .; then
+if docker build -f "$DOCKERFILE" -t "$DOCKER_TAG" -t "$LATEST_TAG" .; then
     success "Docker image built successfully: $DOCKER_TAG"
 else
     error "Docker image build failed"
@@ -111,21 +121,21 @@ fi
 log "Step 4: Validating Kubernetes Manifests"
 
 # Validate deployment manifest
-if kubectl apply --dry-run=client -f k8s/production/deployment.yaml; then
+if kubectl apply --dry-run=client -f "$PRODUCTION_MANIFESTS/deployment.yaml"; then
     success "Deployment manifest is valid"
 else
     error "Deployment manifest validation failed"
 fi
 
 # Validate service manifest
-if kubectl apply --dry-run=client -f k8s/production/service.yaml; then
+if kubectl apply --dry-run=client -f "$PRODUCTION_MANIFESTS/service.yaml"; then
     success "Service manifest is valid"
 else
     error "Service manifest validation failed"
 fi
 
 # Validate monitoring manifest
-if kubectl apply --dry-run=client -f k8s/monitoring/monitoring.yaml; then
+if kubectl apply --dry-run=client -f "$MONITORING_MANIFESTS/monitoring.yaml"; then
     success "Monitoring manifest is valid"
 else
     error "Monitoring manifest validation failed"
@@ -144,14 +154,14 @@ fi
 log "Step 6: Deploying to Kubernetes"
 
 # Deploy application
-if kubectl apply -f k8s/production/ -n "$NAMESPACE"; then
+if kubectl apply -f "$PRODUCTION_MANIFESTS/" -n "$NAMESPACE"; then
     success "Application deployed successfully"
 else
     error "Application deployment failed"
 fi
 
 # Deploy monitoring
-if kubectl apply -f k8s/monitoring/ -n "$NAMESPACE"; then
+if kubectl apply -f "$MONITORING_MANIFESTS/" -n "$NAMESPACE"; then
     success "Monitoring stack deployed successfully"
 else
     error "Monitoring deployment failed"

--- a/tests/unit/test_deployment_manifests.py
+++ b/tests/unit/test_deployment_manifests.py
@@ -1,0 +1,249 @@
+"""Structural guards for the one-click deployment path.
+
+``scripts/deployment/one-click-deploy.sh`` aborted at its first gate because
+``REQUIRED_FILES`` named paths that had moved under ``infrastructure/`` and two
+modules that never existed. Once past that gate it would have rolled out a
+manifest describing the Python image as a Node service on port 3000, and a
+sibling Deployment mounting a ConfigMap that is defined nowhere in the
+repository.
+
+Every assertion here is derived from the repository rather than restated by
+hand, so the checks keep tracking the deployment as it moves.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+def _repo_root():
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "scripts" / "deployment" / "one-click-deploy.sh").exists():
+            return candidate
+    raise AssertionError("repository root not found")
+
+
+REPO_ROOT = _repo_root()
+DEPLOY_SCRIPT = REPO_ROOT / "scripts" / "deployment" / "one-click-deploy.sh"
+PRODUCTION_DIR = REPO_ROOT / "infrastructure" / "k8s" / "production"
+MONITORING_DIR = REPO_ROOT / "infrastructure" / "k8s" / "monitoring"
+
+
+def _script():
+    return DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+
+def _script_variables(script):
+    """Collect the literal top-level assignments the script's paths are built from."""
+
+    variables = {}
+    for name, value in re.findall(
+        r'^([A-Z_]+)="([^"$]*)"$', script, flags=re.MULTILINE
+    ):
+        variables[name] = value
+    return variables
+
+
+def _expand(value, variables):
+    def replace(match):
+        name = match.group(1) or match.group(2)
+        if name not in variables:
+            raise AssertionError(f"unresolved shell variable in path: ${name}")
+        return variables[name]
+
+    return re.sub(r'\$\{([A-Z_]+)\}|\$([A-Z_]+)', replace, value)
+
+
+def _manifests(directory):
+    for path in sorted(directory.glob("*.yaml")):
+        for document in yaml.safe_load_all(path.read_text(encoding="utf-8")):
+            if document:
+                yield path, document
+
+
+class DeployScriptPathTests(unittest.TestCase):
+    def test_required_files_all_exist(self):
+        script = _script()
+        variables = _script_variables(script)
+        block = re.search(
+            r"REQUIRED_FILES=\(\s*(.*?)\s*\)", script, flags=re.DOTALL
+        )
+        self.assertIsNotNone(block, "REQUIRED_FILES array not found")
+
+        entries = re.findall(r'"([^"]+)"', block.group(1))
+        self.assertGreater(len(entries), 0)
+
+        for entry in entries:
+            with self.subTest(entry=entry):
+                resolved = REPO_ROOT / _expand(entry, variables)
+                self.assertTrue(
+                    resolved.is_file(),
+                    f"REQUIRED_FILES names {entry}, which does not exist",
+                )
+
+    def test_every_referenced_path_exists(self):
+        """`docker build -f` and `kubectl apply -f` targets must be real."""
+
+        script = _script()
+        variables = _script_variables(script)
+        referenced = re.findall(
+            r'(?:docker build|kubectl apply)[^\n]*?-f "([^"]+)"', script
+        )
+        self.assertGreater(len(referenced), 0)
+
+        for entry in referenced:
+            if entry == "-":  # `kubectl apply -f -` reads stdin.
+                continue
+            with self.subTest(entry=entry):
+                resolved = REPO_ROOT / _expand(entry, variables).rstrip("/")
+                self.assertTrue(
+                    resolved.exists(),
+                    f"script applies {entry}, which does not exist",
+                )
+
+    def test_script_runs_from_the_repository_root(self):
+        """Relative paths are only meaningful once the script anchors itself."""
+
+        script = _script()
+        self.assertIn('REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")', script)
+        self.assertIn('cd "$REPO_ROOT"', script)
+        self.assertLess(
+            script.index('cd "$REPO_ROOT"'),
+            script.index("REQUIRED_FILES=("),
+        )
+
+
+class ProductionManifestTests(unittest.TestCase):
+    def _documents(self):
+        return [document for _, document in _manifests(PRODUCTION_DIR)]
+
+    def _deployments(self):
+        return [d for d in self._documents() if d.get("kind") == "Deployment"]
+
+    def _services(self):
+        return [d for d in self._documents() if d.get("kind") == "Service"]
+
+    def test_mounted_configmaps_are_defined_in_the_repository(self):
+        """A pod mounting an undefined ConfigMap can never start.
+
+        The removed `mcp-server` Deployment mounted `mcp-server-code`, which no
+        manifest creates, so `kubectl rollout status` could only ever time out.
+        """
+
+        defined = set()
+        for directory in (PRODUCTION_DIR, MONITORING_DIR):
+            for _, document in _manifests(directory):
+                if document.get("kind") == "ConfigMap":
+                    defined.add(document["metadata"]["name"])
+
+        for path, document in _manifests(PRODUCTION_DIR):
+            if document.get("kind") != "Deployment":
+                continue
+            volumes = (
+                document["spec"]["template"]["spec"].get("volumes") or []
+            )
+            for volume in volumes:
+                config_map = volume.get("configMap")
+                if not config_map:
+                    continue
+                with self.subTest(path=path.name, name=config_map["name"]):
+                    self.assertIn(
+                        config_map["name"],
+                        defined,
+                        f"{path.name} mounts ConfigMap "
+                        f"{config_map['name']}, which is defined nowhere",
+                    )
+
+    def test_service_target_ports_match_a_container_port(self):
+        """Traffic sent to a port no container listens on is silently dropped."""
+
+        container_ports = {}
+        for deployment in self._deployments():
+            app = deployment["spec"]["selector"]["matchLabels"]["app"]
+            ports = set()
+            for container in deployment["spec"]["template"]["spec"]["containers"]:
+                for port in container.get("ports") or []:
+                    ports.add(port["containerPort"])
+            container_ports[app] = ports
+
+        for service in self._services():
+            app = service["spec"]["selector"]["app"]
+            with self.subTest(service=service["metadata"]["name"]):
+                self.assertIn(
+                    app,
+                    container_ports,
+                    f"service selects app={app}, which no Deployment provides",
+                )
+                for port in service["spec"]["ports"]:
+                    self.assertIn(
+                        port["targetPort"],
+                        container_ports[app],
+                        f"targetPort {port['targetPort']} is not exposed by "
+                        f"any {app} container",
+                    )
+
+    def test_container_port_matches_the_image_it_runs(self):
+        """The manifest and the Dockerfile must agree on the listening port."""
+
+        dockerfile = (
+            REPO_ROOT / "infrastructure" / "docker" / "Dockerfile.production"
+        ).read_text(encoding="utf-8")
+        exposed = {
+            int(port)
+            for port in re.findall(r"^EXPOSE\s+(\d+)", dockerfile, re.MULTILINE)
+        }
+        self.assertTrue(exposed, "Dockerfile.production declares no EXPOSE")
+
+        for deployment in self._deployments():
+            if deployment["metadata"]["name"] != "enhanced-framework":
+                continue
+            for container in deployment["spec"]["template"]["spec"]["containers"]:
+                for port in container.get("ports") or []:
+                    self.assertIn(
+                        port["containerPort"],
+                        exposed,
+                        "enhanced-framework listens on "
+                        f"{port['containerPort']} but the image exposes "
+                        f"{sorted(exposed)}",
+                    )
+
+    def test_probe_paths_are_served_by_the_application(self):
+        """A probe on an unrouted path fails forever and blocks the rollout."""
+
+        main = (
+            REPO_ROOT / "src" / "youtube_extension" / "main.py"
+        ).read_text(encoding="utf-8")
+        routes = set(re.findall(r'@app\.get\(\s*"([^"]+)"', main))
+        self.assertIn("/health", routes, "sanity: /health route not found")
+
+        for deployment in self._deployments():
+            if deployment["metadata"]["name"] != "enhanced-framework":
+                continue
+            for container in deployment["spec"]["template"]["spec"]["containers"]:
+                for probe in ("livenessProbe", "readinessProbe"):
+                    spec = container.get(probe)
+                    if not spec or "httpGet" not in spec:
+                        continue
+                    with self.subTest(probe=probe):
+                        self.assertIn(
+                            spec["httpGet"]["path"],
+                            routes,
+                            f"{probe} targets {spec['httpGet']['path']}, "
+                            "which the application does not route",
+                        )
+
+    def test_no_manifest_references_a_removed_service(self):
+        """Nothing should point at the phantom MCP server that was removed."""
+
+        for directory in (PRODUCTION_DIR, MONITORING_DIR):
+            for path in sorted(directory.glob("*.yaml")):
+                with self.subTest(path=path.name):
+                    self.assertNotIn(
+                        "mcp-server", path.read_text(encoding="utf-8")
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> Targets `main` directly and is independent of #1154 — the two share no file.
> Either may merge first.

## Canonical issue

Fixes #1127

## Outcome

`scripts/deployment/one-click-deploy.sh` can complete, and what it applies is
capable of becoming ready.

The script aborts at its first gate today. `REQUIRED_FILES` names paths that
moved under `infrastructure/`, plus two modules that never existed:

| Listed | Reality |
|---|---|
| `Dockerfile.production` | `infrastructure/docker/Dockerfile.production` |
| `k8s/production/deployment.yaml` | `infrastructure/k8s/production/deployment.yaml` |
| `k8s/production/service.yaml` | `infrastructure/k8s/production/service.yaml` |
| `k8s/monitoring/monitoring.yaml` | `infrastructure/k8s/monitoring/monitoring.yaml` |
| `mcp_server.py` | does not exist |
| `learning_app_processor.py` | does not exist |

Every `docker build -f` and `kubectl apply -f` target was stale the same way.

**Repairing only the paths would have made a worse failure newly reachable.**
`kubectl apply -f k8s/production/` also creates an `mcp-server` Deployment that
mounts ConfigMap `mcp-server-code` to run `/app/mcp_server.py`:

```console
$ grep -rn "mcp-server-code" .
infrastructure/k8s/production/deployment.yaml:151    # the reference itself
```

One hit — the reference. No manifest defines that ConfigMap, so the pod can
never become ready and `kubectl rollout status` could only time out. That is
exactly the hazard #1127 was split out of #1121 to avoid, so the phantom
resources are removed rather than left to CrashLoop behind a now-working script.

**The main container was also mis-described.** `enhanced-framework:latest` is
built by this same script from `infrastructure/docker/Dockerfile.production`, a
Python/uvicorn image:

```dockerfile
EXPOSE 8000
HEALTHCHECK CMD curl -f http://localhost:8000/health
CMD ["uvicorn", "server:app", ..., "--port", "8000"]
```

The Deployment described that tag as a **Node** app on port 3000 with `NODE_ENV`
and a readiness probe on `/ready`. `src/youtube_extension/main.py` serves
`/health` and `/readyz`; there is no `/ready` route, so readiness could never
pass. The manifest is the stale side.

## Scope

- Included: `scripts/deployment/one-click-deploy.sh`, the three manifests it
  applies (`infrastructure/k8s/production/deployment.yaml`,
  `infrastructure/k8s/production/service.yaml`,
  `infrastructure/k8s/monitoring/monitoring.yaml`), and a new regression suite.
- Explicitly excluded: application code, `infrastructure/docker/Dockerfile.production`,
  and anything owned by open PR #1122. No file in this diff is touched by
  another open PR.

## Risk

- Risk level: medium — this is the production rollout path, though it is
  currently non-functional, so the change moves it from "cannot run" to "runs".
- Failure mode: removing the `mcp-server` Deployment and Service is the only
  irreversible-looking step. If some out-of-tree consumer resolved
  `mcp-server.production.svc`, it would now fail DNS instead of failing to
  connect to a pod that never started. The grep above is the evidence that no
  in-tree consumer exists; `MCP_SERVER_URL` was read by nothing.
- Rollback: revert this commit. Nothing here mutates cluster state on its own —
  the manifests only take effect on the next deliberate `one-click-deploy.sh`
  run, and the deleted resources can be recreated by the revert.

## Verification

Run on the current head.

- `PYTHONPATH=. python3 -m unittest tests.unit.test_deployment_manifests` —
  **8/8 pass**.
- `PYTHONPATH=. python3 -m unittest tests.unit.test_agent_completion_gate` —
  **106/106 pass** on this branch, confirming no cross-contamination.
- `bash -n scripts/deployment/one-click-deploy.sh` — clean.
- All three manifests parse under `yaml.safe_load_all`.
- `grep -rnE "mcp-server|mcp_server|learning_app_processor" infrastructure/ scripts/deployment/`
  returns nothing.

`tests/unit/test_deployment_manifests.py` derives every expectation from the
repository rather than restating it, so the guards keep tracking the deployment
as it moves: every `REQUIRED_FILES` and `kubectl apply` path must resolve; every
mounted ConfigMap must be defined somewhere in the manifests; every Service
`targetPort` must be a declared `containerPort` of the Deployment it selects;
the container port must match the image's `EXPOSE`; and every probe path must be
a route in `main.py`.

The suite was **mutation-tested against all five original defects** — each
mutation applied, the suite run, the file restored:

```
CAUGHT   stale REQUIRED_FILES path (the #1127 bug itself)
CAUGHT   nonexistent module in REQUIRED_FILES
CAUGHT   stale kubectl apply directory
CAUGHT   port 3000 regression
CAUGHT   /ready probe regression
```

- [x] Focused tests
- [ ] Required CI — see below
- [ ] Review threads resolved

`agent-completion/truth-gate` is red for the reason documented in #1154: the
workflow runs on `pull_request_target` and therefore evaluates `main`'s copy of
the gate, so that fix cannot apply to its own pull request. `gitleaks (working tree)` is
a repo-wide `uv.lock` false positive, fixed separately in #1159; this branch is
cut from a `main` that predates that fix, so it stays red here until #1159 lands.
`Agent completion enforcement` fails on every open PR in the repository because
its trust policy is unprovisioned — surveyed and tracked in #1160. None of the
three failures is caused by this diff.

## Production evidence

Not applicable, and deliberately so: this PR is not deployed as part of merging
it. `one-click-deploy.sh` is operator-invoked and requires a live cluster plus
registry credentials that CI does not hold, so no preview or production rollout
can be attached to this head.

That absence is the reason the change is defended by structural assertions
instead. The five mutation results above are the substantive evidence: each one
reintroduces an original defect and is caught, which demonstrates the guards
detect this class of drift rather than merely passing today. The correctness
claims themselves are cross-checked against artifacts in the repository — the
image's `EXPOSE`, the routes registered in `main.py`, and the ConfigMaps the
manifests actually define — not against assumptions about the cluster.

## Notes for reviewers

- **Forward-compatible with #1122**, which changes this image's `CMD` to
  `uvicorn youtube_extension.main:app --port 8000`. Port and probes still match.
- `runAsUser: 1001` is deliberately kept even though the image declares
  `USER appuser`: `runAsNonRoot: true` needs a numeric user or the kubelet
  refuses the pod. `/app` is world-readable and uvicorn logs to stdout under
  `PYTHONUNBUFFERED=1`.
- **Known follow-up, out of scope:** Prometheus scrapes
  `enhanced-framework:80/metrics` but the app exposes no `/metrics` route. This
  does not block rollout, and adding one would touch application code owned by
  other open PRs.

## Agent handoff

- [x] One canonical issue is linked
- [x] No competing PR implements the same issue
- [x] Acceptance criteria are satisfied
- [ ] Required checks pass on the current head — two known repo-wide blockers, explained above
- [x] Human decision is requested only for product, security, irreversible infrastructure, or production approval