### PR TITLE
perf: delete expired Firestore states concurrently under a bound

### DIFF
--- a/src/youtube_extension/services/cloud/firestore_state.py
+++ b/src/youtube_extension/services/cloud/firestore_state.py
@@ -30,9 +30,14 @@ logger = logging.getLogger(__name__)
 # Size of the worker pool that drains expired documents in cleanup_old_states().
 # Cleanup can match an unbounded number of documents, so deletes are pulled from
 # a shared iterator by this many workers rather than dispatched all at once.
-# Sizing the pool -- rather than gating a full fan-out -- bounds the in-flight
-# delete RPCs and the number of allocated task objects by the same constant.
-CLEANUP_DELETE_CONCURRENCY = 16
+# Both controls are configurable so operators can tune cleanup independently of
+# an application deployment; invalid numeric values fail fast during startup.
+CLEANUP_DELETE_CONCURRENCY = max(
+    1, int(os.getenv("CLEANUP_DELETE_CONCURRENCY", "16"))
+)
+CLEANUP_DELETE_TIMEOUT_SECONDS = max(
+    0.001, float(os.getenv("CLEANUP_DELETE_TIMEOUT_SECONDS", "30"))
+)
 
 
 @dataclass
@@ -352,7 +357,7 @@ class FirestoreStateService:
                 except StopIteration:
                     return
                 try:
-                    await doc.reference.delete()
+                    await doc.reference.delete(timeout=CLEANUP_DELETE_TIMEOUT_SECONDS)
                     succeeded += 1
                 except Exception as exc:  # noqa: BLE001 - tallied and logged below
                     failures.append(exc)

--- a/src/youtube_extension/services/cloud/firestore_state.py
+++ b/src/youtube_extension/services/cloud/firestore_state.py
@@ -9,6 +9,7 @@ Replaces in-memory caching for cloud-native, scalable deployment.
 
 import asyncio
 import logging
+import math
 import os
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -27,16 +28,52 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-# Size of the worker pool that drains expired documents in cleanup_old_states().
+def _positive_int_env(name: str, default: int) -> int:
+    """Read a positive integer override, failing fast on invalid configuration.
+
+    An unset or blank variable falls back to ``default`` (blank is common when a
+    compose/Helm template renders an empty value). Anything else must parse to an
+    integer >= 1; out-of-range values raise rather than being silently clamped,
+    so an operator typo surfaces at startup instead of changing behaviour quietly.
+    """
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    value = int(raw.strip())
+    if value < 1:
+        raise ValueError(f"{name} must be >= 1, got {raw!r}")
+    return value
+
+
+def _positive_finite_float_env(name: str, default: float) -> float:
+    """Read a positive, finite float override, failing fast on invalid configuration.
+
+    ``float()`` happily accepts ``inf``/``-inf``/``nan``. An infinite timeout would
+    silently remove the per-delete deadline (or be rejected downstream by gRPC
+    timeout validation), and ``nan`` compares false against every bound, so
+    non-finite values are rejected outright rather than clamped into range.
+    """
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    value = float(raw.strip())
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(
+            f"{name} must be a positive, finite number of seconds, got {raw!r}"
+        )
+    return value
+
+
+# Worker-pool size and per-delete deadline used by cleanup_old_states().
 # Cleanup can match an unbounded number of documents, so deletes are pulled from
 # a shared iterator by this many workers rather than dispatched all at once.
-# Both controls are configurable so operators can tune cleanup independently of
-# an application deployment; invalid numeric values fail fast during startup.
-CLEANUP_DELETE_CONCURRENCY = max(
-    1, int(os.getenv("CLEANUP_DELETE_CONCURRENCY", "16"))
-)
-CLEANUP_DELETE_TIMEOUT_SECONDS = max(
-    0.001, float(os.getenv("CLEANUP_DELETE_TIMEOUT_SECONDS", "30"))
+# Sizing the pool -- rather than gating a full fan-out -- bounds the in-flight
+# delete RPCs and the number of allocated task objects by the same constant.
+# Both controls are overridable so operators can tune cleanup independently of an
+# application deployment; invalid values fail fast during import.
+CLEANUP_DELETE_CONCURRENCY = _positive_int_env("CLEANUP_DELETE_CONCURRENCY", 16)
+CLEANUP_DELETE_TIMEOUT_SECONDS = _positive_finite_float_env(
+    "CLEANUP_DELETE_TIMEOUT_SECONDS", 30.0
 )
 
 

--- a/src/youtube_extension/services/cloud/firestore_state.py
+++ b/src/youtube_extension/services/cloud/firestore_state.py
@@ -27,9 +27,11 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-# Upper bound on concurrent delete RPCs issued by cleanup_old_states(). Cleanup
-# can match an unbounded number of expired documents, so deletes are fanned out
-# under a semaphore rather than dispatched all at once.
+# Size of the worker pool that drains expired documents in cleanup_old_states().
+# Cleanup can match an unbounded number of documents, so deletes are pulled from
+# a shared iterator by this many workers rather than dispatched all at once.
+# Sizing the pool -- rather than gating a full fan-out -- bounds the in-flight
+# delete RPCs and the number of allocated task objects by the same constant.
 CLEANUP_DELETE_CONCURRENCY = 16
 
 

--- a/src/youtube_extension/services/cloud/firestore_state.py
+++ b/src/youtube_extension/services/cloud/firestore_state.py
@@ -330,28 +330,43 @@ class FirestoreStateService:
             logger.info(f"Cleaned up 0 old states (>{days} days)")
             return 0
 
-        # Delete concurrently. Each delete is an independent network round-trip,
-        # so issuing them sequentially made cleanup cost O(n) round-trips. The
-        # semaphore bounds in-flight RPCs so a large backlog cannot flood
-        # Firestore, and return_exceptions keeps one failure from abandoning
-        # deletes that are already in flight.
-        semaphore = asyncio.Semaphore(CLEANUP_DELETE_CONCURRENCY)
+        # Delete with a fixed pool of workers pulling from a shared iterator.
+        # Deleting sequentially made cleanup latency scale with the size of the
+        # expired backlog. The pool overlaps up to CLEANUP_DELETE_CONCURRENCY
+        # deletes at a time while keeping *both* the in-flight RPCs and the
+        # number of pending task objects bounded -- gather() over every document
+        # would allocate one task per document up front, which is unsafe for a
+        # query whose result set has no limit. Failures are tallied rather than
+        # raised so one bad delete cannot abandon the rest of the backlog.
+        pending = iter(docs)
+        succeeded = 0
+        failures: list[Exception] = []
 
-        async def _delete_one(doc: Any) -> None:
-            async with semaphore:
-                await doc.reference.delete()
+        async def _delete_worker() -> None:
+            nonlocal succeeded
+            while True:
+                try:
+                    doc = next(pending)
+                except StopIteration:
+                    return
+                try:
+                    await doc.reference.delete()
+                    succeeded += 1
+                except Exception as exc:  # noqa: BLE001 - tallied and logged below
+                    failures.append(exc)
 
-        results = await asyncio.gather(
-            *(_delete_one(doc) for doc in docs),
-            return_exceptions=True,
+        await asyncio.gather(
+            *(
+                _delete_worker()
+                for _ in range(min(CLEANUP_DELETE_CONCURRENCY, len(docs)))
+            )
         )
 
-        failures = [r for r in results if isinstance(r, BaseException)]
-        count = len(results) - len(failures)
+        count = succeeded
 
         if failures:
             logger.warning(
-                f"Failed to delete {len(failures)} of {len(results)} old states; "
+                f"Failed to delete {len(failures)} of {len(docs)} old states; "
                 f"first error: {failures[0]!r}"
             )
 

--- a/src/youtube_extension/services/cloud/firestore_state.py
+++ b/src/youtube_extension/services/cloud/firestore_state.py
@@ -7,6 +7,7 @@ Manages shared state across pipeline stages using Google Cloud Firestore.
 Replaces in-memory caching for cloud-native, scalable deployment.
 """
 
+import asyncio
 import logging
 import os
 from dataclasses import asdict, dataclass
@@ -25,6 +26,11 @@ except ImportError:
 
 
 logger = logging.getLogger(__name__)
+
+# Upper bound on concurrent delete RPCs issued by cleanup_old_states(). Cleanup
+# can match an unbounded number of expired documents, so deletes are fanned out
+# under a semaphore rather than dispatched all at once.
+CLEANUP_DELETE_CONCURRENCY = 16
 
 
 @dataclass
@@ -320,11 +326,34 @@ class FirestoreStateService:
         query = collection.where('created_at', '<', cutoff_date)
         docs = await query.get()
 
-        # Delete in batch
-        count = 0
-        for doc in docs:
-            await doc.reference.delete()
-            count += 1
+        if not docs:
+            logger.info(f"Cleaned up 0 old states (>{days} days)")
+            return 0
+
+        # Delete concurrently. Each delete is an independent network round-trip,
+        # so issuing them sequentially made cleanup cost O(n) round-trips. The
+        # semaphore bounds in-flight RPCs so a large backlog cannot flood
+        # Firestore, and return_exceptions keeps one failure from abandoning
+        # deletes that are already in flight.
+        semaphore = asyncio.Semaphore(CLEANUP_DELETE_CONCURRENCY)
+
+        async def _delete_one(doc: Any) -> None:
+            async with semaphore:
+                await doc.reference.delete()
+
+        results = await asyncio.gather(
+            *(_delete_one(doc) for doc in docs),
+            return_exceptions=True,
+        )
+
+        failures = [r for r in results if isinstance(r, BaseException)]
+        count = len(results) - len(failures)
+
+        if failures:
+            logger.warning(
+                f"Failed to delete {len(failures)} of {len(results)} old states; "
+                f"first error: {failures[0]!r}"
+            )
 
         logger.info(f"Cleaned up {count} old states (>{days} days)")
         return count

--- a/tests/unit/test_firestore_state.py
+++ b/tests/unit/test_firestore_state.py
@@ -16,6 +16,8 @@ fake `firestore` module object on the target module.
 from __future__ import annotations
 
 import asyncio
+import math
+import os
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -726,6 +728,69 @@ class TestListStates:
             await svc.list_states(limit=50)
         coll_ref.order_by.assert_called_once()
         query.limit.assert_called_once_with(50)
+
+
+# ===========================================================================
+# Module-level cleanup configuration parsing
+# ===========================================================================
+
+
+class TestCleanupConfigEnvParsing:
+    """Tests for the env-override parsers backing the cleanup constants.
+
+    ``float()`` accepts ``inf``/``-inf``/``nan``, so an unvalidated timeout
+    override could silently remove the per-delete deadline. These tests pin that
+    non-finite and non-positive values are rejected rather than clamped.
+    """
+
+    @pytest.mark.parametrize("raw", ["inf", "Infinity", "-inf", "nan", "0", "-1", "0.0"])
+    def test_float_env_rejects_non_finite_and_non_positive(self, raw):
+        with patch.dict(os.environ, {"CLEANUP_TEST_TIMEOUT": raw}, clear=False):
+            with pytest.raises(ValueError, match="positive, finite"):
+                _mod._positive_finite_float_env("CLEANUP_TEST_TIMEOUT", 30.0)
+
+    def test_float_env_rejects_malformed_value(self):
+        with patch.dict(os.environ, {"CLEANUP_TEST_TIMEOUT": "abc"}, clear=False):
+            with pytest.raises(ValueError):
+                _mod._positive_finite_float_env("CLEANUP_TEST_TIMEOUT", 30.0)
+
+    @pytest.mark.parametrize("raw", ["", "   "])
+    def test_float_env_blank_falls_back_to_default(self, raw):
+        with patch.dict(os.environ, {"CLEANUP_TEST_TIMEOUT": raw}, clear=False):
+            assert _mod._positive_finite_float_env("CLEANUP_TEST_TIMEOUT", 30.0) == 30.0
+
+    def test_float_env_unset_falls_back_to_default(self):
+        os.environ.pop("CLEANUP_TEST_TIMEOUT", None)
+        assert _mod._positive_finite_float_env("CLEANUP_TEST_TIMEOUT", 30.0) == 30.0
+
+    def test_float_env_parses_valid_override(self):
+        with patch.dict(os.environ, {"CLEANUP_TEST_TIMEOUT": " 12.5 "}, clear=False):
+            assert _mod._positive_finite_float_env("CLEANUP_TEST_TIMEOUT", 30.0) == 12.5
+
+    @pytest.mark.parametrize("raw", ["0", "-4"])
+    def test_int_env_rejects_non_positive(self, raw):
+        with patch.dict(os.environ, {"CLEANUP_TEST_POOL": raw}, clear=False):
+            with pytest.raises(ValueError, match=">= 1"):
+                _mod._positive_int_env("CLEANUP_TEST_POOL", 16)
+
+    @pytest.mark.parametrize("raw", ["abc", "1.5", "inf"])
+    def test_int_env_rejects_malformed_value(self, raw):
+        with patch.dict(os.environ, {"CLEANUP_TEST_POOL": raw}, clear=False):
+            with pytest.raises(ValueError):
+                _mod._positive_int_env("CLEANUP_TEST_POOL", 16)
+
+    def test_int_env_blank_falls_back_to_default(self):
+        with patch.dict(os.environ, {"CLEANUP_TEST_POOL": ""}, clear=False):
+            assert _mod._positive_int_env("CLEANUP_TEST_POOL", 16) == 16
+
+    def test_int_env_parses_valid_override(self):
+        with patch.dict(os.environ, {"CLEANUP_TEST_POOL": " 4 "}, clear=False):
+            assert _mod._positive_int_env("CLEANUP_TEST_POOL", 16) == 4
+
+    def test_module_defaults_are_positive_and_finite(self):
+        assert _mod.CLEANUP_DELETE_CONCURRENCY >= 1
+        assert math.isfinite(_mod.CLEANUP_DELETE_TIMEOUT_SECONDS)
+        assert _mod.CLEANUP_DELETE_TIMEOUT_SECONDS > 0
 
 
 # ===========================================================================

--- a/tests/unit/test_firestore_state.py
+++ b/tests/unit/test_firestore_state.py
@@ -15,6 +15,7 @@ fake `firestore` module object on the target module.
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -776,6 +777,83 @@ class TestCleanupOldStates:
         # Call with custom days — just ensure it runs without error
         count = await svc.cleanup_old_states(days=30)
         assert count == 0
+
+    @staticmethod
+    def _tracking_docs(n: int) -> tuple[list, dict]:
+        """Build n mock docs whose deletes record peak overlap."""
+        stats = {"in_flight": 0, "peak": 0}
+
+        async def _tracked() -> None:
+            stats["in_flight"] += 1
+            stats["peak"] = max(stats["peak"], stats["in_flight"])
+            # Yield so sibling deletes get a chance to start. Under the previous
+            # sequential loop nothing else could be running here.
+            await asyncio.sleep(0)
+            stats["in_flight"] -= 1
+
+        docs = []
+        for _ in range(n):
+            doc = MagicMock()
+            doc.reference = MagicMock()
+            doc.reference.delete = AsyncMock(side_effect=_tracked)
+            docs.append(doc)
+        return docs, stats
+
+    async def test_cleanup_deletes_overlap_instead_of_running_sequentially(self):
+        """Deletes must overlap. The sequential loop this replaced had peak overlap 1."""
+        svc, _, _, _, _, coll_ref, query = _make_service_with_db()
+        docs, stats = self._tracking_docs(8)
+        query.get = AsyncMock(return_value=docs)
+
+        count = await svc.cleanup_old_states(days=7)
+
+        assert count == 8
+        assert stats["peak"] > 1, (
+            f"deletes never overlapped (peak={stats['peak']}); "
+            "cleanup is still issuing one round-trip at a time"
+        )
+
+    async def test_cleanup_bounds_in_flight_deletes(self):
+        """A large backlog must not fan out unbounded concurrent RPCs."""
+        svc, _, _, _, _, coll_ref, query = _make_service_with_db()
+        limit = _mod.CLEANUP_DELETE_CONCURRENCY
+        docs, stats = self._tracking_docs(limit * 3)
+        query.get = AsyncMock(return_value=docs)
+
+        count = await svc.cleanup_old_states(days=7)
+
+        assert count == limit * 3
+        assert stats["peak"] <= limit, (
+            f"peak in-flight deletes {stats['peak']} exceeded the "
+            f"CLEANUP_DELETE_CONCURRENCY bound of {limit}"
+        )
+
+    async def test_cleanup_failure_does_not_abandon_remaining_deletes(self):
+        """One failing delete must not strand the rest, and must not be counted."""
+        svc, _, _, _, _, coll_ref, query = _make_service_with_db()
+
+        ok_before = MagicMock()
+        ok_before.reference = MagicMock()
+        ok_before.reference.delete = AsyncMock()
+
+        failing = MagicMock()
+        failing.reference = MagicMock()
+        failing.reference.delete = AsyncMock(side_effect=RuntimeError("firestore boom"))
+
+        ok_after = MagicMock()
+        ok_after.reference = MagicMock()
+        ok_after.reference.delete = AsyncMock()
+
+        query.get = AsyncMock(return_value=[ok_before, failing, ok_after])
+
+        count = await svc.cleanup_old_states(days=7)
+
+        # Only the two successful deletes are reported.
+        assert count == 2
+        # The delete queued after the failure still ran; the sequential loop
+        # would have propagated the error and skipped it entirely.
+        ok_before.reference.delete.assert_awaited_once()
+        ok_after.reference.delete.assert_awaited_once()
 
 
 # ===========================================================================

--- a/tests/unit/test_firestore_state.py
+++ b/tests/unit/test_firestore_state.py
@@ -855,31 +855,42 @@ class TestCleanupOldStates:
         )
 
     async def test_cleanup_failure_does_not_abandon_remaining_deletes(self):
-        """One failing delete must not strand the rest, and must not be counted."""
+        """One failing delete must not strand the rest, and must not be counted.
+
+        The pool is deliberately narrowed to a single worker while the backlog is
+        larger, so the *same* worker whose delete raises has to keep pulling from
+        the shared iterator. With a pool wider than the backlog every worker
+        handles exactly one document and the continuation path is never taken --
+        the assertions below would then hold even for a worker that returned on
+        its first exception.
+        """
         svc, _, _, _, _, coll_ref, query = _make_service_with_db()
 
-        ok_before = MagicMock()
-        ok_before.reference = MagicMock()
-        ok_before.reference.delete = AsyncMock()
+        pool_size = 1
+        doc_count = 5
 
-        failing = MagicMock()
-        failing.reference = MagicMock()
-        failing.reference.delete = AsyncMock(side_effect=RuntimeError("firestore boom"))
+        docs = []
+        for i in range(doc_count):
+            doc = MagicMock(name=f"doc{i}")
+            doc.reference = MagicMock()
+            # Fail on the very first document the lone worker touches.
+            doc.reference.delete = AsyncMock(
+                side_effect=RuntimeError("firestore boom") if i == 0 else None
+            )
+            docs.append(doc)
 
-        ok_after = MagicMock()
-        ok_after.reference = MagicMock()
-        ok_after.reference.delete = AsyncMock()
+        query.get = AsyncMock(return_value=docs)
 
-        query.get = AsyncMock(return_value=[ok_before, failing, ok_after])
+        with patch.object(_mod, "CLEANUP_DELETE_CONCURRENCY", pool_size):
+            count = await svc.cleanup_old_states(days=7)
 
-        count = await svc.cleanup_old_states(days=7)
-
-        # Only the two successful deletes are reported.
-        assert count == 2
-        # The delete queued after the failure still ran; the sequential loop
-        # would have propagated the error and skipped it entirely.
-        ok_before.reference.delete.assert_awaited_once()
-        ok_after.reference.delete.assert_awaited_once()
+        # Only the successful deletes are reported.
+        assert count == doc_count - 1
+        # Every document was attempted exactly once. The four after the failure
+        # were reachable only because the worker continued draining the queue;
+        # the original sequential loop propagated the error and skipped them.
+        for doc in docs:
+            doc.reference.delete.assert_awaited_once()
 
 
 # ===========================================================================

--- a/tests/unit/test_firestore_state.py
+++ b/tests/unit/test_firestore_state.py
@@ -760,6 +760,19 @@ class TestCleanupOldStates:
         doc1.reference.delete.assert_awaited_once()
         doc2.reference.delete.assert_awaited_once()
 
+    async def test_cleanup_passes_configured_delete_timeout(self):
+        svc, _, _, _, _, coll_ref, query = _make_service_with_db()
+        doc = MagicMock()
+        doc.reference = MagicMock()
+        doc.reference.delete = AsyncMock()
+        query.get = AsyncMock(return_value=[doc])
+
+        with patch.object(_mod, "CLEANUP_DELETE_TIMEOUT_SECONDS", 12.5):
+            count = await svc.cleanup_old_states(days=7)
+
+        assert count == 1
+        doc.reference.delete.assert_awaited_once_with(timeout=12.5)
+
     async def test_cleanup_queries_with_where_clause(self):
         svc, _, _, _, _, coll_ref, query = _make_service_with_db()
         query.get = AsyncMock(return_value=[])
@@ -783,7 +796,8 @@ class TestCleanupOldStates:
         """Build n mock docs whose deletes record peak overlap."""
         stats = {"in_flight": 0, "peak": 0, "peak_tasks": 0}
 
-        async def _tracked() -> None:
+        async def _tracked(*, timeout: float) -> None:
+            assert timeout > 0
             stats["in_flight"] += 1
             stats["peak"] = max(stats["peak"], stats["in_flight"])
             # Task count reflects how many coroutines were *allocated*, which is

--- a/tests/unit/test_firestore_state.py
+++ b/tests/unit/test_firestore_state.py
@@ -781,11 +781,14 @@ class TestCleanupOldStates:
     @staticmethod
     def _tracking_docs(n: int) -> tuple[list, dict]:
         """Build n mock docs whose deletes record peak overlap."""
-        stats = {"in_flight": 0, "peak": 0}
+        stats = {"in_flight": 0, "peak": 0, "peak_tasks": 0}
 
         async def _tracked() -> None:
             stats["in_flight"] += 1
             stats["peak"] = max(stats["peak"], stats["in_flight"])
+            # Task count reflects how many coroutines were *allocated*, which is
+            # a stricter bound than how many RPCs are in flight.
+            stats["peak_tasks"] = max(stats["peak_tasks"], len(asyncio.all_tasks()))
             # Yield so sibling deletes get a chance to start. Under the previous
             # sequential loop nothing else could be running here.
             await asyncio.sleep(0)
@@ -826,6 +829,29 @@ class TestCleanupOldStates:
         assert stats["peak"] <= limit, (
             f"peak in-flight deletes {stats['peak']} exceeded the "
             f"CLEANUP_DELETE_CONCURRENCY bound of {limit}"
+        )
+
+    async def test_cleanup_bounds_allocated_delete_tasks_not_just_rpcs(self):
+        """A worker pool must not allocate one task per document.
+
+        Gathering over every document would schedule len(docs) tasks up front,
+        so a large backlog would cost unbounded task/event-loop memory even
+        though only CLEANUP_DELETE_CONCURRENCY RPCs are in flight. The query
+        driving this has no limit, so that allocation must stay bounded too.
+        """
+        svc, _, _, _, _, coll_ref, query = _make_service_with_db()
+        limit = _mod.CLEANUP_DELETE_CONCURRENCY
+        docs, stats = self._tracking_docs(limit * 3)
+        query.get = AsyncMock(return_value=docs)
+
+        count = await svc.cleanup_old_states(days=7)
+
+        assert count == limit * 3
+        # Allow a small margin for the enclosing test task and gather bookkeeping.
+        assert stats["peak_tasks"] <= limit + 3, (
+            f"cleanup allocated {stats['peak_tasks']} concurrent tasks for "
+            f"{limit * 3} documents; delete tasks are not bounded by the "
+            f"CLEANUP_DELETE_CONCURRENCY worker pool of {limit}"
         )
 
     async def test_cleanup_failure_does_not_abandon_remaining_deletes(self):


### PR DESCRIPTION
## Canonical issue

Closes #1169

## Outcome

`FirestoreStateService.cleanup_old_states()` deleted expired documents in a
sequential `await` loop, so every delete waited for the previous one to
complete — despite a `# Delete in batch` comment claiming otherwise.

Deletes are now handled by a fixed pool of `CLEANUP_DELETE_CONCURRENCY = 16`
workers pulling from a shared iterator over the expired documents.

**What this does and does not improve** (corrected after review — see
[this comment](https://github.com/groupthinking/EventRelay/pull/1170#discussion_r0)):

| | |
|---|---|
| ✅ Improves | **Wall-clock latency.** Up to 16 deletes overlap per latency wave, so N sequential waves collapse to ~`ceil(N/16)` waves. |
| ❌ Does **not** change | **Firestore request count or quota usage.** This still issues exactly one `delete()` RPC per document. |

An earlier revision of this description claimed a reduction in "network
round-trips", which wrongly implied reduced request/quota usage. Only a native
batch write would do that; a bounded fan-out does not. The claim has been
reworded throughout.

Two correctness improvements come with it:

- One failing delete no longer abandons the rest of the backlog. Previously the
  exception propagated out of the loop and every remaining document was skipped.
- The returned count reflects deletes that **actually succeeded**, instead of
  being lost along with the propagating exception.

## Scope

| | |
|---|---|
| In scope | The delete fan-out inside `cleanup_old_states()`; four regression tests |
| Out of scope | The query/`where` clause, caching, singleton lifecycle, the method signature |

Two files changed: `src/youtube_extension/services/cloud/firestore_state.py` and
`tests/unit/test_firestore_state.py` (tests only).

## Design notes

**Why a worker pool rather than `gather` + semaphore?** The first revision of
this PR used `asyncio.gather()` over a generator with a semaphore inside each
coroutine. Review correctly pointed out that `gather` allocates **one task per
document up front**, before the semaphore gates anything — so a large backlog
still cost unbounded task and event-loop memory, and the cleanup query has no
`limit`. The worker pool bounds *both* in-flight RPCs and allocated tasks by the
same constant. This is measured, not assumed — see the task-allocation test below.

Pulling from the shared iterator with `next()` needs no lock: the event loop is
single-threaded and there is no `await` between taking a document and using it.

**Why not Firestore's native `AsyncWriteBatch`?** It would genuinely reduce
request count, which this does not. It also caps at 500 operations, so correct
use requires chunking plus a second error path for partial batch failure. Given
that cleanup is a periodic maintenance job, the latency win here is the valuable
part and the smaller diff is the better trade. Native batching is a reasonable
follow-up if cleanup volume grows enough to make quota the binding constraint.

**Why a call-scoped pool rather than the per-instance/loop-keyed semaphore in
#1152?** That PR needed loop-keyed laziness because `intelligent_cache.py`
constructs its singleton **at import time**, binding an eagerly-created
`asyncio.Semaphore` to the wrong event loop. Here `_firestore_service` is created
lazily *inside* `async def get_firestore_service()`, so there is no import-time
loop hazard, and cleanup is a periodic job rather than a hot concurrent path.

## Risk

**Low.** One behavioural change is intentional: cleanup no longer raises when an
individual delete fails. It logs a warning naming the failure count and the first
error, and returns the number of successful deletes. For a maintenance job this
is strictly better than aborting halfway — the previous behaviour left the
collection partially cleaned *and* discarded the count.

Delete ordering is no longer deterministic. Deletes of distinct documents are
independent, so this has no semantic consequence.

## Verification

At head `f6c7910e4232403a121e6fd7bd5378b13640eca3`:

```
PYTHONPATH=src pytest tests/unit/test_firestore_state.py
=> 90 passed

ruff check src/.../firestore_state.py tests/unit/test_firestore_state.py
=> 1 error (pre-existing F841 at test_firestore_state.py:530, identical on main)
```

**Non-vacuity — every new test was run against the implementation it replaced
and confirmed to fail.**

Against the original *sequential* loop:

| Test | Failure |
|---|---|
| `test_cleanup_deletes_overlap_instead_of_running_sequentially` | `AssertionError: deletes never overlapped (peak=1)` |
| `test_cleanup_bounds_in_flight_deletes` | `AttributeError: ... has no attribute 'CLEANUP_DELETE_CONCURRENCY'` |
| `test_cleanup_failure_does_not_abandon_remaining_deletes` | `RuntimeError: firestore boom` propagated, stranding the remaining delete |

Against a worker that **returns instead of continuing** after its own delete
fails -- the defect the first version of this test was too weak to catch, raised
in review and fixed in `7558f03`:

```
>       assert count == doc_count - 1
E       assert 0 == (5 - 1)
FAILED ... ::test_cleanup_failure_does_not_abandon_remaining_deletes
```

That test previously used 3 documents against a pool of 16, so `min(16, 3) = 3`
workers each handled exactly one document and the `while True` continuation
branch never ran. It now narrows the pool to a single worker over a 5-document
backlog, which is the only arrangement that isolates that path -- with 2+ workers
a surviving sibling drains the backlog and the assertion passes regardless.

Against the intermediate `gather` + semaphore revision, proving the review
finding was real and is now fixed:

```
AssertionError: cleanup allocated 49 concurrent tasks for 48 documents;
delete tasks are not bounded by the CLEANUP_DELETE_CONCURRENCY worker pool of 16
assert 49 <= (16 + 3)
```

The overlap test measures peak concurrent in-flight deletes; the old loop pins it
at exactly 1. The allocation test measures peak `len(asyncio.all_tasks())`, which
is the stricter bound the review asked for.

Against the `max(0.001, float(os.getenv(...)))` clamping that the configuration
commit originally shipped -- `float()` accepts `inf`, and `max(0.001, inf)` is
`inf`, so an operator could silently remove the per-delete deadline. Restoring
only that clamping inside the new parser:

```
FAILED ...::test_float_env_rejects_non_finite_and_non_positive[inf]
FAILED ...::test_float_env_rejects_non_finite_and_non_positive[Infinity]
FAILED ...::test_float_env_rejects_non_finite_and_non_positive[-inf]
FAILED ...::test_float_env_rejects_non_finite_and_non_positive[nan]
FAILED ...::test_float_env_rejects_non_finite_and_non_positive[0]
FAILED ...::test_float_env_rejects_non_finite_and_non_positive[-1]
FAILED ...::test_float_env_rejects_non_finite_and_non_positive[0.0]
E           Failed: DID NOT RAISE ValueError
7 failed, 83 deselected
```

`nan` failed in the opposite direction: `max(0.001, nan)` returns `0.001`
because `nan > 0.001` is false, so a `nan` override was silently swallowed
rather than reported. Both are now rejected by a single `math.isfinite` check.

## Production evidence

The module is live, with 4 importers:

```
src/youtube_extension/services/cloud/cloud_video_processor.py
src/youtube_extension/services/cloud/__init__.py
tests/unit/test_firestore_state.py
tests/unit/test_cloud_video_processor.py
```

`cleanup_old_states` is the retention path for the `video_processing_state`
collection, so its latency grows with exactly the backlog it exists to drain —
the sequential loop was slowest precisely when cleanup mattered most.

## Agent handoff

@coderabbitai review


