### PR TITLE
fix(ci): allowlist generated uv.lock in gitleaks secret scan

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,4 +14,9 @@ paths = [
   '''docs/security/.*''',
   # Test fixtures use obvious dummy keys (e.g. "xai-secret-123"), not real secrets.
   '''tests/.*''',
+  # Generated dependency lockfile: uv.lock records package registry URLs and
+  # sha256 content hashes, not credentials. Some package hashes trip default
+  # high-entropy rules (e.g. a "parso" sdist sha256 matches "square-access-token")
+  # as false positives, which fails `gitleaks detect --no-git` on every PR.
+  '''^uv\.lock$''',
 ]


### PR DESCRIPTION
## Canonical issue

No pre-existing tracking issue. Surfaced while reviewing **#1152** (`perf/redis-tag-gather`), whose CI was red on `gitleaks (working tree)`. The failure is not caused by #1152 — it is a repo-wide false positive. Please attach/create a canonical issue per your triage process if required.

## Outcome

Restores a green `gitleaks (working tree)` check across the repo. `gitleaks detect --no-git` scans the whole working tree, so it flags package **content hashes** in the generated `uv.lock` lockfile. The default `square-access-token` rule matches the `parso` sdist sha256 at `uv.lock:5129` (`sha256:eaaac4c9…`) — a false positive that fails the check on **every** PR, blocking the merge pipeline. This change allowlists the generated lockfile so the check passes.

## Scope

- Included: one allowlist path (`^uv\.lock$`) added to `.gitleaks.toml`, alongside the existing vendored-asset / test-fixture allowlists.
- Explicitly excluded: no change to gitleaks rules, no `.gitleaksignore` fingerprint pin (brittle — line numbers shift as the lockfile regenerates and other package hashes may trip the rule later), and no broadening to other lockfiles (only `uv.lock` has been observed to false-positive).

## Risk

- Risk level: low
- Failure mode: a real secret hand-committed into `uv.lock` would no longer be scanned. `uv.lock` is machine-generated (`uv`) and contains only registry URLs + content hashes, so this is not a realistic vector; excluding lockfiles from secret scanning is standard practice.
- Rollback: revert this one-line commit.

## Verification

Verified against head `e29bf07`.

- [x] Config validated — TOML parses; `^uv\.lock$` present in `allowlist.paths`.
- [ ] Focused tests — n/a (CI config only, no code path).
- [ ] Required CI — **gitleaks not installed in the review sandbox**, so the suppression could not be run locally; the `gitleaks (working tree)` check on this PR is the authoritative confirmation.
- [ ] Review threads resolved

## Production evidence

Not applicable — this changes a CI secret-scanning config only; no runtime or deployment surface is touched.

## Agent handoff

- [ ] One canonical issue is linked — see note above.
- [x] No competing PR implements the same issue.
- [x] Acceptance criteria are satisfied (scoped allowlist entry).
- [ ] Required checks pass on the current head — pending this PR's own gitleaks run.
- [ ] **Human decision requested (security):** this suppresses a secret-scanner finding. Although it is an unambiguous lockfile-hash false positive, the merge decision is intentionally left to a human — this PR is a **draft** and stages the change up to, but not including, merge.

## Agent provenance

Agent-authored (Claude Code, PR-remediation routine). Discovered during automated review of PR #1152; no provider run-id manifest is published because none applies to this out-of-band remediation. Scope above is authoritative.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuvMSJNV2oCyJBHe1E6cfr)_