### PR TITLE
perf(web): index events by id in ResultsViewer

### DIFF
--- a/apps/web/src/components/ResultsViewer.tsx
+++ b/apps/web/src/components/ResultsViewer.tsx
@@ -2,6 +2,7 @@
 
 import { clsx } from 'clsx';
 import { Check } from 'lucide-react';
+import { useMemo } from 'react';
 import type { AgentExecution, ExtractedEvent } from '@/lib/types';
 
 interface ResultsViewerProps {
@@ -19,7 +20,14 @@ interface ResultsViewerProps {
  * @returns The results section for completed executions with results, or `null` when none are available.
  */
 export default function ResultsViewer({ executions, events, className }: ResultsViewerProps) {
-  const completed = executions.filter((e) => e.status === 'complete' && e.result);
+  const completed = useMemo(
+    () => executions.filter((e) => e.status === 'complete' && e.result),
+    [executions],
+  );
+
+  // Index events by id so each rendered row resolves its event in O(1) rather than
+  // rescanning the whole `events` array, which made rendering O(completed x events).
+  const eventsById = useMemo(() => new Map(events.map((e) => [e.id, e])), [events]);
 
   if (completed.length === 0) return null;
 
@@ -31,7 +39,7 @@ export default function ResultsViewer({ executions, events, className }: Results
 
       <div className="space-y-3">
         {completed.map((exec) => {
-          const event = events.find((e) => e.id === exec.event_id);
+          const event = exec.event_id ? eventsById.get(exec.event_id) : undefined;
           return (
             <div
               key={exec.agent_id}


### PR DESCRIPTION
## Canonical issue

Closes #1167

## Outcome

`ResultsViewer` resolved each row's event with `events.find()` **inside** `completed.map()`, so the
entire `events` array was rescanned once per rendered row. Rendering was O(completed x events).

This indexes `events` into a `Map` once per `events` change and looks each row up in O(1), and
memoises the `completed` filter on `executions`. Total render work is now O(completed + events).

| completed rows | events | comparisons before | comparisons after |
|---|---|---|---|
| 10 | 50 | 500 | 60 |
| 50 | 200 | 10,000 | 250 |
| 100 | 500 | 50,000 | 600 |

`ResultsViewer` renders inside the live pipeline view, which re-renders on every streamed update, so
this cost was paid continuously for the duration of a job rather than once.

Secondary win: `completed` no longer rebuilds when `executions` is referentially unchanged, so
re-renders driven by unrelated parent state (e.g. a `className` change) no longer re-filter.

## Scope

**In scope** — `apps/web/src/components/ResultsViewer.tsx` only:
- `import { useMemo } from 'react'`
- `completed` wrapped in `useMemo(..., [executions])`
- new `eventsById = useMemo(() => new Map(events.map((e) => [e.id, e])), [events])`
- `events.find((e) => e.id === exec.event_id)` -> `exec.event_id ? eventsById.get(exec.event_id) : undefined`

**Out of scope** — deliberately not touched:
- wrapping the component in `React.memo` (changes the component's public contract)
- the parent's re-render cadence
- the same `.find()`-in-`.map()` pattern elsewhere in the tree

**No dependency changes.**

## Risk

**Low.** No behaviour change and no public API change.

The one semantic edge worth calling out: `AgentExecution.event_id` is optional (`event_id?: string`,
`types.ts:98`). The old `events.find((e) => e.id === exec.event_id)` returned `undefined` when
`event_id` was `undefined`, because `ExtractedEvent.id` is a required `string` and so never matches
`undefined`. The new code guards explicitly with `exec.event_id ? ... : undefined`, producing the
identical result. The `{event && ...}` render guard downstream is unchanged.

Duplicate event ids would resolve to the *last* occurrence under `Map` versus the *first* under
`.find()`. `ExtractedEvent.id` is an identity field and the existing `key={exec.agent_id}` already
assumes uniqueness, so this is not reachable in practice.

Rules-of-hooks: both `useMemo` calls are declared **above** the `if (completed.length === 0) return null;`
early return, so hook order is stable across renders. Confirmed by `npm run lint` passing.

## Verification

At head `33e438e86e2863a7c37fc743b01e5125b342da62`:

```
$ cd apps/web && npm run lint
> eslint src middleware.ts
(clean - no rules-of-hooks violation)

$ npm run type-check
> tsc --noEmit
(clean)

$ npm run build:web        # from repo root
Compiled successfully - all 23 routes emitted

$ npm test                 # vitest
Test Files  1 failed | 43 passed (44)
     Tests  1 failed | 244 passed (245)
```

The single failure is `src/app/api/__tests__/billing-chat-gating.test.ts >
"blocks free tier after daily quota"`, a 5s timeout. It is **pre-existing and unrelated** — verified
by stashing this change and re-running on clean `main`:

```
$ git stash && npx vitest run src/app/api/__tests__/billing-chat-gating.test.ts
     × blocks free tier after daily quota 5004ms
     Tests  1 failed | 1 passed (2)
```

Same failure, same duration, without this change applied.

No component-render test is added: the web workspace has `vitest` but no
`@testing-library/react`, and adding it would be a dependency change (out of scope per #1167). The
change is covered by `tsc --noEmit` for the optional-`event_id` narrowing and by ESLint's
`react-hooks/rules-of-hooks` for hook placement.

## Production evidence

`ResultsViewer` is rendered from the live pipeline view and receives `executions` and `events` that
both grow over the lifetime of a job. Because it re-renders on every streamed pipeline update, the
O(completed x events) scan ran on each update rather than once — the quadratic term was multiplied by
the update count. Indexing removes the inner scan entirely.

The `useMemo` on `completed` additionally prevents re-filtering on renders where `executions` did not
change, which is the common case when only sibling state updates.

## Agent handoff

- Reviewed by `@coderabbitai`.
- Follow-up candidates, intentionally excluded here: `React.memo` on the component, and auditing other
  `.find()`-inside-`.map()` call sites in `apps/web/src`.
- Note for reviewers: `@linear` is an Organization account on GitHub and does not respond to mentions,
  and no Linear MCP server is configured in this environment. `@coderabbitai` is the repo's active
  review agent and is used in its place.
