### PR TITLE
perf(performance-monitor): move blocking sqlite3 I/O off the event loop

### DIFF
--- a/src/youtube_extension/backend/services/performance_monitor.py
+++ b/src/youtube_extension/backend/services/performance_monitor.py
@@ -270,7 +270,8 @@ class PerformanceMonitor:
 
     async def _store_metric(self, metric: PerformanceMetric):
         """Store metric in database"""
-        try:
+
+        def _write() -> None:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
 
@@ -290,6 +291,8 @@ class PerformanceMonitor:
             conn.commit()
             conn.close()
 
+        try:
+            await asyncio.to_thread(_write)
         except Exception as e:
             logger.error(f"Failed to store metric in database: {e}")
 
@@ -353,7 +356,8 @@ class PerformanceMonitor:
 
     async def _store_alert(self, alert: PerformanceAlert):
         """Store alert in database"""
-        try:
+
+        def _write() -> None:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
 
@@ -375,6 +379,8 @@ class PerformanceMonitor:
             conn.commit()
             conn.close()
 
+        try:
+            await asyncio.to_thread(_write)
         except Exception as e:
             logger.error(f"Failed to store alert in database: {e}")
 
@@ -498,7 +504,8 @@ class PerformanceMonitor:
 
     async def _basic_cleanup(self):
         """Basic cleanup fallback when service is not available"""
-        try:
+
+        def _purge() -> None:
             cutoff_date = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
 
             conn = sqlite3.connect(self.db_path)
@@ -518,8 +525,9 @@ class PerformanceMonitor:
             conn.commit()
             conn.close()
 
+        try:
+            await asyncio.to_thread(_purge)
             logger.info("Basic cleanup completed successfully")
-
         except Exception as e:
             logger.error(f"Error in basic cleanup: {e}")
 
@@ -562,7 +570,8 @@ class PerformanceMonitor:
 
     async def get_current_performance_summary(self) -> dict[str, dict[str, float]]:
         """Get current performance summary (last hour averages)"""
-        try:
+
+        def _query() -> dict[str, dict[str, float]]:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
 
@@ -582,6 +591,8 @@ class PerformanceMonitor:
             conn.close()
             return dict(results)
 
+        try:
+            return await asyncio.to_thread(_query)
         except Exception as e:
             logger.error(f"Error getting performance summary: {e}")
             return {}
@@ -658,7 +669,8 @@ class PerformanceMonitor:
 
     async def _get_recent_metrics_summary(self) -> dict[str, Any]:
         """Get recent metrics summary"""
-        try:
+
+        def _query() -> dict[str, Any]:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
 
@@ -683,6 +695,8 @@ class PerformanceMonitor:
             conn.close()
             return metrics_summary
 
+        try:
+            return await asyncio.to_thread(_query)
         except Exception as e:
             logger.error(f"Error getting recent metrics summary: {e}")
             return {}
@@ -798,7 +812,8 @@ class PerformanceMonitor:
 
     async def _store_benchmark_result(self, result: dict[str, Any]):
         """Store benchmark result in database"""
-        try:
+
+        def _write() -> None:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
 
@@ -824,6 +839,8 @@ class PerformanceMonitor:
             conn.commit()
             conn.close()
 
+        try:
+            await asyncio.to_thread(_write)
         except Exception as e:
             logger.error(f"Failed to store benchmark result: {e}")
 

--- a/tests/unit/test_performance_monitor.py
+++ b/tests/unit/test_performance_monitor.py
@@ -17,14 +17,20 @@ import psutil as _real_psutil
 sys.modules['psutil'] = _real_psutil
 sys.modules.pop('youtube_extension.backend.services.performance_monitor', None)
 
+import asyncio
+import contextlib
+import sqlite3
+import time
 from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 
+from youtube_extension.backend.services import performance_monitor as perf_mod
 from youtube_extension.backend.services.performance_monitor import (
     PerformanceAlert,
     PerformanceMetric,
@@ -1002,3 +1008,139 @@ class TestPerformanceTimerDecorator:
 
         result = my_sync_func()
         assert result == "hello"
+
+
+# ===========================================================================
+# SQLite I/O must not block the event loop
+# ===========================================================================
+
+
+class TestSqliteDoesNotBlockEventLoop:
+    """`sqlite3` is fully synchronous: connect + INSERT + commit (fsync) + close.
+
+    `PerformanceMonitor.record_metric` runs on live request paths
+    (`api/v1/router.py:1165` and `:1183`), so every one of those calls used to
+    stall the event loop for the duration of the write.  These tests measure
+    whether an independent coroutine keeps getting scheduled while the database
+    work is in flight.
+    """
+
+    _DB_SECONDS = 0.15
+    _HEARTBEAT_INTERVAL = 0.01
+
+    @pytest.fixture
+    def monitor(self, tmp_path):
+        return PerformanceMonitor(db_path=str(tmp_path / "perf.db"))
+
+    def _slow_connect(self, real_connect):
+        """Wrap sqlite3.connect so the *synchronous* work takes a visible time."""
+
+        def _connect(*args, **kwargs):
+            time.sleep(self._DB_SECONDS)
+            return real_connect(*args, **kwargs)
+
+        return _connect
+
+    async def _count_heartbeats_during(self, coro):
+        ticks = 0
+        stop = False
+
+        async def heartbeat():
+            nonlocal ticks
+            while not stop:
+                await asyncio.sleep(self._HEARTBEAT_INTERVAL)
+                ticks += 1
+
+        beat = asyncio.create_task(heartbeat())
+        await asyncio.sleep(0)  # let the heartbeat reach its first await first
+        try:
+            result = await coro
+        finally:
+            stop = True
+            beat.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await beat
+        return result, ticks
+
+    async def test_store_metric_does_not_block_event_loop(self, monitor):
+        metric = PerformanceMetric(
+            component="api",
+            metric_name="api_response_time",
+            value=12.5,
+            timestamp=datetime.now(timezone.utc),
+            unit="ms",
+            tags={},
+        )
+        real = perf_mod.sqlite3.connect
+        with patch.object(perf_mod.sqlite3, "connect", self._slow_connect(real)):
+            _, ticks = await self._count_heartbeats_during(monitor._store_metric(metric))
+        assert ticks > 0, "event loop was blocked for the whole sqlite write"
+
+    async def test_record_metric_does_not_block_event_loop(self, monitor):
+        """The public request-path entry point, not just the private writer."""
+        real = perf_mod.sqlite3.connect
+        with patch.object(perf_mod.sqlite3, "connect", self._slow_connect(real)):
+            _, ticks = await self._count_heartbeats_during(
+                monitor.record_metric("api", "api_response_time", 12.5)
+            )
+        assert ticks > 0, "record_metric blocked the event loop"
+
+    async def test_read_path_does_not_block_event_loop(self, monitor):
+        real = perf_mod.sqlite3.connect
+        with patch.object(perf_mod.sqlite3, "connect", self._slow_connect(real)):
+            _, ticks = await self._count_heartbeats_during(
+                monitor.get_current_performance_summary()
+            )
+        assert ticks > 0, "the read path blocked the event loop"
+
+    # --- preserved-behaviour guards (pass under old and new code alike) -----
+
+    async def test_store_metric_still_writes_the_row(self, monitor):
+        metric = PerformanceMetric(
+            component="api",
+            metric_name="api_response_time",
+            value=42.0,
+            timestamp=datetime.now(timezone.utc),
+            unit="ms",
+            tags={"route": "/x"},
+        )
+        await monitor._store_metric(metric)
+
+        conn = sqlite3.connect(monitor.db_path)
+        rows = conn.execute(
+            "SELECT component, metric_name, value, unit FROM performance_metrics"
+        ).fetchall()
+        conn.close()
+        assert rows == [("api", "api_response_time", 42.0, "ms")]
+
+    async def test_summary_reflects_stored_metrics(self, monitor):
+        for value in (10.0, 20.0):
+            await monitor._store_metric(
+                PerformanceMetric(
+                    component="api",
+                    metric_name="api_response_time",
+                    value=value,
+                    timestamp=datetime.now(timezone.utc),
+                    unit="ms",
+                    tags={},
+                )
+            )
+        summary = await monitor.get_current_performance_summary()
+        assert summary["api"]["api_response_time"] == 15.0
+
+    async def test_store_metric_swallows_database_errors(self, monitor):
+        """Error handling must still absorb failures rather than propagate."""
+        metric = PerformanceMetric(
+            component="api",
+            metric_name="api_response_time",
+            value=1.0,
+            timestamp=datetime.now(timezone.utc),
+            unit="ms",
+            tags={},
+        )
+
+        def _boom(*_args, **_kwargs):
+            raise sqlite3.OperationalError("disk I/O error")
+
+        with patch.object(perf_mod.sqlite3, "connect", _boom):
+            await monitor._store_metric(metric)  # must not raise


### PR DESCRIPTION
## Canonical issue

Closes #1195

## Outcome

`PerformanceMonitor` used the synchronous `sqlite3` driver directly inside six `async def` methods. Every call ran connect → statement → `commit()` (which fsyncs) → `close()` **on the event loop**, so nothing else could be scheduled for the duration of the disk write.

This is on a live request path — `router.py:1165` and `:1183` `await performance_monitor.record_metric(...)`, and `record_metric` calls `_store_metric` unconditionally (no sampling, no enable flag).

| This change **does** | This change **does not** |
|---|---|
| Stop the event loop stalling during sqlite connect/commit/close | Make the queries themselves faster |
| Keep the API, SQL text and return values byte-identical | Change transaction boundaries or isolation |
| Let other coroutines run while a metric is being written | Make writes concurrent — SQLite still serialises writers |
| Preserve the existing swallow-and-log error handling | Add retries, pooling or WAL tuning |

The honest claim is **"stops stalling the event loop"**, not "faster". Under concurrent load that is the difference that matters: a request that records a metric no longer freezes every other in-flight request while the disk write completes.

## Scope

Six sites, all in `performance_monitor.py`, all the same defect and the same fix:

`_store_metric` · `_store_alert` · `_basic_cleanup` · `get_current_performance_summary` · `_get_recent_metrics_summary` · `_store_benchmark_result`

Each body moved verbatim into a nested sync function dispatched with `await asyncio.to_thread(...)`. Because the original bodies were already indented inside `try:`, they move into the nested `def` **without re-indentation** — so the diff is genuinely structural, not a rewrite.

## Design notes

**Why not `aiosqlite`?** It is not a dependency of this project, and adding a driver is a much larger change than this defect warrants. `asyncio.to_thread` uses the default executor and needs no new dependency.

**Why nested functions rather than methods?** They close over `self` and the local variables (`cutoff_date`, `metric`, …) that the original code already computed, so no signature or state has to be threaded through.

**No use-after-close hazard.** Converting a synchronous call to `to_thread` can introduce a use-after-close race when a caller tears the resource down in a `finally` — that exact bug was found in #1190. It does not apply here: every connection is opened *and* closed inside the same call, so there is no shared handle for a caller to close underneath an in-flight statement. `PerformanceMonitor` has no `close()`; `stop_monitoring()` only clears a task flag.

**`_init_database` deliberately untouched.** It is a synchronous method called from `__init__` — it never runs on the event loop, so wrapping it would add noise and no benefit.

## Risk

Low.

- No SQL, schema, transaction boundary or return type changed.
- All 113 existing tests pass **with zero test edits** — the observable contract is unchanged.
- `sqlite3` connections are thread-affine (`check_same_thread=True` by default). That constraint is *satisfied*, not violated: each connection is created, used and closed entirely within a single `to_thread` call, so it never crosses threads.
- Failure mode if the executor is saturated is a delay, not an error; the existing `except Exception` handlers are unchanged.

## Verification

All results below are at head `b38b9fdb3`.

```
119 passed
```

- **113 pre-existing tests pass with zero test edits**
- +6 new in `TestSqliteDoesNotBlockEventLoop`: 3 loop-responsiveness tests and 3 preserved-behaviour guards

**Non-vacuity, by behavioural mutation.** Deleting the code would raise `AttributeError`s, which proves nothing. Instead all six `to_thread` dispatches were replaced with direct synchronous calls, keeping everything else identical:

```
MUTATED 6 dispatch sites -> direct sync calls

FAILED TestSqliteDoesNotBlockEventLoop::test_store_metric_does_not_block_event_loop
FAILED TestSqliteDoesNotBlockEventLoop::test_record_metric_does_not_block_event_loop
FAILED TestSqliteDoesNotBlockEventLoop::test_read_path_does_not_block_event_loop
3 failed, 116 passed
```

Exactly the 3 responsiveness tests fail and nothing else. A uniform "everything failed" would have meant the proof was structural rather than behavioural.

The test measures whether an independent heartbeat coroutine keeps getting scheduled while `sqlite3.connect` is artificially slowed:

```python
beat = asyncio.create_task(heartbeat())
await asyncio.sleep(0)          # let the heartbeat reach its first await first
result = await coro
assert ticks > 0
```

Blocking → 0 ticks. Off-loop → > 0.

**Honest note:** the 3 guards (`test_store_metric_still_writes_the_row`, `test_summary_reflects_stored_metrics`, `test_store_metric_swallows_database_errors`) pass under both old and new code *by design*. They exist to pin behaviour the change must not regress, not to prove the change. Only the 3 heartbeat tests discriminate.

**ruff:** `All checks passed!` on both touched files, exact parity with `main`.

## Production evidence

`youtube_extension.backend.services.performance_monitor` is in the transitive import closure of the production entrypoint `youtube_extension.main:app` (root `Dockerfile:93`).

```
router.py:69    from ...services.performance_monitor import PerformanceMonitor
router.py:1165  await performance_monitor.record_metric(...)
router.py:1183  await performance_monitor.record_metric(...)
     -> record_metric        (performance_monitor.py:231)
     -> await self._store_metric(metric)   (:261, unconditional)
     -> sqlite3.connect + INSERT + commit  (:274)
```

Other live callers: `memory_manager.py:472/475`, `load_balancer.py:381`, `database_optimizer.py:49`.

## Agent handoff

Reviewers: the interesting questions are in **Design notes** and the **Verification** mutation output. Specific challenges are posted as a separate comment.
