### PR TITLE
fix(deps): drop phantom python-jose to clear unfixable ecdsa advisory

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -19,5 +19,5 @@ paths = [
   # parso's digest at L5129). Verified: the file references only
   # https://pypi.org/simple + files.pythonhosted.org and contains no
   # credentials in URLs, so it cannot carry a real secret.
-  '''uv\.lock''',
+  '''^uv\.lock$''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,4 +14,10 @@ paths = [
   '''docs/security/.*''',
   # Test fixtures use obvious dummy keys (e.g. "xai-secret-123"), not real secrets.
   '''tests/.*''',
+  # uv.lock stores package integrity digests (`hash = "sha256:<64 hex>"`) and
+  # sizes. High-entropy hex triggers token rules (e.g. square-access-token on
+  # parso's digest at L5129). Verified: the file references only
+  # https://pypi.org/simple + files.pythonhosted.org and contains no
+  # credentials in URLs, so it cannot carry a real secret.
+  '''uv\.lock''',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "psycopg[binary]>=3.2,<4",
     "aiosqlite>=0.19.0",
-    "python-jose[cryptography]>=3.3.0",
     "passlib[bcrypt]>=1.7.4",
     "python-decouple>=3.8",
     "structlog>=23.2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,6 @@ aiosqlite>=0.19.0
 alembic>=1.12.0
 
 # Security & Auth
-python-jose[cryptography]>=3.3.0
 passlib[bcrypt]>=1.7.4
 
 # Configuration

--- a/uv.lock
+++ b/uv.lock
@@ -1521,18 +1521,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
-]
-
-[[package]]
 name = "envier"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -6019,25 +6007,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[package.optional-dependencies]
-cryptography = [
-    { name = "cryptography" },
-]
-
-[[package]]
 name = "python-json-logger"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6820,18 +6789,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
     { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
     { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]
@@ -8713,7 +8670,6 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-decouple" },
     { name = "python-dotenv" },
-    { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "qrcode", extra = ["pil"] },
@@ -8877,7 +8833,6 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "python-decouple", specifier = ">=3.8" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "qrcode", extras = ["pil"], specifier = ">=7.0" },


### PR DESCRIPTION

`dependency-review` and `gitleaks` fail on `main` itself, so every open PR
inherits two red checks that no PR author can fix. Both are addressed here.

1. ecdsa GHSA-wj6h-64fc-37mp (high) -- removal, not upgrade

   `gh api /advisories/GHSA-wj6h-64fc-37mp` reports:
     first_patched_version: null
     vulnerable_version_range: ">= 0"

   There is no patched release and upstream treats side-channel attacks as
   out of scope, so `dependency-review` fails on `main` permanently. It
   cannot be resolved by bumping.

   The sole path to `ecdsa` was `python-jose[cryptography]` declared in
   `pyproject.toml` and `requirements.txt`. `python-jose` is never imported:

     src/youtube_extension/backend/code_generator.py:1012
       inside `auth_imports = '''...from jose import JWTError, jwt...'''`,
       a FastAPI scaffold template emitted into generated projects
     src/youtube_extension/backend/code_generator.py:371
       `requirements.append("python-jose[cryptography]==3.3.0")`, building
       the *generated* project's requirements list
     scripts/archive/package-info/requires.txt:16
       archived build artifact

   All three are string literals. Removing the declaration therefore has no
   runtime effect. `uv lock` drops ecdsa, python-jose and transitive rsa.

2. gitleaks false positive on uv.lock

   uv.lock:5129 is parso-0.8.7's integrity digest
   (`hash = "sha256:eaaac4c9fdd...", size = 401824`), matched by the
   `square-access-token` rule at entropy 3.88 -- a package hash, not a
   credential. Verified the file references only https://pypi.org/simple and
   files.pythonhosted.org with zero credentials in URLs, so it cannot carry a
   real secret. Allowlisted by path in `.gitleaks.toml`.

Verification
  uv lock            -> Removed ecdsa v0.19.2, python-jose v3.5.0, rsa v4.9.1
  grep ecdsa uv.lock -> no matches, no dangling references
  gitleaks detect --no-git --config .gitleaks.toml (exact CI command)
                     -> uv.lock produces no finding

Follow-ups (not in this PR)
  * `passlib[bcrypt]` is phantom by the same test -- its only mention is the
    same template string at code_generator.py:1013. Left in place to keep
    this change scoped to the failing check.
  * Generated projects still receive `python-jose==3.3.0` via
    code_generator.py:371, handing users a package with an unfixable
    high-severity advisory. That is a product decision, filed separately.
  * CI pins gitleaks 8.18.4. Upstream has since fixed this rule, but 8.30.0
    surfaces two new `curl-auth-header` findings in
    docs/knowledge_prototypes/.../TECHNICAL_NOTES.md. Both are the literal
    placeholder `REDACTED_GOOGLE_API_KEY_ROTATE`, not live secrets -- but a
    version bump would need those allowlisted first.

