### PR TITLE
perf(performance-monitor): move blocking sqlite3 I/O off the event loop

### DIFF
--- a/src/youtube_extension/backend/services/performance_monitor.py
+++ b/src/youtube_extension/backend/services/performance_monitor.py
@@ -270,7 +270,8 @@ class PerformanceMonitor:
 
     async def _store_metric(self, metric: PerformanceMetric):
         """Store metric in database"""
-        try:
+
+        def _write() -> None:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
 
@@ -290,6 +291,8 @@ class PerformanceMonitor:
             conn.commit()
             conn.close()
 
+        try:
+            await asyncio.to_thread(_write)
         except Exception as e:
             logger.error(f"Failed to store metric in database: {e}")
 
@@ -353,7 +356,8 @@ class PerformanceMonitor:
 
     async def _store_alert(self, alert: PerformanceAlert):
         """Store alert in database"""
-        try:
+
+        def _write() -> None:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
 
@@ -375,6 +379,8 @@ class PerformanceMonitor:
             conn.commit()
             conn.close()
 
+        try:
+            await asyncio.to_thread(_write)
         except Exception as e:
             logger.error(f"Failed to store alert in database: {e}")
 
@@ -498,7 +504,8 @@ class PerformanceMonitor:
 
     async def _basic_cleanup(self):
         """Basic cleanup fallback when service is not available"""
-        try:
+
+        def _purge() -> None:
             cutoff_date = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
 
             conn = sqlite3.connect(self.db_path)
@@ -518,8 +525,9 @@ class PerformanceMonitor:
             conn.commit()
             conn.close()
 
+        try:
+            await asyncio.to_thread(_purge)
             logger.info("Basic cleanup completed successfully")
-
         except Exception as e:
             logger.error(f"Error in basic cleanup: {e}")
 
@@ -562,7 +570,8 @@ class PerformanceMonitor:
 
     async def get_current_performance_summary(self) -> dict[str, dict[str, float]]:
         """Get current performance summary (last hour averages)"""
-        try:
+
+        def _query() -> dict[str, dict[str, float]]:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
 
@@ -582,6 +591,8 @@ class PerformanceMonitor:
             conn.close()
             return dict(results)
 
+        try:
+            return await asyncio.to_thread(_query)
         except Exception as e:
             logger.error(f"Error getting performance summary: {e}")
             return {}
@@ -658,7 +669,8 @@ class PerformanceMonitor:
 
     async def _get_recent_metrics_summary(self) -> dict[str, Any]:
         """Get recent metrics summary"""
-        try:
+
+        def _query() -> dict[str, Any]:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
 
@@ -683,6 +695,8 @@ class PerformanceMonitor:
             conn.close()
             return metrics_summary
 
+        try:
+            return await asyncio.to_thread(_query)
         except Exception as e:
             logger.error(f"Error getting recent metrics summary: {e}")
             return {}
@@ -798,7 +812,8 @@ class PerformanceMonitor:
 
     async def _store_benchmark_result(self, result: dict[str, Any]):
         """Store benchmark result in database"""
-        try:
+
+        def _write() -> None:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
 
@@ -824,6 +839,8 @@ class PerformanceMonitor:
             conn.commit()
             conn.close()
 
+        try:
+            await asyncio.to_thread(_write)
         except Exception as e:
             logger.error(f"Failed to store benchmark result: {e}")
 

--- a/tests/unit/test_performance_monitor.py
+++ b/tests/unit/test_performance_monitor.py
@@ -17,14 +17,20 @@ import psutil as _real_psutil
 sys.modules['psutil'] = _real_psutil
 sys.modules.pop('youtube_extension.backend.services.performance_monitor', None)
 
+import asyncio
+import contextlib
+import sqlite3
+import time
 from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 
+from youtube_extension.backend.services import performance_monitor as perf_mod
 from youtube_extension.backend.services.performance_monitor import (
     PerformanceAlert,
     PerformanceMetric,
@@ -1002,3 +1008,139 @@ class TestPerformanceTimerDecorator:
 
         result = my_sync_func()
         assert result == "hello"
+
+
+# ===========================================================================
+# SQLite I/O must not block the event loop
+# ===========================================================================
+
+
+class TestSqliteDoesNotBlockEventLoop:
+    """`sqlite3` is fully synchronous: connect + INSERT + commit (fsync) + close.
+
+    `PerformanceMonitor.record_metric` runs on live request paths
+    (`api/v1/router.py:1165` and `:1183`), so every one of those calls used to
+    stall the event loop for the duration of the write.  These tests measure
+    whether an independent coroutine keeps getting scheduled while the database
+    work is in flight.
+    """
+
+    _DB_SECONDS = 0.15
+    _HEARTBEAT_INTERVAL = 0.01
+
+    @pytest.fixture
+    def monitor(self, tmp_path):
+        return PerformanceMonitor(db_path=str(tmp_path / "perf.db"))
+
+    def _slow_connect(self, real_connect):
+        """Wrap sqlite3.connect so the *synchronous* work takes a visible time."""
+
+        def _connect(*args, **kwargs):
+            time.sleep(self._DB_SECONDS)
+            return real_connect(*args, **kwargs)
+
+        return _connect
+
+    async def _count_heartbeats_during(self, coro):
+        ticks = 0
+        stop = False
+
+        async def heartbeat():
+            nonlocal ticks
+            while not stop:
+                await asyncio.sleep(self._HEARTBEAT_INTERVAL)
+                ticks += 1
+
+        beat = asyncio.create_task(heartbeat())
+        await asyncio.sleep(0)  # let the heartbeat reach its first await first
+        try:
+            result = await coro
+        finally:
+            stop = True
+            beat.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await beat
+        return result, ticks
+
+    async def test_store_metric_does_not_block_event_loop(self, monitor):
+        metric = PerformanceMetric(
+            component="api",
+            metric_name="api_response_time",
+            value=12.5,
+            timestamp=datetime.now(timezone.utc),
+            unit="ms",
+            tags={},
+        )
+        real = perf_mod.sqlite3.connect
+        with patch.object(perf_mod.sqlite3, "connect", self._slow_connect(real)):
+            _, ticks = await self._count_heartbeats_during(monitor._store_metric(metric))
+        assert ticks > 0, "event loop was blocked for the whole sqlite write"
+
+    async def test_record_metric_does_not_block_event_loop(self, monitor):
+        """The public request-path entry point, not just the private writer."""
+        real = perf_mod.sqlite3.connect
+        with patch.object(perf_mod.sqlite3, "connect", self._slow_connect(real)):
+            _, ticks = await self._count_heartbeats_during(
+                monitor.record_metric("api", "api_response_time", 12.5)
+            )
+        assert ticks > 0, "record_metric blocked the event loop"
+
+    async def test_read_path_does_not_block_event_loop(self, monitor):
+        real = perf_mod.sqlite3.connect
+        with patch.object(perf_mod.sqlite3, "connect", self._slow_connect(real)):
+            _, ticks = await self._count_heartbeats_during(
+                monitor.get_current_performance_summary()
+            )
+        assert ticks > 0, "the read path blocked the event loop"
+
+    # --- preserved-behaviour guards (pass under old and new code alike) -----
+
+    async def test_store_metric_still_writes_the_row(self, monitor):
+        metric = PerformanceMetric(
+            component="api",
+            metric_name="api_response_time",
+            value=42.0,
+            timestamp=datetime.now(timezone.utc),
+            unit="ms",
+            tags={"route": "/x"},
+        )
+        await monitor._store_metric(metric)
+
+        conn = sqlite3.connect(monitor.db_path)
+        rows = conn.execute(
+            "SELECT component, metric_name, value, unit FROM performance_metrics"
+        ).fetchall()
+        conn.close()
+        assert rows == [("api", "api_response_time", 42.0, "ms")]
+
+    async def test_summary_reflects_stored_metrics(self, monitor):
+        for value in (10.0, 20.0):
+            await monitor._store_metric(
+                PerformanceMetric(
+                    component="api",
+                    metric_name="api_response_time",
+                    value=value,
+                    timestamp=datetime.now(timezone.utc),
+                    unit="ms",
+                    tags={},
+                )
+            )
+        summary = await monitor.get_current_performance_summary()
+        assert summary["api"]["api_response_time"] == 15.0
+
+    async def test_store_metric_swallows_database_errors(self, monitor):
+        """Error handling must still absorb failures rather than propagate."""
+        metric = PerformanceMetric(
+            component="api",
+            metric_name="api_response_time",
+            value=1.0,
+            timestamp=datetime.now(timezone.utc),
+            unit="ms",
+            tags={},
+        )
+
+        def _boom(*_args, **_kwargs):
+            raise sqlite3.OperationalError("disk I/O error")
+
+        with patch.object(perf_mod.sqlite3, "connect", _boom):
+            await monitor._store_metric(metric)  # must not raise


### PR DESCRIPTION
## Canonical issue

Closes # <!-- no dedicated issue; standalone event-loop-blocking fix -->

## Outcome

`PerformanceMonitor` used the fully synchronous `sqlite3` driver directly inside six `async def` methods. Each call ran connect + statement + commit (fsync) + close **on the event loop**, stalling every other coroutine for the duration of the disk write. Because `record_metric()` is awaited on live request paths (`api/v1/router.py:1165` and `:1183`), each metric write blocked request handling. This PR moves that I/O onto a worker thread so the loop stays responsive.

## Scope

- Included: `_store_metric`, `_store_alert`, `_basic_cleanup`, `get_current_performance_summary`, `_get_recent_metrics_summary`, `_store_benchmark_result` — each DB block is now a nested sync function dispatched via `await asyncio.to_thread(...)`. Statement text, transaction boundaries, return values, and error handling are unchanged; only the thread the work runs on changes.
- Explicitly excluded: `_init_database` — it is a synchronous method called from `__init__`, so it never runs on the event loop.

## Risk

- Risk level: low
- Failure mode: connections are opened and closed inside each `to_thread` call, so there is no shared handle a caller could tear down mid-flight; a thread-pool exhaustion would degrade to the same latency as before, not error.
- Rollback: revert this commit; behaviour returns to synchronous on-loop writes.

## Verification

- [x] Focused tests — `pytest tests/unit/test_performance_monitor.py`: **119 passed** (113 pre-existing unchanged + 6 new in `TestSqliteDoesNotBlockEventLoop`)
- [x] Non-vacuity — replacing all six `to_thread` dispatches with direct calls fails exactly the 3 heartbeat tests and no others
- [ ] Required CI — pending on this head
- [ ] Review threads resolved — pending review

## Production evidence

Not applicable — internal service latency change with no user-facing surface; effect is reduced event-loop stall during metric persistence, covered by the heartbeat tests.

## Agent handoff

- [ ] One canonical issue is linked — no dedicated issue exists
- [x] No competing PR implements the same issue
- [x] Acceptance criteria are satisfied
- [ ] Required checks pass on the current head — pending CI
- [x] Human decision is requested for merge (protected `main`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMAb43Z8DCW5TQLWyotowc)_