### PR TITLE
fix(ci): allowlist lockfile sha256 hashes in gitleaks working-tree scan

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -5,7 +5,17 @@
 useDefault = true
 
 [allowlist]
-description = "Paths excluded from secret scanning"
+description = "Paths and false-positive patterns excluded from secret scanning"
+# Package lockfiles (uv.lock, package-lock.json, etc.) record public SHA-256
+# package-integrity hashes. Their high entropy trips the default
+# square-access-token rule (e.g. uv.lock:5129, the `parso` sdist hash), even
+# though a `sha256:<hex>` integrity digest is not a credential. Match on the
+# whole line so only genuine `hash = "sha256:..."` digests are allowlisted;
+# any real token elsewhere in a lockfile is still scanned.
+regexTarget = "line"
+regexes = [
+  '''hash = "sha256:[0-9a-f]{64}"''',
+]
 paths = [
   # Vendored saved web pages from Google (AI Studio / APIs Explorer): contain
   # Google's own public page keys, not EventRelay credentials.


### PR DESCRIPTION
## Canonical issue

No canonical issue — repo-hygiene CI fix surfaced while triaging the `gitleaks (working tree)` failure that appears on **every** open PR (observed on the dependabot bump #1171, but present repo-wide).

## Outcome

The `gitleaks (working tree)` job stops failing on a false positive. The default `square-access-token` rule was flagging the high-entropy SHA-256 package-integrity digests in `uv.lock` (`uv.lock:5129`, the `parso` sdist hash) as a leaked credential. Because that job scans `uv.lock` on every branch off `main`, the false positive was failing the scan — and blocking the green gate — on essentially every open PR. After this change the scan reports `no leaks found`.

## Scope

- Included: `.gitleaks.toml` — one line-scoped regex allowlist entry.
- Explicitly excluded: no production code, no dependency/lockfile movement, no other scan rules touched. The allowlist is scoped to `hash = "sha256:<hex>"` lines only, so a genuine token appearing elsewhere in a lockfile (e.g. a credentialed private-index URL) is **still scanned**.

## Risk

- Risk level: **low** — CI-config only, one file.
- Failure mode: worst case is that a real secret formatted *exactly* as a 64-char lowercase-hex SHA-256 digest on a `hash = "sha256:..."` line would be missed. Real credentials do not take that shape (Square tokens are `sq0atp-…`/`EAAA…` base64, not lowercase hex), so this is not a realistic exposure.
- Rollback: revert this commit; `.gitleaks.toml` returns to the prior allowlist. Nothing else depends on it.

## Verification

Verified with **gitleaks 8.18.4** (the exact version CI installs) against the current head on a clean tree off `main` (`ad7e2c1`):

- [x] **Reproduced the failure** — `gitleaks detect --no-git --config .gitleaks.toml --redact --exit-code 1` on the pre-fix config → `leaks found: 1`, `RuleID: square-access-token`, `File: uv.lock`, `Line: 5129`, exit **1**.
- [x] **Confirmed the fix** — same command on the post-fix config → `no leaks found`, exit **0**.
- [x] **Allowlist is narrow** — `regexTarget = "line"` with `hash = "sha256:[0-9a-f]{64}"`; only matches integrity-digest lines.
- [ ] **Required CI** — will confirm on this PR's head once the checks run.
- [x] **Review threads resolved** — none open.

## Production evidence

Not applicable as a runtime artifact: this PR changes only `.gitleaks.toml` (a CI config file). It touches no `apps/web` file, no route, and no dependency, so the deployed bundle for this head is byte-identical to `main`. The relevant evidence is the behavioural before/after above (exit 1 → exit 0 with gitleaks 8.18.4).

## Agent handoff

- [ ] One canonical issue is linked — none exists; this is a CI-hygiene fix found during PR triage.
- [x] No competing PR implements the same issue.
- [x] Acceptance criteria are satisfied (scan goes from failing to clean).
- [ ] Required checks pass on the current head — pending first CI run.
- [x] Human decision is requested only for merge approval (protected `main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1YVe2AKQxtpn5LKpJW6BE)_