### PR TITLE
perf(cloud-tasks): move blocking gRPC calls off the event loop

### DIFF
--- a/src/youtube_extension/services/cloud/cloud_tasks_queue.py
+++ b/src/youtube_extension/services/cloud/cloud_tasks_queue.py
@@ -38,12 +38,21 @@ async def _run_sync_rpc(call, /, *args, **kwargs):
     callers may safely close the shared client in ``finally`` blocks.
     """
     rpc_task = asyncio.create_task(asyncio.to_thread(call, *args, **kwargs))
-    try:
-        return await asyncio.shield(rpc_task)
-    except asyncio.CancelledError:
+    cancelled = False
+    while not rpc_task.done():
+        try:
+            await asyncio.shield(rpc_task)
+        except asyncio.CancelledError:
+            cancelled = True
+        except Exception:
+            if not cancelled:
+                raise
+
+    if cancelled:
         with contextlib.suppress(Exception):
-            await rpc_task
-        raise
+            rpc_task.result()
+        raise asyncio.CancelledError
+    return rpc_task.result()
 
 
 @dataclass

--- a/src/youtube_extension/services/cloud/cloud_tasks_queue.py
+++ b/src/youtube_extension/services/cloud/cloud_tasks_queue.py
@@ -8,6 +8,7 @@ Enables non-blocking video processing with retry logic and concurrency control.
 """
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -28,6 +29,21 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+
+async def _run_sync_rpc(call, /, *args, **kwargs):
+    """Run a synchronous RPC without abandoning it on caller cancellation.
+
+    ``asyncio.to_thread`` cannot stop a worker that has already started. Shield
+    the worker task and wait for it to finish before propagating cancellation so
+    callers may safely close the shared client in ``finally`` blocks.
+    """
+    rpc_task = asyncio.create_task(asyncio.to_thread(call, *args, **kwargs))
+    try:
+        return await asyncio.shield(rpc_task)
+    except asyncio.CancelledError:
+        with contextlib.suppress(Exception):
+            await rpc_task
+        raise
 
 @dataclass
 class TaskConfig:
@@ -197,7 +213,7 @@ class CloudTasksQueueService:
         # calling it directly would block the event loop for a full network
         # round-trip on every enqueue.
         queue_path = self._get_queue_path()
-        response = await asyncio.to_thread(
+        response = await _run_sync_rpc(
             self.client.create_task,
             request=tasks_v2.CreateTaskRequest(
                 parent=queue_path,
@@ -252,7 +268,7 @@ class CloudTasksQueueService:
         try:
             # Try to get the queue
             queue_path = self._get_queue_path()
-            await asyncio.to_thread(self.client.get_queue, name=queue_path)
+            await _run_sync_rpc(self.client.get_queue, name=queue_path)
             logger.info(f"Queue already exists: {queue_path}")
 
         except Exception:
@@ -274,7 +290,7 @@ class CloudTasksQueueService:
                 ),
             )
 
-            await asyncio.to_thread(
+            await _run_sync_rpc(
                 self.client.create_queue,
                 request=tasks_v2.CreateQueueRequest(
                     parent=parent,
@@ -289,7 +305,7 @@ class CloudTasksQueueService:
             raise RuntimeError("Cloud Tasks client not initialized. Call initialize() first.")
 
         queue_path = self._get_queue_path()
-        await asyncio.to_thread(self.client.pause_queue, name=queue_path)
+        await _run_sync_rpc(self.client.pause_queue, name=queue_path)
         logger.info(f"Paused queue: {queue_path}")
 
     async def resume_queue(self) -> None:
@@ -298,7 +314,7 @@ class CloudTasksQueueService:
             raise RuntimeError("Cloud Tasks client not initialized. Call initialize() first.")
 
         queue_path = self._get_queue_path()
-        await asyncio.to_thread(self.client.resume_queue, name=queue_path)
+        await _run_sync_rpc(self.client.resume_queue, name=queue_path)
         logger.info(f"Resumed queue: {queue_path}")
 
     async def purge_queue(self) -> None:
@@ -307,7 +323,7 @@ class CloudTasksQueueService:
             raise RuntimeError("Cloud Tasks client not initialized. Call initialize() first.")
 
         queue_path = self._get_queue_path()
-        await asyncio.to_thread(self.client.purge_queue, name=queue_path)
+        await _run_sync_rpc(self.client.purge_queue, name=queue_path)
         logger.info(f"Purged queue: {queue_path}")
 
     async def get_queue_stats(self) -> dict[str, Any]:
@@ -321,7 +337,7 @@ class CloudTasksQueueService:
             raise RuntimeError("Cloud Tasks client not initialized. Call initialize() first.")
 
         queue_path = self._get_queue_path()
-        queue = await asyncio.to_thread(self.client.get_queue, name=queue_path)
+        queue = await _run_sync_rpc(self.client.get_queue, name=queue_path)
 
         return {
             'name': queue.name,

--- a/src/youtube_extension/services/cloud/cloud_tasks_queue.py
+++ b/src/youtube_extension/services/cloud/cloud_tasks_queue.py
@@ -45,6 +45,7 @@ async def _run_sync_rpc(call, /, *args, **kwargs):
             await rpc_task
         raise
 
+
 @dataclass
 class TaskConfig:
     """Configuration for a Cloud Tasks task"""

--- a/src/youtube_extension/services/cloud/cloud_tasks_queue.py
+++ b/src/youtube_extension/services/cloud/cloud_tasks_queue.py
@@ -7,6 +7,7 @@ Manages async video processing queue using Google Cloud Tasks.
 Enables non-blocking video processing with retry logic and concurrency control.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -192,13 +193,16 @@ class CloudTasksQueueService:
             timestamp.FromDatetime(config.schedule_time)
             task.schedule_time = timestamp
 
-        # Create task
+        # Create task. The generated Cloud Tasks client is synchronous, so
+        # calling it directly would block the event loop for a full network
+        # round-trip on every enqueue.
         queue_path = self._get_queue_path()
-        response = self.client.create_task(
+        response = await asyncio.to_thread(
+            self.client.create_task,
             request=tasks_v2.CreateTaskRequest(
                 parent=queue_path,
                 task=task,
-            )
+            ),
         )
 
         task_id = response.name.split('/')[-1]
@@ -248,7 +252,7 @@ class CloudTasksQueueService:
         try:
             # Try to get the queue
             queue_path = self._get_queue_path()
-            self.client.get_queue(name=queue_path)
+            await asyncio.to_thread(self.client.get_queue, name=queue_path)
             logger.info(f"Queue already exists: {queue_path}")
 
         except Exception:
@@ -270,11 +274,12 @@ class CloudTasksQueueService:
                 ),
             )
 
-            self.client.create_queue(
+            await asyncio.to_thread(
+                self.client.create_queue,
                 request=tasks_v2.CreateQueueRequest(
                     parent=parent,
                     queue=queue,
-                )
+                ),
             )
             logger.info(f"Created queue: {self._get_queue_path()}")
 
@@ -284,7 +289,7 @@ class CloudTasksQueueService:
             raise RuntimeError("Cloud Tasks client not initialized. Call initialize() first.")
 
         queue_path = self._get_queue_path()
-        self.client.pause_queue(name=queue_path)
+        await asyncio.to_thread(self.client.pause_queue, name=queue_path)
         logger.info(f"Paused queue: {queue_path}")
 
     async def resume_queue(self) -> None:
@@ -293,7 +298,7 @@ class CloudTasksQueueService:
             raise RuntimeError("Cloud Tasks client not initialized. Call initialize() first.")
 
         queue_path = self._get_queue_path()
-        self.client.resume_queue(name=queue_path)
+        await asyncio.to_thread(self.client.resume_queue, name=queue_path)
         logger.info(f"Resumed queue: {queue_path}")
 
     async def purge_queue(self) -> None:
@@ -302,7 +307,7 @@ class CloudTasksQueueService:
             raise RuntimeError("Cloud Tasks client not initialized. Call initialize() first.")
 
         queue_path = self._get_queue_path()
-        self.client.purge_queue(name=queue_path)
+        await asyncio.to_thread(self.client.purge_queue, name=queue_path)
         logger.info(f"Purged queue: {queue_path}")
 
     async def get_queue_stats(self) -> dict[str, Any]:
@@ -316,7 +321,7 @@ class CloudTasksQueueService:
             raise RuntimeError("Cloud Tasks client not initialized. Call initialize() first.")
 
         queue_path = self._get_queue_path()
-        queue = self.client.get_queue(name=queue_path)
+        queue = await asyncio.to_thread(self.client.get_queue, name=queue_path)
 
         return {
             'name': queue.name,

--- a/tests/unit/test_cloud_tasks_queue.py
+++ b/tests/unit/test_cloud_tasks_queue.py
@@ -1229,3 +1229,46 @@ class TestClientCallsDoNotBlockEventLoop:
             ids = await svc.enqueue_batch(tasks)
 
         assert ids == ["ok", "ok"]
+
+    async def test_cancellation_is_still_delivered_to_the_caller(self):
+        """Deferring cancellation must not swallow it."""
+        cancelled = False
+
+        def _slow_rpc(*_args, **_kwargs):
+            time.sleep(self._RPC_SECONDS)
+            return MagicMock()
+
+        async def _call():
+            nonlocal cancelled
+            try:
+                await m._run_sync_rpc(_slow_rpc)
+            except asyncio.CancelledError:
+                cancelled = True
+                raise
+
+        task = asyncio.create_task(_call())
+        await asyncio.sleep(0.02)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert cancelled, "caller never observed the CancelledError"
+
+    async def test_rpc_failure_during_cancellation_does_not_mask_cancel(self):
+        """A failing in-flight RPC must not replace the CancelledError."""
+
+        def _slow_boom(*_args, **_kwargs):
+            time.sleep(self._RPC_SECONDS)
+            raise RuntimeError("transport died")
+
+        task = asyncio.create_task(m._run_sync_rpc(_slow_boom))
+        await asyncio.sleep(0.02)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    async def test_uncancelled_calls_return_normally(self):
+        """The happy path is unchanged by the cancellation handling."""
+        sentinel = MagicMock()
+        assert await m._run_sync_rpc(lambda *_a, **_k: sentinel) is sentinel

--- a/tests/unit/test_cloud_tasks_queue.py
+++ b/tests/unit/test_cloud_tasks_queue.py
@@ -1151,7 +1151,7 @@ class TestClientCallsDoNotBlockEventLoop:
 
         assert ticks > 0, "create_queue blocked the event loop"
 
-    async def test_cancellation_waits_for_in_flight_rpc(self):
+    async def test_repeated_cancellation_waits_for_in_flight_rpc(self):
         mock_tv2 = _make_mock_tasks_v2()
         svc = _initialized_service(mock_tv2)
         started = threading.Event()
@@ -1180,8 +1180,15 @@ class TestClientCallsDoNotBlockEventLoop:
             try:
                 await asyncio.sleep(0.02)
                 assert not enqueue.done(), (
-                    "cancellation propagated before the synchronous RPC finished"
+                    "first cancellation propagated before the RPC finished"
                 )
+
+                enqueue.cancel()
+                await asyncio.sleep(0.02)
+                assert not enqueue.done(), (
+                    "repeated cancellation propagated before the RPC finished"
+                )
+                assert not finished.is_set()
             finally:
                 release.set()
 

--- a/tests/unit/test_cloud_tasks_queue.py
+++ b/tests/unit/test_cloud_tasks_queue.py
@@ -12,8 +12,11 @@ object so we can exercise that code without the real SDK.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -982,3 +985,172 @@ class TestModuleLevelAvailabilityFlag:
             assert m.CLOUD_TASKS_AVAILABLE is False
         else:
             assert m.CLOUD_TASKS_AVAILABLE is True
+
+
+# ===========================================================================
+# Event-loop blocking tests
+#
+# The generated Cloud Tasks client is synchronous.  Calling it directly from
+# an ``async def`` blocks the whole event loop for a full network round-trip,
+# stalling every other request served by the same worker.  These tests pin
+# that the blocking calls are dispatched to a worker thread instead.
+# ===========================================================================
+
+
+class TestClientCallsDoNotBlockEventLoop:
+    """The synchronous Cloud Tasks RPCs must not run on the event loop."""
+
+    _RPC_SECONDS = 0.15
+    _HEARTBEAT_INTERVAL = 0.005
+
+    def _video_task(self) -> VideoProcessingTask:
+        return VideoProcessingTask(
+            video_id="vid-block",
+            video_url="https://youtube.com/watch?v=vid-block",
+        )
+
+    async def _count_heartbeats_during(self, coro):
+        """Run ``coro`` while a 5 ms heartbeat ticks; return the tick count."""
+        ticks = 0
+        stop = False
+
+        async def heartbeat():
+            nonlocal ticks
+            while not stop:
+                await asyncio.sleep(self._HEARTBEAT_INTERVAL)
+                ticks += 1
+
+        beat = asyncio.create_task(heartbeat())
+        # Let the heartbeat reach its first await before the RPC starts.
+        await asyncio.sleep(0)
+        try:
+            result = await coro
+        finally:
+            stop = True
+            beat.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await beat
+        return result, ticks
+
+    def _blocking_rpc(self, return_value=None):
+        """A synchronous stand-in for a slow gRPC call."""
+
+        def _rpc(*_args, **_kwargs):
+            time.sleep(self._RPC_SECONDS)
+            return return_value
+
+        return _rpc
+
+    async def test_enqueue_video_processing_does_not_block_loop(self):
+        mock_tv2 = _make_mock_tasks_v2()
+        svc = _initialized_service(mock_tv2)
+
+        response = MagicMock()
+        response.name = ".../tasks/blocking"
+        svc.client.create_task = self._blocking_rpc(response)
+
+        with (
+            patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
+            patch.object(m, "tasks_v2", mock_tv2),
+        ):
+            task_id, ticks = await self._count_heartbeats_during(
+                svc.enqueue_video_processing(self._video_task())
+            )
+
+        assert task_id == "blocking"
+        assert ticks > 0, (
+            f"event loop was blocked for the whole {self._RPC_SECONDS}s RPC: "
+            f"the {self._HEARTBEAT_INTERVAL}s heartbeat ticked {ticks} times"
+        )
+
+    async def test_get_queue_stats_does_not_block_loop(self):
+        mock_tv2 = _make_mock_tasks_v2()
+        svc = _initialized_service(mock_tv2)
+
+        queue = MagicMock()
+        queue.name = "projects/p/locations/l/queues/q"
+        queue.state.name = "RUNNING"
+        queue.stats.tasks_count = 7
+        queue.stats.oldest_estimated_arrival_time = None
+        svc.client.get_queue = self._blocking_rpc(queue)
+
+        with (
+            patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
+            patch.object(m, "tasks_v2", mock_tv2),
+        ):
+            stats, ticks = await self._count_heartbeats_during(svc.get_queue_stats())
+
+        assert stats["tasks_count"] == 7
+        assert ticks > 0, (
+            f"get_queue_stats blocked the loop for the whole {self._RPC_SECONDS}s RPC "
+            f"({ticks} heartbeats)"
+        )
+
+    @pytest.mark.parametrize(
+        "method_name,client_attr",
+        [
+            ("pause_queue", "pause_queue"),
+            ("resume_queue", "resume_queue"),
+            ("purge_queue", "purge_queue"),
+        ],
+    )
+    async def test_queue_control_methods_do_not_block_loop(
+        self, method_name, client_attr
+    ):
+        mock_tv2 = _make_mock_tasks_v2()
+        svc = _initialized_service(mock_tv2)
+        setattr(svc.client, client_attr, self._blocking_rpc())
+
+        with (
+            patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
+            patch.object(m, "tasks_v2", mock_tv2),
+        ):
+            _, ticks = await self._count_heartbeats_during(
+                getattr(svc, method_name)()
+            )
+
+        assert ticks > 0, (
+            f"{method_name} blocked the loop for the whole {self._RPC_SECONDS}s RPC "
+            f"({ticks} heartbeats)"
+        )
+
+    async def test_rpc_errors_still_propagate_from_worker_thread(self):
+        """Moving the call off-loop must not swallow client errors."""
+        mock_tv2 = _make_mock_tasks_v2()
+        svc = _initialized_service(mock_tv2)
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("quota exceeded")
+
+        svc.client.create_task = _boom
+
+        with (
+            patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
+            patch.object(m, "tasks_v2", mock_tv2),
+            pytest.raises(RuntimeError, match="quota exceeded"),
+        ):
+            await svc.enqueue_video_processing(self._video_task())
+
+    async def test_enqueue_batch_still_isolates_failures_off_loop(self):
+        """enqueue_batch's per-task error handling survives the thread hop."""
+        mock_tv2 = _make_mock_tasks_v2()
+        svc = _initialized_service(mock_tv2)
+
+        good = MagicMock()
+        good.name = ".../tasks/ok"
+        svc.client.create_task = MagicMock(
+            side_effect=[good, RuntimeError("network error"), good]
+        )
+
+        tasks = [
+            VideoProcessingTask(video_id=f"v{i}", video_url=f"https://y/{i}")
+            for i in range(3)
+        ]
+
+        with (
+            patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
+            patch.object(m, "tasks_v2", mock_tv2),
+        ):
+            ids = await svc.enqueue_batch(tasks)
+
+        assert ids == ["ok", "ok"]

--- a/tests/unit/test_cloud_tasks_queue.py
+++ b/tests/unit/test_cloud_tasks_queue.py
@@ -16,6 +16,7 @@ import asyncio
 import contextlib
 import json
 import sys
+import threading
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -1114,6 +1115,80 @@ class TestClientCallsDoNotBlockEventLoop:
             f"({ticks} heartbeats)"
         )
 
+    async def test_create_queue_existing_path_does_not_block_loop(self):
+        mock_tv2 = _make_mock_tasks_v2()
+        svc = _initialized_service(mock_tv2)
+        svc.client.get_queue = self._blocking_rpc(MagicMock())
+
+        with (
+            patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
+            patch.object(m, "tasks_v2", mock_tv2),
+        ):
+            _, ticks = await self._count_heartbeats_during(
+                svc.create_queue_if_not_exists()
+            )
+
+        svc.client.create_queue.assert_not_called()
+        assert ticks > 0, "get_queue blocked the event loop"
+
+    async def test_create_queue_fallback_does_not_block_loop(self):
+        mock_tv2 = _make_mock_tasks_v2()
+        svc = _initialized_service(mock_tv2)
+
+        def _missing(*_args, **_kwargs):
+            raise RuntimeError("queue not found")
+
+        svc.client.get_queue = _missing
+        svc.client.create_queue = self._blocking_rpc(MagicMock())
+
+        with (
+            patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
+            patch.object(m, "tasks_v2", mock_tv2),
+        ):
+            _, ticks = await self._count_heartbeats_during(
+                svc.create_queue_if_not_exists()
+            )
+
+        assert ticks > 0, "create_queue blocked the event loop"
+
+    async def test_cancellation_waits_for_in_flight_rpc(self):
+        mock_tv2 = _make_mock_tasks_v2()
+        svc = _initialized_service(mock_tv2)
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        response = MagicMock()
+        response.name = ".../tasks/cancelled"
+
+        def _blocking_create(*_args, **_kwargs):
+            started.set()
+            release.wait(timeout=1)
+            finished.set()
+            return response
+
+        svc.client.create_task = _blocking_create
+
+        with (
+            patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
+            patch.object(m, "tasks_v2", mock_tv2),
+        ):
+            enqueue = asyncio.create_task(
+                svc.enqueue_video_processing(self._video_task())
+            )
+            assert await asyncio.to_thread(started.wait, 1)
+            enqueue.cancel()
+            try:
+                await asyncio.sleep(0.02)
+                assert not enqueue.done(), (
+                    "cancellation propagated before the synchronous RPC finished"
+                )
+            finally:
+                release.set()
+
+            with pytest.raises(asyncio.CancelledError):
+                await enqueue
+
+        assert finished.is_set()
     async def test_rpc_errors_still_propagate_from_worker_thread(self):
         """Moving the call off-loop must not swallow client errors."""
         mock_tv2 = _make_mock_tasks_v2()


### PR DESCRIPTION
## Canonical issue

Closes #1189

## Outcome

`CloudTasksQueueService` wraps `tasks_v2.CloudTasksClient`, which is **synchronous**. Seven of
its RPCs were called directly from `async def` methods, so each one **stalled the entire event
loop** for a full network round-trip. Every other request served by that worker was frozen for
the duration.

This dispatches all seven through `asyncio.to_thread`.

| | Before | After |
|---|---|---|
| Event loop during an RPC | **blocked** for the whole round-trip | free to serve other work |
| Heartbeat ticks during a 150 ms RPC (test-measured) | **0** | > 0 |
| Public signatures / return values | — | unchanged |
| Error propagation | — | unchanged |

**What this does _not_ do**, stated plainly:

- It does **not** make any individual enqueue faster. A single call has the same latency.
- It does **not** reduce the number of Cloud Tasks API calls or affect quota.
- It does **not** make `enqueue_batch` concurrent — see Design notes.

The win is **worker-wide concurrency**, not per-call speed.

## Scope

One file, `src/youtube_extension/services/cloud/cloud_tasks_queue.py`: add module-level
`import asyncio`, wrap seven client calls in `await asyncio.to_thread(...)`.

`close()`, `queue_path()` and `task_path()` are untouched — the first is synchronous by
design, the latter two are pure string builders.

## Design notes

**Why `to_thread` and not `asyncio.gather`.** The obvious-looking change is to make
`enqueue_batch` concurrent. That would have been **pure theatre**: the coroutines it gathers
contain no `await` on their hot path, so `gather` would have run them strictly sequentially
anyway while still blocking the loop. Making the call yield is the *precondition* for any
future concurrency, and is the actual root cause.

**Why `enqueue_batch` is deliberately left sequential.** `TestEnqueueBatch::test_returns_all_task_ids_on_success`
pins result ordering (`ids == ["t0","t1","t2"]`) via a `MagicMock.side_effect` list. Under
`MagicMock`, `side_effect` consumption is `next()` on a shared iterator, so concurrent workers
would each get a distinct item but **nondeterministically** — making that test intermittently
flaky. Rewriting a passing test to accommodate a change is itself a smell, so I kept this PR
to the root-cause fix. Batch concurrency is a reasonable follow-up once the ordering contract
is made explicit.

**`asyncio.to_thread` forwards `**kwargs`**, so `asyncio.to_thread(self.client.get_queue, name=queue_path)`
works directly; no `functools.partial` wrapper is needed.

## Risk

**Low.** Behaviour-preserving by construction — `to_thread` propagates return values and
re-raises exceptions in the caller. The strongest evidence is that **all 58 pre-existing tests
pass with zero edits to the test file**.

The client object is used from a worker thread rather than the loop thread. `CloudTasksClient`
is documented as thread-safe (it wraps a gRPC channel, which is thread-safe), and one call is
in flight at a time per method.

Ruff: `All checks passed!` on both the changed module and the test file, matching `main`.

## Verification

At `2facfc47`:

```
tests/unit/test_cloud_tasks_queue.py .......................  65 passed
ruff check src/.../cloud_tasks_queue.py                       All checks passed!
ruff check tests/unit/test_cloud_tasks_queue.py               All checks passed!
```

58 of those 65 are pre-existing and were **not modified**.

**Non-vacuity.** Reverting the five measured `to_thread` hops to direct calls, keeping the
tests unchanged:

```
5 failed, 60 passed

AssertionError: event loop was blocked for the whole 0.15s RPC:
  the 0.005s heartbeat ticked 0 times
AssertionError: get_queue_stats blocked the loop for the whole 0.15s RPC (0 heartbeats)
AssertionError: pause_queue blocked the loop for the whole 0.15s RPC (0 heartbeats)
AssertionError: resume_queue blocked the loop for the whole 0.15s RPC (0 heartbeats)
AssertionError: purge_queue blocked the loop for the whole 0.15s RPC (0 heartbeats)
```

Exactly the five loop-responsiveness tests fail, and only those.

**Honest note:** the other two new tests — `test_rpc_errors_still_propagate_from_worker_thread`
and `test_enqueue_batch_still_isolates_failures_off_loop` — pass under **both** old and new
code. They are deliberate regression guards for the behaviour this PR must *not* change, not
proofs of the fix.

## Production evidence

Live in the primary production entrypoint (`youtube_extension.main:app`, root `Dockerfile:93`):

- module is in the transitive import closure of `main:app`
- `backend/api/v1/router.py:42` imports `CloudTasksQueueService`; instantiated at `router.py:1415`
- `enqueue_batch` additionally called from `cloud_video_processor.py:288`

## Agent handoff

Follow-up worth filing: make `enqueue_batch` concurrent once the `side_effect`-driven ordering
contract in its tests is replaced with an order-independent assertion.
