### PR TITLE
perf(websocket): broadcast to all peers concurrently instead of one at a time

### DIFF
--- a/src/youtube_extension/backend/services/websocket_service.py
+++ b/src/youtube_extension/backend/services/websocket_service.py
@@ -70,13 +70,25 @@ class WebSocketConnectionManager:
             return_exceptions=True,
         )
 
-        # isinstance(..., Exception) mirrors the previous `except Exception`
-        # clause: BaseException-only failures (e.g. CancelledError) propagate
-        # as before rather than being treated as a dead connection.
+        # `return_exceptions=True` captures BaseException-only failures (most
+        # notably CancelledError) into `results` instead of propagating them,
+        # so `isinstance(result, Exception)` alone would silently swallow a
+        # cancellation that the previous `except Exception` loop let escape.
+        # Dead peers are cleaned up first so a cancellation does not leak them,
+        # then the cancellation is re-raised to restore the old semantics.
+        cancellations = [
+            result
+            for result in results
+            if isinstance(result, BaseException) and not isinstance(result, Exception)
+        ]
+
         for connection, result in zip(connections, results, strict=True):
             if isinstance(result, Exception):
                 logger.error(f"Error broadcasting message: {result}")
                 self.disconnect(connection)
+
+        if cancellations:
+            raise cancellations[0]
 
 
 class WebSocketService:

--- a/src/youtube_extension/backend/services/websocket_service.py
+++ b/src/youtube_extension/backend/services/websocket_service.py
@@ -7,6 +7,7 @@ Extracted WebSocket handling business logic.
 Handles real-time communication, message routing, and connection management.
 """
 
+import asyncio
 import json
 import logging
 from datetime import datetime
@@ -47,18 +48,35 @@ class WebSocketConnectionManager:
             self.disconnect(websocket)
 
     async def broadcast(self, message: str):
-        """Broadcast message to all active connections"""
-        disconnected = []
-        for connection in self.active_connections:
-            try:
-                await connection.send_text(message)
-            except Exception as e:
-                logger.error(f"Error broadcasting message: {e}")
-                disconnected.append(connection)
+        """Broadcast message to all active connections concurrently.
 
-        # Remove disconnected connections
-        for connection in disconnected:
-            self.disconnect(connection)
+        Sends are issued in parallel rather than one at a time. A sequential
+        loop makes every client wait for the ones ahead of it, so a single slow
+        or backpressured peer delays delivery to the whole fleet (head-of-line
+        blocking) and total latency grows with the connection count.
+
+        Each WebSocket owns an independent send buffer, so there is no shared
+        pooled resource to exhaust here and concurrency is naturally bounded by
+        the number of connected clients. Failures are isolated via
+        ``return_exceptions=True`` so one dead peer cannot abort the broadcast.
+        """
+        # Snapshot: disconnect() mutates active_connections as we clean up.
+        connections = list(self.active_connections)
+        if not connections:
+            return
+
+        results = await asyncio.gather(
+            *(connection.send_text(message) for connection in connections),
+            return_exceptions=True,
+        )
+
+        # isinstance(..., Exception) mirrors the previous `except Exception`
+        # clause: BaseException-only failures (e.g. CancelledError) propagate
+        # as before rather than being treated as a dead connection.
+        for connection, result in zip(connections, results, strict=True):
+            if isinstance(result, Exception):
+                logger.error(f"Error broadcasting message: {result}")
+                self.disconnect(connection)
 
 
 class WebSocketService:

--- a/tests/unit/test_websocket_service.py
+++ b/tests/unit/test_websocket_service.py
@@ -579,7 +579,12 @@ class TestBroadcastFanOut:
 
         await mgr.broadcast("event")
 
-        assert completed == ["fast-1", "fast-2", "slow"], (
+        # Both fast peers must finish before the slow head-of-list peer. Their
+        # order relative to each other is scheduler-dependent (both sleep(0)),
+        # so it is deliberately not asserted -- only that neither was blocked
+        # behind the slow peer. Under a sequential loop the slow peer, being
+        # first, completes first and this fails.
+        assert completed[-1] == "slow" and set(completed[:2]) == {"fast-1", "fast-2"}, (
             f"completion order was {completed}; a slow peer at the head of the "
             "connection list delayed delivery to the fast peers behind it"
         )

--- a/tests/unit/test_websocket_service.py
+++ b/tests/unit/test_websocket_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -513,3 +514,105 @@ class TestGetConnectionStats:
         mgr.active_connections = []
         stats = svc.get_connection_stats()
         assert stats["active_connections"] == 0
+
+
+# ===========================================================================
+# WebSocketConnectionManager.broadcast – fan-out concurrency
+# ===========================================================================
+
+
+class TestBroadcastFanOut:
+    """broadcast() must issue sends in parallel, not one connection at a time.
+
+    A sequential loop makes every client wait for the ones ahead of it, so a
+    single slow peer delays delivery to the entire fleet (head-of-line
+    blocking). These tests fail against a serialised implementation.
+    """
+
+    @staticmethod
+    def _tracking_ws(state, delay=0.01):
+        """A mock WebSocket that records peak concurrent send_text() calls."""
+        ws = _make_ws()
+
+        async def _send(_message):
+            state["inflight"] += 1
+            state["peak"] = max(state["peak"], state["inflight"])
+            await asyncio.sleep(delay)
+            state["inflight"] -= 1
+
+        ws.send_text = AsyncMock(side_effect=_send)
+        return ws
+
+    async def test_sends_are_concurrent_not_serialised(self):
+        mgr = WebSocketConnectionManager()
+        state = {"inflight": 0, "peak": 0}
+        n = 5
+        mgr.active_connections.extend(self._tracking_ws(state) for _ in range(n))
+
+        await mgr.broadcast("event")
+
+        assert state["peak"] == n, (
+            f"broadcast() peaked at {state['peak']} concurrent send(s) for {n} "
+            "connections - sends are serialised (head-of-line blocking)"
+        )
+
+    async def test_slow_peer_does_not_delay_other_peers(self):
+        mgr = WebSocketConnectionManager()
+        completed: list[str] = []
+
+        def _ws(name, delay):
+            ws = _make_ws()
+
+            async def _send(_message):
+                await asyncio.sleep(delay)
+                completed.append(name)
+
+            ws.send_text = AsyncMock(side_effect=_send)
+            return ws
+
+        # The slow peer is first in the list: under a sequential loop it blocks
+        # both fast peers behind it and therefore completes first.
+        mgr.active_connections.extend(
+            [_ws("slow", 0.05), _ws("fast-1", 0.0), _ws("fast-2", 0.0)]
+        )
+
+        await mgr.broadcast("event")
+
+        assert completed == ["fast-1", "fast-2", "slow"], (
+            f"completion order was {completed}; a slow peer at the head of the "
+            "connection list delayed delivery to the fast peers behind it"
+        )
+
+    async def test_all_peers_still_receive_the_message(self):
+        mgr = WebSocketConnectionManager()
+        conns = [_make_ws() for _ in range(4)]
+        mgr.active_connections.extend(conns)
+
+        await mgr.broadcast("payload")
+
+        for ws in conns:
+            ws.send_text.assert_awaited_once_with("payload")
+
+    async def test_failures_are_isolated_and_only_bad_peers_removed(self):
+        mgr = WebSocketConnectionManager()
+        ok_1, ok_2 = _make_ws(), _make_ws()
+        bad_1, bad_2 = _make_ws(), _make_ws()
+        bad_1.send_text = AsyncMock(side_effect=RuntimeError("peer gone"))
+        bad_2.send_text = AsyncMock(side_effect=ConnectionResetError("reset"))
+        # Failing peers first: a raising send must not abort the whole fan-out.
+        mgr.active_connections.extend([bad_1, ok_1, bad_2, ok_2])
+
+        await mgr.broadcast("event")
+
+        ok_1.send_text.assert_awaited_once_with("event")
+        ok_2.send_text.assert_awaited_once_with("event")
+        assert mgr.active_connections == [ok_1, ok_2], (
+            "expected only the failing peers to be dropped, got "
+            f"{len(mgr.active_connections)} surviving connection(s)"
+        )
+
+    async def test_empty_connection_list_issues_no_sends(self):
+        mgr = WebSocketConnectionManager()
+        # Must not raise and must not construct an empty gather.
+        await mgr.broadcast("event")
+        assert mgr.active_connections == []

--- a/tests/unit/test_websocket_service.py
+++ b/tests/unit/test_websocket_service.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi import WebSocketDisconnect
 
 from youtube_extension.backend.services.websocket_service import (
@@ -616,3 +617,37 @@ class TestBroadcastFanOut:
         # Must not raise and must not construct an empty gather.
         await mgr.broadcast("event")
         assert mgr.active_connections == []
+
+    async def test_cancelled_send_is_re_raised_not_swallowed(self):
+        """gather(return_exceptions=True) captures CancelledError; broadcast must not eat it.
+
+        The pre-fan-out implementation used `except Exception`, so a
+        CancelledError raised by send_text escaped broadcast(). Collecting it
+        into `results` and filtering on `Exception` would silently drop it.
+        """
+        mgr = WebSocketConnectionManager()
+        ok = _make_ws()
+        cancelled = _make_ws()
+        cancelled.send_text = AsyncMock(side_effect=asyncio.CancelledError())
+        mgr.active_connections.extend([ok, cancelled])
+
+        with pytest.raises(asyncio.CancelledError):
+            await mgr.broadcast("event")
+
+    async def test_cancellation_does_not_leak_dead_peers(self):
+        """Ordinary failures are still cleaned up before the cancellation propagates."""
+        mgr = WebSocketConnectionManager()
+        ok = _make_ws()
+        dead = _make_ws()
+        dead.send_text = AsyncMock(side_effect=RuntimeError("peer gone"))
+        cancelled = _make_ws()
+        cancelled.send_text = AsyncMock(side_effect=asyncio.CancelledError())
+        mgr.active_connections.extend([ok, dead, cancelled])
+
+        with pytest.raises(asyncio.CancelledError):
+            await mgr.broadcast("event")
+
+        assert mgr.active_connections == [ok, cancelled], (
+            "the failed peer must still be dropped even though the broadcast "
+            f"was cancelled, got {mgr.active_connections}"
+        )


### PR DESCRIPTION
## Canonical issue

Closes #1185

## Outcome

`WebSocketConnectionManager.broadcast()` now fans out to all connected peers **concurrently**
instead of awaiting each `send_text()` in sequence.

Previously each client waited for every client ahead of it in `active_connections`, so a single
slow or backpressured peer delayed delivery to the entire fleet and broadcast latency for the
last client was the *sum* of all preceding sends. Now the sends are issued together and the
broadcast completes in roughly the time of the **slowest** peer rather than the **total** of all
peers.

| | Before | After |
|---|---|---|
| Peak in-flight `send_text()` (5 peers) | 1 | 5 |
| Completion order with a slow peer first | `slow, fast-1, fast-2` | `fast-1, fast-2, slow` |
| Broadcast wall-clock | Σ(all peers) | ≈ max(peers) |

**What this does not change:** the number of frames sent, per-peer send cost, message ordering
*within* a single connection, or the removal semantics for dead peers.

## Scope

One function plus tests.

- `src/youtube_extension/backend/services/websocket_service.py` — `broadcast()` (+ `import asyncio`)
- `tests/unit/test_websocket_service.py` — new `TestBroadcastFanOut` (5 tests)

No API, signature, or behavioural contract changes. The three pre-existing `broadcast` tests
(`test_broadcast_sends_to_all`, `test_broadcast_removes_failed_connections`,
`test_broadcast_empty_connections_no_error`) are untouched and still pass.

## Design notes

**Why `gather` here, when #1153 and #1169 deliberately used a bounded worker pool?**
Those changes fanned out over a *shared, finite* resource — a Redis connection pool and a
Firestore client — where unbounded concurrency causes pool exhaustion and quota pressure, so a
semaphore was load-bearing. A WebSocket broadcast is the opposite shape: **each peer owns an
independent send buffer**, there is no shared pool to exhaust, and the task count is already
bounded by the number of connected clients (which the server admits and tracks). Adding a
semaphore here would reintroduce exactly the serialisation skew this change removes, so it would
be a pessimisation rather than a safeguard.

**Failure isolation.** `return_exceptions=True` ensures one dead peer cannot abort delivery to
the rest — under `gather`'s default, the first raise would cancel the remaining sends.

**Exception parity (corrected at `69f0b9848`).** The original version of this note claimed that
`isinstance(result, Exception)` alone preserved the previous `except Exception:` semantics because
`CancelledError` derives from `BaseException`. **That was wrong**, and `@Copilot` caught it:
`gather(..., return_exceptions=True)` *captures* a child `CancelledError` into `results` instead of
propagating it, so filtering on `Exception` silently swallowed a cancellation that the old loop let
escape. `broadcast()` now collects `BaseException`-but-not-`Exception` results, cleans up the
ordinary per-peer failures first (so a cancellation cannot leak dead connections), and then
re-raises. Two tests pin this, both proven to fail without the re-raise
(`Failed: DID NOT RAISE CancelledError`).

**Snapshot.** `connections = list(self.active_connections)` is taken up front because
`disconnect()` mutates that list during cleanup; `zip(..., strict=True)` then guarantees results
stay aligned with their connections.

**Empty case.** An early `return` avoids constructing an empty `gather`.

## Risk

**Low.** Single function, no signature change, fully covered by pre-existing plus new tests.

The one behavioural difference worth naming: sends now start in parallel, so peers no longer
receive the message in strict list order. Broadcast has no cross-peer ordering contract (ordering
*within* a connection is unchanged and guaranteed by the transport), and the previous ordering was
an artefact of the serial loop rather than a designed property.

## Verification

At head `97e1d4f01837259b5800822ca62934a36533bcbc`:

```
$ pytest tests/unit/test_websocket_service.py
59 passed in 0.22s

$ ruff check src/.../websocket_service.py tests/unit/test_websocket_service.py
All checks passed!
```

**Non-vacuity — the new tests fail against the previous sequential implementation.** Reverting
only the source (`git stash push <file>`) and re-running the new tests:

```
AssertionError: broadcast() peaked at 1 concurrent send(s) for 5 connections
                - sends are serialised (head-of-line blocking)
assert 1 == 5

AssertionError: completion order was ['slow', 'fast-1', 'fast-2']; a slow peer at the
                head of the connection list delayed delivery to the fast peers behind it
assert ['slow', 'fast-1', 'fast-2'] == ['fast-1', 'fast-2', 'slow']

2 failed, 3 passed
```

The remaining 3 tests are invariants (all peers receive, failures isolated, empty no-op) that hold
under both implementations by design.

## Production evidence

`websocket_service` is reachable from the containerised production entrypoint
`youtube_extension.main:app` (root `Dockerfile:93`):

```
youtube_extension.main
  -> youtube_extension.backend.api.v1.router      (include_router in main.py)
     -> backend/api/v1/router.py:74  from ...services.websocket_service import WebSocketConnectionManager
```

Also registered as a DI singleton at `backend/containers/service_container.py:115` and
constructed at `:286-288`. Verified present in a transitive-import closure computed over **all**
deployed entrypoints (`[project.scripts]`, root `Dockerfile` CMD, `docker-compose.full.yml`) —
this check is why several superficially-attractive candidates in this series were dropped as
unreachable rather than shipped.

## Agent handoff

- Review agent: `@coderabbitai` (see comment below for specific challenge questions).
- Follow-up candidates already filed from this audit: #1180 (worker-pool bound for the
  `intelligent_cache` tag fan-out).
- No migration, config, or rollout steps. Behaviour is identical for a single connected client.

