### PR TITLE
fix(ci): stop gitleaks flagging uv.lock PyPI package hashes

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,4 +14,9 @@ paths = [
   '''docs/security/.*''',
   # Test fixtures use obvious dummy keys (e.g. "xai-secret-123"), not real secrets.
   '''tests/.*''',
+  # uv-generated lockfile: contains only package coordinates and PyPI sha256
+  # artifact hashes (e.g. parso's `hash = "sha256:eaaa..."`), which the default
+  # `square-access-token` rule misfires on. It is machine-generated and never
+  # hand-edited, so it holds no EventRelay credentials.
+  '''(^|/)uv\.lock$''',
 ]


### PR DESCRIPTION
## Canonical issue

No pre-existing issue — this CI-hygiene regression was discovered while reviewing PR #1194, whose only red real-CI check (`gitleaks (working tree)`) is caused by this false positive rather than by that PR's diff.

## Outcome

The `gitleaks (working tree)` job stops failing on every new PR. A recently-added lockfile entry trips gitleaks' default `square-access-token` rule:

```
Finding:  ...gz", hash = "sha256:REDACTED, size = 401824, upl...
RuleID:   square-access-token
File:     uv.lock:5129        (parso 0.8.7 sdist hash)
```

That string is a PyPI artifact **sha256 hash**, not a credential. Because it lives on `main` now, it reds the gitleaks check on *every* branch cut after it landed (e.g. #1194); PRs cut before it — such as #1075 — still pass, which pinpoints the lockfile line as the source.

## Scope

- **Included:** one allowlist entry in `.gitleaks.toml` for the `uv.lock` path.
- **Explicitly excluded:** no rule changes, no other lockfiles (only `uv.lock` was observed tripping the scan; JS lockfiles can get the same treatment if/when they do).

`uv.lock` is machine-generated by `uv` and never hand-edited, so allowlisting it holds no EventRelay credentials — consistent with how this config already allowlists other generated/vendored assets (`docs/gemini_reference/`, `docs/security/`, `tests/`).

## Risk

- Risk level: **low**
- Failure mode: a real secret pasted into `uv.lock` would no longer be scanned — negligible, as the file is tool-generated and not hand-edited.
- Rollback: revert the single added allowlist line.

## Verification

Run at head `d6cdaa5` with gitleaks **8.18.4** (the version CI installs), using the exact CI command `gitleaks detect --no-git --config .gitleaks.toml --redact --exit-code 1`:

- [x] Focused check — **before:** `exit 1, "leaks found: 1"`; **after:** `exit 0, "no leaks found"`
- [x] Config parses (`tomllib.load` OK)
- [ ] Required CI — will run on this PR
- [ ] Review threads resolved

## Production evidence

Not applicable — this changes only CI secret-scan configuration; no runtime or deployed code is touched.

## Agent handoff

- [ ] One canonical issue is linked — none exists; fix found during review of #1194
- [x] No competing PR implements the same issue
- [x] Acceptance criteria are satisfied (gitleaks passes on current tree)
- [ ] Required checks pass on the current head — pending CI
- [x] Human decision is requested for merge (protected `main`)

---
_Generated by [Claude Code](https://claude.ai/code/session_0131w7V9YdkuBdMvktHLwdz2)_