### PR TITLE
fix(ci): stop gitleaks false-positive on uv.lock package digests

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -5,7 +5,18 @@
 useDefault = true
 
 [allowlist]
-description = "Paths excluded from secret scanning"
+description = "Paths and package-digest lines excluded from secret scanning"
+# Match the regexes below against the whole line, not just the captured secret,
+# so digest-only false positives can be scoped to their `sha256:` context.
+regexTarget = "line"
+regexes = [
+  # PyPI / uv lockfile package digests: `sha256:<64 hex>`. Gitleaks' default
+  # `square-access-token` rule (Square tokens begin "EAAA…") false-matches hex
+  # digests whose leading characters spell that prefix — e.g. parso 0.8.7's
+  # `sha256:eaaac4c9…` in uv.lock. These are public package hashes, not secrets.
+  # Scoped to the `sha256:` prefix so a real credential sharing a line is still caught.
+  '''sha256:[a-f0-9]{64}''',
+]
 paths = [
   # Vendored saved web pages from Google (AI Studio / APIs Explorer): contain
   # Google's own public page keys, not EventRelay credentials.


### PR DESCRIPTION
## Canonical issue

No pre-existing tracking issue. Surfaced while triaging the `Secret Scan / gitleaks` failure that blocks **#1152** (and, being a working-tree scan of `uv.lock`, every other open PR).

## Outcome

`Secret Scan / gitleaks` no longer fails on PyPI/uv lockfile package digests. Gitleaks' default `square-access-token` rule (Square tokens begin `EAAA…`) false-matches sha256 hex digests whose leading characters spell that prefix — concretely `parso 0.8.7`'s `sha256:eaaac4c9…` at `uv.lock:5129`. Because the job runs `gitleaks detect --no-git` over the whole tree, this is a repo-wide CI blocker unrelated to any individual change.

## Scope

- Included: one line-scoped allowlist regex in `.gitleaks.toml` for `sha256:<64 hex>` package digests.
- Explicitly excluded: allowlisting `uv.lock` wholesale (would stop scanning the file for genuinely embedded credentials, e.g. a private-index URL with inline creds). The regex is scoped to the `sha256:` digest context instead, so a real secret sharing a lockfile line is still detected.

## Risk

- Risk level: low
- Failure mode: an over-broad allowlist could mask a real secret. Mitigated by anchoring the regex to `sha256:` + exactly 64 hex chars (the machine-generated digest shape), which no real Square/AWS/GitHub token matches.
- Rollback: revert this one-commit change; no runtime, dependency, or schema impact.

## Verification

Head `ddae32f`.

- [x] `.gitleaks.toml` parses (`tomllib`)
- [x] The `parso 0.8.7` digest line **is** allowlisted by the new regex
- [x] A control line with an embedded `EAAA…`-style token in a URL is **not** allowlisted
- [ ] Live `gitleaks` run — the binary isn't installed in this sandbox, so this PR's own `Secret Scan / gitleaks` check is the authoritative validation (fail-safe: a malformed config surfaces as a failed check here rather than silently).

## Production evidence

Not applicable — CI-configuration change with no runtime surface.

## Agent handoff

- [x] Change is minimal and reversible
- [x] Fix verified against the real false-positive line and a negative control
- [ ] Human decision requested: this touches a **security-scanning control**, so it is left as a draft for a maintainer to review and merge.

## Agent provenance

Agent-authored by a scheduled PR-remediation routine. A structured `agent-lock-manifest` with a provider run-id is not available from this run; leaving provenance for a maintainer rather than fabricating identifiers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8r8RAPkzfcD559FyzB52M)_