### PR TITLE
perf: batch structured log writes into a single aiofiles call

### DIFF
--- a/src/youtube_extension/backend/services/logging_service.py
+++ b/src/youtube_extension/backend/services/logging_service.py
@@ -372,19 +372,22 @@ class LoggingService:
     async def _write_to_files(self, logs: list[StructuredLogEntry]) -> None:
         """Write logs to file outputs"""
         try:
-            # Write structured logs
+            # Write structured logs.
+            # aiofiles dispatches every write() to the thread-pool executor, so a
+            # per-entry loop costs one executor round-trip per log line. Serialise
+            # the whole batch first and issue a single write instead.
             structured_path = self.config['log_directory'] / 'structured_logs.jsonl'
+            structured_payload = ''.join(f'{log.json()}\n' for log in logs)
             async with aiofiles.open(structured_path, 'a') as f:
-                for log in logs:
-                    await f.write(log.json() + '\n')
+                await f.write(structured_payload)
 
             # Write error logs separately
             error_logs = [log for log in logs if log.level in ['ERROR', 'CRITICAL']]
             if error_logs:
                 error_path = self.config['log_directory'] / 'error_logs.jsonl'
+                error_payload = ''.join(f'{log.json()}\n' for log in error_logs)
                 async with aiofiles.open(error_path, 'a') as f:
-                    for log in error_logs:
-                        await f.write(log.json() + '\n')
+                    await f.write(error_payload)
 
         except Exception as e:
             self.logger.error(f"Failed to write logs to files: {e}")

--- a/tests/unit/test_logging_service.py
+++ b/tests/unit/test_logging_service.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import sys
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -15,6 +17,8 @@ from youtube_extension.backend.services.logging_service import (
     LogLevel,
     StructuredLogEntry,
 )
+
+MODULE_PATH = "youtube_extension.backend.services.logging_service"
 
 # ===========================================================================
 # LogLevel constants
@@ -386,3 +390,116 @@ class TestLoggingServiceGetHealthStatus:
         status = service.get_health_status()
         assert "uptime_seconds" in status
         assert status["uptime_seconds"] >= 0
+
+
+# ===========================================================================
+# LoggingService._write_to_files — batching
+# ===========================================================================
+
+
+class TestLoggingServiceWriteToFiles:
+    """Tests for _write_to_files().
+
+    aiofiles delegates every ``write()`` to the thread-pool executor, so the
+    number of ``write()`` calls -- not the number of bytes -- is what costs.
+    These tests pin the batch to a single write per file.
+    """
+
+    @pytest.fixture
+    async def service(self, tmp_path):
+        return LoggingService(
+            config={"log_directory": tmp_path / "logs", "enable_remote_logging": False}
+        )
+
+    @staticmethod
+    def _entries(n: int, level: str = "INFO") -> list[StructuredLogEntry]:
+        return [
+            StructuredLogEntry(
+                timestamp=f"2026-01-01T00:00:{i:02d}Z",
+                level=level,
+                logger_name="test",
+                message=f"msg-{i}",
+            )
+            for i in range(n)
+        ]
+
+    async def test_batches_structured_logs_into_one_write(self, service, tmp_path):
+        writes: list[str] = []
+
+        class _FakeFile:
+            async def write(self, data):
+                writes.append(data)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        with patch(f"{MODULE_PATH}.aiofiles.open", return_value=_FakeFile()):
+            await service._write_to_files(self._entries(25))
+
+        assert len(writes) == 1, (
+            f"_write_to_files issued {len(writes)} write() calls for 25 log entries; "
+            "each aiofiles write is a separate thread-pool round-trip, so the batch "
+            "must be serialised into a single write"
+        )
+        assert writes[0].count("\n") == 25
+
+    async def test_batches_error_logs_into_one_write(self, service, tmp_path):
+        writes: list[str] = []
+
+        class _FakeFile:
+            async def write(self, data):
+                writes.append(data)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        with patch(f"{MODULE_PATH}.aiofiles.open", return_value=_FakeFile()):
+            await service._write_to_files(self._entries(12, level="ERROR"))
+
+        # One write for structured_logs.jsonl, one for error_logs.jsonl.
+        assert len(writes) == 2, (
+            f"_write_to_files issued {len(writes)} write() calls for 12 ERROR entries; "
+            "expected exactly one batched write per file"
+        )
+        assert all(payload.count("\n") == 12 for payload in writes)
+
+    async def test_writes_every_entry_exactly_once(self, service, tmp_path):
+        await service._write_to_files(self._entries(5))
+
+        path = tmp_path / "logs" / "structured_logs.jsonl"
+        lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 5
+        assert [json.loads(ln)["message"] for ln in lines] == [f"msg-{i}" for i in range(5)]
+
+    async def test_appends_rather_than_truncating(self, service, tmp_path):
+        await service._write_to_files(self._entries(3))
+        await service._write_to_files(self._entries(2))
+
+        path = tmp_path / "logs" / "structured_logs.jsonl"
+        lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 5
+
+    async def test_error_logs_routed_to_separate_file(self, service, tmp_path):
+        mixed = self._entries(2, level="INFO") + self._entries(3, level="CRITICAL")
+        await service._write_to_files(mixed)
+
+        structured = tmp_path / "logs" / "structured_logs.jsonl"
+        errors = tmp_path / "logs" / "error_logs.jsonl"
+        assert len([ln for ln in structured.read_text().splitlines() if ln.strip()]) == 5
+        assert len([ln for ln in errors.read_text().splitlines() if ln.strip()]) == 3
+
+    async def test_no_error_content_written_when_no_error_logs(self, service, tmp_path):
+        await service._write_to_files(self._entries(4, level="INFO"))
+        errors = tmp_path / "logs" / "error_logs.jsonl"
+        # The service pre-creates its log files at init, so assert on content.
+        existing = errors.read_text() if errors.exists() else ""
+        assert [ln for ln in existing.splitlines() if ln.strip()] == []
+
+    async def test_empty_batch_does_not_raise(self, service):
+        await service._write_to_files([])


### PR DESCRIPTION
## Canonical issue

Closes #1181

## Outcome

`LoggingService._write_to_files()` now issues **one `write()` per output file**
instead of one per log entry.

`aiofiles` is a thread-pool shim, not a native-async file layer. Every method on
its file objects is generated by `_make_delegate_method`:

```python
async def method(self, *args, **kwargs):
    cb = functools.partial(getattr(self._file, attr_name), *args, **kwargs)
    return await self._loop.run_in_executor(self._executor, cb)
```

Each `await f.write(...)` is therefore a full executor round-trip -- submit,
context-switch to a worker thread, write, hop back to the loop. Cost scales with
the **number of calls**, not the number of bytes.

`LoggingService` defaults to `'buffer_size': 100` and `flush_logs()` drains the
whole buffer at once, so a single flush previously cost:

| | before | after |
|---|---|---|
| `structured_logs.jsonl` | 100 executor round-trips | **1** |
| `error_logs.jsonl` (all-ERROR batch) | 100 executor round-trips | **1** |

Flushes fire on a 30s timer *and* whenever the buffer fills, so this is the
steady-state path.

## Scope

One function, `src/youtube_extension/backend/services/logging_service.py:372`.

```python
structured_payload = ''.join(f'{log.json()}\n' for log in logs)
async with aiofiles.open(structured_path, 'a') as f:
    await f.write(structured_payload)
```

**What this does not change:** output bytes, file paths, `'a'` append mode,
ERROR/CRITICAL routing to the separate file, or the surrounding `try/except`.
Only the number of `write()` calls changes.

## Design notes

**Why not add an empty-batch guard around the structured write?**
The per-entry loop still *opened* `structured_logs.jsonl` for an empty batch,
which creates the file as a side effect. Guarding the open would change that
observable behaviour for a path that already costs nothing (`''.join([])` is
`''`, and a single `write('')` is one no-op round-trip). `test_empty_batch_does_not_raise`
pins the safety of that path without changing it. The existing `if error_logs:`
guard on the error file is untouched.

**Why `''.join(...)` rather than `writelines()`?**
`aiofiles`' `writelines` is delegated the same way, and CPython's `writelines`
loops internally -- so it is one executor round-trip either way, but `''.join`
makes the single-call property explicit and directly assertable in a test.

**Memory.** The batch is bounded by `buffer_size` (default 100 entries), which is
already fully materialised in `log_buffer` before this function is called. Joining
it adds one transient string of the same order as the data already in memory.

## Risk

**Low.** No public API change, no behaviour change beyond call count.
The failure mode of the old code (partial batch written, then an exception) is
strictly *worse* than the new one -- a single `write()` cannot interleave a
partial batch with a concurrent flush.

## Verification

At head `60ae14e84d937235520a4470918a2e4658932ad9`:

```
PYTHONPATH=src pytest tests/unit/test_logging_service.py \
                      tests/unit/test_logging_service_models.py \
                      tests/unit/test_misc_services.py
=> 223 passed

ruff check src/.../logging_service.py tests/unit/test_logging_service.py
=> 1 error (pre-existing F401 at logging_service.py:27, identical on main)
```

**Non-vacuity — the new tests were run against the per-entry loop they replace
and confirmed to fail:**

```
E  AssertionError: _write_to_files issued 25 write() calls for 25 log entries;
   each aiofiles write is a separate thread-pool round-trip, so the batch must
   be serialised into a single write

E  AssertionError: _write_to_files issued 24 write() calls for 12 ERROR entries;
   expected exactly one batched write per file

2 failed, 5 passed, 57 deselected
```

The `24` in the second case is the point of the change: 12 entries × 2 files.

Tests added (`TestLoggingServiceWriteToFiles`):

| Test | Pins |
|---|---|
| `test_batches_structured_logs_into_one_write` | exactly 1 `write()` for 25 entries |
| `test_batches_error_logs_into_one_write` | exactly 2 `write()` for an all-ERROR batch |
| `test_writes_every_entry_exactly_once` | every entry lands, in order, parseable as JSON |
| `test_appends_rather_than_truncating` | 3 + 2 flushes → 5 lines |
| `test_error_logs_routed_to_separate_file` | mixed batch → 5 structured / 3 error |
| `test_no_error_content_written_when_no_error_logs` | INFO-only batch writes no error rows |
| `test_empty_batch_does_not_raise` | empty flush is safe |

## Production evidence

`logging_service` has **11 importers**, including request-path middleware:

```
src/youtube_extension/backend/middleware/error_handling_middleware.py:27
src/youtube_extension/backend/services/health_monitoring_service.py:25
```

Enclosing function confirmed genuinely `async` (line 372), so the awaits are real
event-loop yields rather than a `run_in_executor` worker where blocking would be
correct.

## Agent handoff

Reviewed by `@coderabbitai`. Second in a series of bounded-IO performance fixes;
follows #1152 (bounded Redis tag writes) and #1170 (bounded Firestore cleanup).
