### PR TITLE
perf(cloud-ai): run AWS Rekognition boto3 calls off the event loop

### DIFF
--- a/src/youtube_extension/integrations/cloud_ai/providers/aws_rekognition.py
+++ b/src/youtube_extension/integrations/cloud_ai/providers/aws_rekognition.py
@@ -11,6 +11,8 @@ Implements video and image analysis using AWS Rekognition:
 
 import asyncio
 import logging
+import math
+import os
 from datetime import datetime
 from typing import Any
 
@@ -29,6 +31,79 @@ from ..exceptions import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Default botocore timeouts. Every Rekognition/S3 call in this module runs via
+# ``asyncio.to_thread``, i.e. on the *shared* default executor. Without an
+# explicit read timeout a stalled AWS request pins one of the pool's limited
+# worker threads indefinitely, which would starve every other ``to_thread``
+# user in the process. Bounding the request bounds the worker.
+_DEFAULT_CONNECT_TIMEOUT = 10.0
+_DEFAULT_READ_TIMEOUT = 60.0
+_DEFAULT_MAX_ATTEMPTS = 3
+
+
+def _positive_finite_float_env(name: str, default: float) -> float:
+    """Read a strictly positive, finite float from the environment."""
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise ConfigurationError(
+            f"{name} must be a number, got {raw!r}",
+            provider=CloudAIProvider.AWS_REKOGNITION.value,
+        ) from exc
+    if not math.isfinite(value) or value <= 0:
+        raise ConfigurationError(
+            f"{name} must be a positive finite number, got {raw!r}",
+            provider=CloudAIProvider.AWS_REKOGNITION.value,
+        )
+    return value
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    """Read a strictly positive integer from the environment."""
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ConfigurationError(
+            f"{name} must be an integer, got {raw!r}",
+            provider=CloudAIProvider.AWS_REKOGNITION.value,
+        ) from exc
+    if value <= 0:
+        raise ConfigurationError(
+            f"{name} must be a positive integer, got {raw!r}",
+            provider=CloudAIProvider.AWS_REKOGNITION.value,
+        )
+    return value
+
+
+def _timeout_config_kwargs() -> dict:
+    """Parse botocore timeout settings from the environment.
+
+    Kept separate from ``initialize`` so a bad value raises ConfigurationError
+    with its precise message instead of being re-wrapped as a generic
+    CloudAIError by that method's catch-all handler.
+    """
+    return {
+        'connect_timeout': _positive_finite_float_env(
+            'AWS_REKOGNITION_CONNECT_TIMEOUT', _DEFAULT_CONNECT_TIMEOUT
+        ),
+        'read_timeout': _positive_finite_float_env(
+            'AWS_REKOGNITION_READ_TIMEOUT', _DEFAULT_READ_TIMEOUT
+        ),
+        'retries': {
+            'max_attempts': _positive_int_env(
+                'AWS_REKOGNITION_MAX_ATTEMPTS', _DEFAULT_MAX_ATTEMPTS
+            ),
+            'mode': 'standard',
+        },
+    }
 
 
 def _read_file_bytes(path: str) -> bytes:
@@ -64,8 +139,12 @@ class AWSRekognition(BaseCloudAI):
 
     async def initialize(self) -> None:
         """Initialize AWS Rekognition client."""
+        # Parsed before the try so a misconfigured value surfaces as a
+        # ConfigurationError rather than the catch-all CloudAIError below.
+        timeout_kwargs = _timeout_config_kwargs()
         try:
             import boto3
+            from botocore.config import Config as BotoConfig
             from botocore.exceptions import ClientError, NoCredentialsError
 
             # Create session with credentials
@@ -75,9 +154,15 @@ class AWSRekognition(BaseCloudAI):
                 region_name=self.config["region"]
             )
 
+            # Bound every request so a stalled call cannot hold a shared
+            # executor thread forever (all SDK calls here run in to_thread).
+            client_config = BotoConfig(**timeout_kwargs)
+
             # Initialize clients
-            self._rekognition_client = session.client('rekognition')
-            self._s3_client = session.client('s3')
+            self._rekognition_client = session.client(
+                'rekognition', config=client_config
+            )
+            self._s3_client = session.client('s3', config=client_config)
 
             # Test connection
             await self._test_connection()

--- a/src/youtube_extension/integrations/cloud_ai/providers/aws_rekognition.py
+++ b/src/youtube_extension/integrations/cloud_ai/providers/aws_rekognition.py
@@ -31,6 +31,13 @@ from ..exceptions import (
 logger = logging.getLogger(__name__)
 
 
+def _read_file_bytes(path: str) -> bytes:
+    """Read a file's bytes. Module-level so it can run in a worker thread."""
+    with open(path, 'rb') as handle:
+        return handle.read()
+
+
+
 class AWSRekognition(BaseCloudAI):
     """Amazon Rekognition video and image analysis integration."""
 
@@ -103,8 +110,9 @@ class AWSRekognition(BaseCloudAI):
         """Test AWS Rekognition connection."""
         try:
             # Simple API call to test connectivity
-            self._rekognition_client.describe_collection(
-                CollectionId='non-existent-collection'
+            await asyncio.to_thread(
+                self._rekognition_client.describe_collection,
+                CollectionId='non-existent-collection',
             )
         except Exception as e:
             if "ResourceNotFoundException" in str(e):
@@ -174,27 +182,31 @@ class AWSRekognition(BaseCloudAI):
             results = {}
 
             if AnalysisType.LABEL_DETECTION in analysis_types:
-                results['labels'] = self._rekognition_client.detect_labels(
+                results['labels'] = await asyncio.to_thread(
+                    self._rekognition_client.detect_labels,
                     Image=image_data,
                     MaxLabels=50,
-                    MinConfidence=0.5
+                    MinConfidence=0.5,
                 )
 
             if AnalysisType.FACE_DETECTION in analysis_types:
-                results['faces'] = self._rekognition_client.detect_faces(
+                results['faces'] = await asyncio.to_thread(
+                    self._rekognition_client.detect_faces,
                     Image=image_data,
-                    Attributes=['ALL']
+                    Attributes=['ALL'],
                 )
 
             if AnalysisType.TEXT_DETECTION in analysis_types:
-                results['text'] = self._rekognition_client.detect_text(
-                    Image=image_data
+                results['text'] = await asyncio.to_thread(
+                    self._rekognition_client.detect_text,
+                    Image=image_data,
                 )
 
             if AnalysisType.CONTENT_MODERATION in analysis_types:
-                results['moderation'] = self._rekognition_client.detect_moderation_labels(
+                results['moderation'] = await asyncio.to_thread(
+                    self._rekognition_client.detect_moderation_labels,
                     Image=image_data,
-                    MinConfidence=0.5
+                    MinConfidence=0.5,
                 )
 
             processing_time = (datetime.utcnow() - start_time).total_seconds()
@@ -219,8 +231,9 @@ class AWSRekognition(BaseCloudAI):
 
             # Test with describe_collection call
             try:
-                self._rekognition_client.describe_collection(
-                    CollectionId='health-check-collection'
+                await asyncio.to_thread(
+                    self._rekognition_client.describe_collection,
+                    CollectionId='health-check-collection',
                 )
             except Exception as e:
                 if "ResourceNotFoundException" in str(e):
@@ -278,28 +291,32 @@ class AWSRekognition(BaseCloudAI):
 
         # Start different analysis operations based on requested types
         if AnalysisType.LABEL_DETECTION in analysis_types:
-            response = self._rekognition_client.start_label_detection(
+            response = await asyncio.to_thread(
+                self._rekognition_client.start_label_detection,
                 Video=video_input,
-                MinConfidence=0.5
+                MinConfidence=0.5,
             )
             job_ids['labels'] = response['JobId']
 
         if AnalysisType.FACE_DETECTION in analysis_types:
-            response = self._rekognition_client.start_face_detection(
-                Video=video_input
+            response = await asyncio.to_thread(
+                self._rekognition_client.start_face_detection,
+                Video=video_input,
             )
             job_ids['faces'] = response['JobId']
 
         if AnalysisType.TEXT_DETECTION in analysis_types:
-            response = self._rekognition_client.start_text_detection(
-                Video=video_input
+            response = await asyncio.to_thread(
+                self._rekognition_client.start_text_detection,
+                Video=video_input,
             )
             job_ids['text'] = response['JobId']
 
         if AnalysisType.CONTENT_MODERATION in analysis_types:
-            response = self._rekognition_client.start_content_moderation(
+            response = await asyncio.to_thread(
+                self._rekognition_client.start_content_moderation,
                 Video=video_input,
-                MinConfidence=0.5
+                MinConfidence=0.5,
             )
             job_ids['moderation'] = response['JobId']
 
@@ -326,13 +343,25 @@ class AWSRekognition(BaseCloudAI):
         while elapsed_time < max_wait_time:
             try:
                 if analysis_type == 'labels':
-                    response = self._rekognition_client.get_label_detection(JobId=job_id)
+                    response = await asyncio.to_thread(
+                        self._rekognition_client.get_label_detection,
+                        JobId=job_id,
+                    )
                 elif analysis_type == 'faces':
-                    response = self._rekognition_client.get_face_detection(JobId=job_id)
+                    response = await asyncio.to_thread(
+                        self._rekognition_client.get_face_detection,
+                        JobId=job_id,
+                    )
                 elif analysis_type == 'text':
-                    response = self._rekognition_client.get_text_detection(JobId=job_id)
+                    response = await asyncio.to_thread(
+                        self._rekognition_client.get_text_detection,
+                        JobId=job_id,
+                    )
                 elif analysis_type == 'moderation':
-                    response = self._rekognition_client.get_content_moderation(JobId=job_id)
+                    response = await asyncio.to_thread(
+                        self._rekognition_client.get_content_moderation,
+                        JobId=job_id,
+                    )
                 else:
                     raise ValueError(f"Unknown analysis type: {analysis_type}")
 
@@ -369,9 +398,8 @@ class AWSRekognition(BaseCloudAI):
                 response = await client.get(image_url)
                 return {'Bytes': response.content}
         else:
-            # Local file
-            with open(image_url, 'rb') as image_file:
-                return {'Bytes': image_file.read()}
+            # Local file - read off the event loop
+            return {'Bytes': await asyncio.to_thread(_read_file_bytes, image_url)}
 
     def _process_video_results(self, results: dict[str, Any], video_id: str,
                              analysis_types: list[AnalysisType],

--- a/tests/unit/test_aws_rekognition_provider.py
+++ b/tests/unit/test_aws_rekognition_provider.py
@@ -1157,6 +1157,7 @@ class TestRekognitionDoesNotBlockEventLoop:
         assert ticks > 0, (
             f"describe_collection in {provider_method} blocked the event loop"
         )
+
     async def test_local_image_read_runs_off_the_event_loop_thread(self, tmp_path):
         """
         Deterministic counterpart to the heartbeat tests.
@@ -1168,23 +1169,24 @@ class TestRekognitionDoesNotBlockEventLoop:
         """
         import threading
 
-        from youtube_extension.integrations.cloud_ai.providers import (
-            aws_rekognition as _rek_mod,
-        )
-
         image = tmp_path / "frame.jpg"
         image.write_bytes(b"BINARY-IMAGE-PAYLOAD")
         provider = _make_provider()
 
+        # Patch the exact namespace that _prepare_image_input resolves from.
+        # Other test modules evict cloud_ai modules from sys.modules during
+        # collection, so re-importing the module here can patch a stale object.
+        method_globals = type(provider)._prepare_image_input.__globals__
+        real_read = method_globals["_read_file_bytes"]
+
         loop_thread_id = threading.get_ident()
         observed: dict[str, int] = {}
-        real_read = _rek_mod._read_file_bytes
 
         def _recording_read(path):
             observed['thread_id'] = threading.get_ident()
             return real_read(path)
 
-        with patch.object(_rek_mod, '_read_file_bytes', _recording_read):
+        with patch.dict(method_globals, {"_read_file_bytes": _recording_read}):
             result = await provider._prepare_image_input(str(image))
 
         assert result == {'Bytes': b"BINARY-IMAGE-PAYLOAD"}

--- a/tests/unit/test_aws_rekognition_provider.py
+++ b/tests/unit/test_aws_rekognition_provider.py
@@ -1121,7 +1121,17 @@ class TestRekognitionDoesNotBlockEventLoop:
         assert result == {'labels': 'j-1'}
         assert ticks > 0, "start_label_detection blocked the event loop"
 
-    async def test_local_image_read_does_not_stall_the_event_loop(self, tmp_path):
+    async def test_local_image_read_runs_off_the_event_loop_thread(self, tmp_path):
+        """
+        Deterministic counterpart to the heartbeat tests.
+
+        The local read is far too fast to time reliably on a loaded runner, so
+        instead of measuring elapsed ticks this asserts the property directly:
+        the read must execute on a worker thread, not on the thread running the
+        event loop. This is immune to scheduler load and needs no sleeps.
+        """
+        import threading
+
         from youtube_extension.integrations.cloud_ai.providers import (
             aws_rekognition as _rek_mod,
         )
@@ -1130,20 +1140,23 @@ class TestRekognitionDoesNotBlockEventLoop:
         image.write_bytes(b"BINARY-IMAGE-PAYLOAD")
         provider = _make_provider()
 
+        loop_thread_id = threading.get_ident()
+        observed: dict[str, int] = {}
         real_read = _rek_mod._read_file_bytes
 
-        def _slow_read(path):
-            import time
-            time.sleep(0.12)
+        def _recording_read(path):
+            observed['thread_id'] = threading.get_ident()
             return real_read(path)
 
-        with patch.object(_rek_mod, '_read_file_bytes', _slow_read):
-            result, ticks = await _count_heartbeats(
-                provider._prepare_image_input(str(image))
-            )
+        with patch.object(_rek_mod, '_read_file_bytes', _recording_read):
+            result = await provider._prepare_image_input(str(image))
 
         assert result == {'Bytes': b"BINARY-IMAGE-PAYLOAD"}
-        assert ticks > 0, "the local image read blocked the event loop"
+        assert 'thread_id' in observed, "_read_file_bytes was never called"
+        assert observed['thread_id'] != loop_thread_id, (
+            "the local image read ran on the event loop thread instead of "
+            "being dispatched to a worker thread"
+        )
 
     async def test_local_image_bytes_are_read_correctly(self, tmp_path):
         """Guard: offloading must not change what is returned."""

--- a/tests/unit/test_aws_rekognition_provider.py
+++ b/tests/unit/test_aws_rekognition_provider.py
@@ -1004,3 +1004,154 @@ class TestAWSRekognitionEstimateCost:
         cost1 = provider.estimate_cost(60.0, [AnalysisType.LABEL_DETECTION])
         cost2 = provider.estimate_cost(120.0, [AnalysisType.LABEL_DETECTION])
         assert cost2 == pytest.approx(cost1 * 2)
+
+
+# ===========================================================================
+# Event-loop responsiveness: every boto3 call must run off the loop
+# ===========================================================================
+
+async def _count_heartbeats(coro, tick: float = 0.005) -> tuple[object, int]:
+    """Run ``coro`` while a heartbeat task ticks; return (result, ticks).
+
+    If the awaited work performs blocking I/O directly on the event loop the
+    heartbeat never gets scheduled and ``ticks`` stays at 0.
+    """
+    import asyncio
+    import contextlib
+
+    ticks = 0
+    stop = False
+
+    async def _beat():
+        nonlocal ticks
+        while not stop:
+            await asyncio.sleep(tick)
+            ticks += 1
+
+    beat = asyncio.create_task(_beat())
+    await asyncio.sleep(0)  # let the heartbeat reach its first await first
+    try:
+        result = await coro
+    finally:
+        stop = True
+        beat.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await beat
+    return result, ticks
+
+
+def _slow(return_value, delay: float = 0.12):
+    """A synchronous callable that blocks for ``delay`` seconds."""
+    import time
+
+    def _call(*_args, **_kwargs):
+        time.sleep(delay)
+        return return_value
+
+    return _call
+
+
+class TestRekognitionDoesNotBlockEventLoop:
+    async def test_analyze_image_does_not_stall_the_event_loop(self):
+        provider = _make_provider()
+        mock_client = _make_rekognition_client()
+        mock_client.detect_labels.side_effect = _slow({"Labels": []})
+        provider._rekognition_client = mock_client
+
+        with patch.object(provider, '_prepare_image_input',
+                          new=AsyncMock(return_value={"Bytes": b"img"})):
+            result, ticks = await _count_heartbeats(
+                provider.analyze_image("http://e.com/i.jpg", [AnalysisType.LABEL_DETECTION])
+            )
+
+        assert isinstance(result, VideoAnalysisResult)
+        assert ticks > 0, "detect_labels blocked the event loop"
+
+    async def test_every_detection_type_runs_off_the_loop(self):
+        provider = _make_provider()
+        mock_client = _make_rekognition_client()
+        # four blocking calls back to back
+        mock_client.detect_labels.side_effect = _slow({"Labels": []}, 0.06)
+        mock_client.detect_faces.side_effect = _slow({"FaceDetails": []}, 0.06)
+        mock_client.detect_text.side_effect = _slow({"TextDetections": []}, 0.06)
+        mock_client.detect_moderation_labels.side_effect = _slow({"ModerationLabels": []}, 0.06)
+        provider._rekognition_client = mock_client
+
+        with patch.object(provider, '_prepare_image_input',
+                          new=AsyncMock(return_value={"Bytes": b"img"})):
+            _result, ticks = await _count_heartbeats(
+                provider.analyze_image(
+                    "http://e.com/i.jpg",
+                    [AnalysisType.LABEL_DETECTION, AnalysisType.FACE_DETECTION,
+                     AnalysisType.TEXT_DETECTION, AnalysisType.CONTENT_MODERATION],
+                )
+            )
+
+        mock_client.detect_labels.assert_called_once()
+        mock_client.detect_moderation_labels.assert_called_once()
+        assert ticks > 0, "the detect_* chain blocked the event loop"
+
+    async def test_job_polling_does_not_stall_the_event_loop(self):
+        provider = _make_provider()
+        mock_client = MagicMock()
+        mock_client.get_label_detection.side_effect = _slow(
+            {'JobStatus': 'SUCCEEDED', 'Labels': []}
+        )
+        provider._rekognition_client = mock_client
+
+        result, ticks = await _count_heartbeats(
+            provider._wait_for_job_completion("job-1", "labels")
+        )
+
+        assert result['JobStatus'] == 'SUCCEEDED'
+        assert ticks > 0, "get_label_detection blocked the event loop"
+
+    async def test_start_video_analysis_does_not_stall_the_event_loop(self):
+        provider = _make_provider()
+        mock_client = MagicMock()
+        mock_client.start_label_detection.side_effect = _slow({'JobId': 'j-1'})
+        provider._rekognition_client = mock_client
+
+        result, ticks = await _count_heartbeats(
+            provider._start_video_analysis(
+                "my-bucket", "video.mp4", [AnalysisType.LABEL_DETECTION]
+            )
+        )
+
+        assert result == {'labels': 'j-1'}
+        assert ticks > 0, "start_label_detection blocked the event loop"
+
+    async def test_local_image_read_does_not_stall_the_event_loop(self, tmp_path):
+        from youtube_extension.integrations.cloud_ai.providers import (
+            aws_rekognition as _rek_mod,
+        )
+
+        image = tmp_path / "frame.jpg"
+        image.write_bytes(b"BINARY-IMAGE-PAYLOAD")
+        provider = _make_provider()
+
+        real_read = _rek_mod._read_file_bytes
+
+        def _slow_read(path):
+            import time
+            time.sleep(0.12)
+            return real_read(path)
+
+        with patch.object(_rek_mod, '_read_file_bytes', _slow_read):
+            result, ticks = await _count_heartbeats(
+                provider._prepare_image_input(str(image))
+            )
+
+        assert result == {'Bytes': b"BINARY-IMAGE-PAYLOAD"}
+        assert ticks > 0, "the local image read blocked the event loop"
+
+    async def test_local_image_bytes_are_read_correctly(self, tmp_path):
+        """Guard: offloading must not change what is returned."""
+        image = tmp_path / "frame.png"
+        payload = bytes(range(256)) * 8
+        image.write_bytes(payload)
+        provider = _make_provider()
+
+        result = await provider._prepare_image_input(str(image))
+
+        assert result == {'Bytes': payload}

--- a/tests/unit/test_aws_rekognition_provider.py
+++ b/tests/unit/test_aws_rekognition_provider.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+import os
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -131,6 +133,7 @@ class TestAWSRekognitionInitialize:
         mock_boto3.Session.return_value = mock_session
 
         with patch.dict("sys.modules", {"boto3": mock_boto3, "botocore": MagicMock(),
+                                         "botocore.config": MagicMock(),
                                          "botocore.exceptions": MagicMock(
                                              ClientError=Exception, NoCredentialsError=Exception
                                          )}):
@@ -147,6 +150,7 @@ class TestAWSRekognitionInitialize:
         mock_boto3.Session.return_value = mock_session
 
         with patch.dict("sys.modules", {"boto3": mock_boto3, "botocore": MagicMock(),
+                                         "botocore.config": MagicMock(),
                                          "botocore.exceptions": MagicMock(
                                              ClientError=Exception, NoCredentialsError=Exception
                                          )}):
@@ -169,6 +173,7 @@ class TestAWSRekognitionInitialize:
         mock_boto3.Session.return_value = mock_session
 
         with patch.dict("sys.modules", {"boto3": mock_boto3, "botocore": MagicMock(),
+                                         "botocore.config": MagicMock(),
                                          "botocore.exceptions": MagicMock(
                                              ClientError=Exception, NoCredentialsError=Exception
                                          )}):
@@ -1206,3 +1211,96 @@ class TestRekognitionDoesNotBlockEventLoop:
         result = await provider._prepare_image_input(str(image))
 
         assert result == {'Bytes': payload}
+
+
+# ---------------------------------------------------------------------------
+# botocore client timeouts
+# ---------------------------------------------------------------------------
+class TestClientTimeoutConfiguration:
+    """Every SDK call here runs on the shared default executor via
+    ``asyncio.to_thread``. Without an explicit read timeout a stalled AWS
+    request would pin one of that pool's limited worker threads forever and
+    starve every other ``to_thread`` user in the process, so the clients must
+    always be built with a bounded botocore config.
+    """
+
+    @staticmethod
+    async def _initialize(env: dict | None = None):
+        provider = _make_provider()
+        mock_session = MagicMock()
+        mock_session.client.return_value = _make_rekognition_client()
+        mock_boto3 = MagicMock()
+        mock_boto3.Session.return_value = mock_session
+        config_mod = MagicMock()
+
+        stubs = {
+            "boto3": mock_boto3,
+            "botocore": MagicMock(),
+            "botocore.config": config_mod,
+            "botocore.exceptions": MagicMock(
+                ClientError=Exception, NoCredentialsError=Exception
+            ),
+        }
+        with patch.dict("sys.modules", stubs), patch.dict(os.environ, env or {}):
+            await provider.initialize()
+        return mock_session, config_mod
+
+    async def test_both_clients_are_built_with_a_bounded_config(self):
+        mock_session, config_mod = await self._initialize()
+
+        built = config_mod.Config.return_value
+        services = {}
+        for call in mock_session.client.call_args_list:
+            services[call.args[0]] = call.kwargs.get("config")
+
+        assert set(services) == {"rekognition", "s3"}
+        assert services["rekognition"] is built
+        assert services["s3"] is built
+
+    async def test_default_timeouts_are_finite_and_positive(self):
+        _session, config_mod = await self._initialize()
+
+        kwargs = config_mod.Config.call_args.kwargs
+        assert 0 < kwargs["connect_timeout"] < math.inf
+        assert 0 < kwargs["read_timeout"] < math.inf
+        assert kwargs["retries"]["max_attempts"] >= 1
+
+    async def test_timeouts_are_overridable_from_the_environment(self):
+        _session, config_mod = await self._initialize(
+            {
+                "AWS_REKOGNITION_CONNECT_TIMEOUT": "2.5",
+                "AWS_REKOGNITION_READ_TIMEOUT": "7",
+                "AWS_REKOGNITION_MAX_ATTEMPTS": "5",
+            }
+        )
+
+        kwargs = config_mod.Config.call_args.kwargs
+        assert kwargs["connect_timeout"] == 2.5
+        assert kwargs["read_timeout"] == 7.0
+        assert kwargs["retries"]["max_attempts"] == 5
+
+    @pytest.mark.parametrize(
+        "var",
+        ["AWS_REKOGNITION_CONNECT_TIMEOUT", "AWS_REKOGNITION_READ_TIMEOUT"],
+    )
+    @pytest.mark.parametrize("bad", ["inf", "-inf", "nan", "0", "-1", "abc"])
+    async def test_non_finite_or_non_positive_timeouts_are_rejected(self, var, bad):
+        with pytest.raises(ConfigurationError):
+            await self._initialize({var: bad})
+
+    @pytest.mark.parametrize("bad", ["0", "-3", "1.5", "abc"])
+    async def test_invalid_max_attempts_is_rejected(self, bad):
+        with pytest.raises(ConfigurationError):
+            await self._initialize({"AWS_REKOGNITION_MAX_ATTEMPTS": bad})
+
+    @pytest.mark.parametrize(
+        "var",
+        [
+            "AWS_REKOGNITION_CONNECT_TIMEOUT",
+            "AWS_REKOGNITION_READ_TIMEOUT",
+            "AWS_REKOGNITION_MAX_ATTEMPTS",
+        ],
+    )
+    async def test_blank_values_fall_back_to_defaults(self, var):
+        _session, config_mod = await self._initialize({var: "   "})
+        assert config_mod.Config.call_args is not None

--- a/tests/unit/test_aws_rekognition_provider.py
+++ b/tests/unit/test_aws_rekognition_provider.py
@@ -1052,75 +1052,111 @@ def _slow(return_value, delay: float = 0.12):
 
 
 class TestRekognitionDoesNotBlockEventLoop:
-    async def test_analyze_image_does_not_stall_the_event_loop(self):
+    @pytest.mark.parametrize(
+        ("analysis_type", "client_method", "response"),
+        [
+            (AnalysisType.LABEL_DETECTION, "detect_labels", {"Labels": []}),
+            (AnalysisType.FACE_DETECTION, "detect_faces", {"FaceDetails": []}),
+            (AnalysisType.TEXT_DETECTION, "detect_text", {"TextDetections": []}),
+            (
+                AnalysisType.CONTENT_MODERATION,
+                "detect_moderation_labels",
+                {"ModerationLabels": []},
+            ),
+        ],
+    )
+    async def test_each_image_detection_runs_off_the_loop(
+        self, analysis_type, client_method, response
+    ):
         provider = _make_provider()
         mock_client = _make_rekognition_client()
-        mock_client.detect_labels.side_effect = _slow({"Labels": []})
+        getattr(mock_client, client_method).side_effect = _slow(response)
         provider._rekognition_client = mock_client
 
-        with patch.object(provider, '_prepare_image_input',
-                          new=AsyncMock(return_value={"Bytes": b"img"})):
+        with patch.object(
+            provider,
+            "_prepare_image_input",
+            new=AsyncMock(return_value={"Bytes": b"img"}),
+        ):
             result, ticks = await _count_heartbeats(
-                provider.analyze_image("http://e.com/i.jpg", [AnalysisType.LABEL_DETECTION])
+                provider.analyze_image("http://e.com/i.jpg", [analysis_type])
             )
 
         assert isinstance(result, VideoAnalysisResult)
-        assert ticks > 0, "detect_labels blocked the event loop"
+        getattr(mock_client, client_method).assert_called_once()
+        assert ticks > 0, f"{client_method} blocked the event loop"
 
-    async def test_every_detection_type_runs_off_the_loop(self):
-        provider = _make_provider()
-        mock_client = _make_rekognition_client()
-        # four blocking calls back to back
-        mock_client.detect_labels.side_effect = _slow({"Labels": []}, 0.06)
-        mock_client.detect_faces.side_effect = _slow({"FaceDetails": []}, 0.06)
-        mock_client.detect_text.side_effect = _slow({"TextDetections": []}, 0.06)
-        mock_client.detect_moderation_labels.side_effect = _slow({"ModerationLabels": []}, 0.06)
-        provider._rekognition_client = mock_client
-
-        with patch.object(provider, '_prepare_image_input',
-                          new=AsyncMock(return_value={"Bytes": b"img"})):
-            _result, ticks = await _count_heartbeats(
-                provider.analyze_image(
-                    "http://e.com/i.jpg",
-                    [AnalysisType.LABEL_DETECTION, AnalysisType.FACE_DETECTION,
-                     AnalysisType.TEXT_DETECTION, AnalysisType.CONTENT_MODERATION],
-                )
-            )
-
-        mock_client.detect_labels.assert_called_once()
-        mock_client.detect_moderation_labels.assert_called_once()
-        assert ticks > 0, "the detect_* chain blocked the event loop"
-
-    async def test_job_polling_does_not_stall_the_event_loop(self):
+    @pytest.mark.parametrize(
+        ("analysis_type", "client_method", "result_key"),
+        [
+            (AnalysisType.LABEL_DETECTION, "start_label_detection", "labels"),
+            (AnalysisType.FACE_DETECTION, "start_face_detection", "faces"),
+            (AnalysisType.TEXT_DETECTION, "start_text_detection", "text"),
+            (
+                AnalysisType.CONTENT_MODERATION,
+                "start_content_moderation",
+                "moderation",
+            ),
+        ],
+    )
+    async def test_each_video_start_runs_off_the_loop(
+        self, analysis_type, client_method, result_key
+    ):
         provider = _make_provider()
         mock_client = MagicMock()
-        mock_client.get_label_detection.side_effect = _slow(
-            {'JobStatus': 'SUCCEEDED', 'Labels': []}
-        )
-        provider._rekognition_client = mock_client
-
-        result, ticks = await _count_heartbeats(
-            provider._wait_for_job_completion("job-1", "labels")
-        )
-
-        assert result['JobStatus'] == 'SUCCEEDED'
-        assert ticks > 0, "get_label_detection blocked the event loop"
-
-    async def test_start_video_analysis_does_not_stall_the_event_loop(self):
-        provider = _make_provider()
-        mock_client = MagicMock()
-        mock_client.start_label_detection.side_effect = _slow({'JobId': 'j-1'})
+        getattr(mock_client, client_method).side_effect = _slow({"JobId": "j-1"})
         provider._rekognition_client = mock_client
 
         result, ticks = await _count_heartbeats(
             provider._start_video_analysis(
-                "my-bucket", "video.mp4", [AnalysisType.LABEL_DETECTION]
+                "my-bucket", "video.mp4", [analysis_type]
             )
         )
 
-        assert result == {'labels': 'j-1'}
-        assert ticks > 0, "start_label_detection blocked the event loop"
+        assert result == {result_key: "j-1"}
+        assert ticks > 0, f"{client_method} blocked the event loop"
 
+    @pytest.mark.parametrize(
+        ("analysis_key", "client_method"),
+        [
+            ("labels", "get_label_detection"),
+            ("faces", "get_face_detection"),
+            ("text", "get_text_detection"),
+            ("moderation", "get_content_moderation"),
+        ],
+    )
+    async def test_each_video_poll_runs_off_the_loop(
+        self, analysis_key, client_method
+    ):
+        provider = _make_provider()
+        mock_client = MagicMock()
+        getattr(mock_client, client_method).side_effect = _slow(
+            {"JobStatus": "SUCCEEDED"}
+        )
+        provider._rekognition_client = mock_client
+
+        result, ticks = await _count_heartbeats(
+            provider._wait_for_job_completion("job-1", analysis_key)
+        )
+
+        assert result["JobStatus"] == "SUCCEEDED"
+        assert ticks > 0, f"{client_method} blocked the event loop"
+
+    @pytest.mark.parametrize("provider_method", ["_test_connection", "get_service_status"])
+    async def test_each_describe_collection_runs_off_the_loop(self, provider_method):
+        provider = _make_provider()
+        mock_client = MagicMock()
+        mock_client.describe_collection.side_effect = _slow({})
+        provider._rekognition_client = mock_client
+
+        _result, ticks = await _count_heartbeats(
+            getattr(provider, provider_method)()
+        )
+
+        mock_client.describe_collection.assert_called_once()
+        assert ticks > 0, (
+            f"describe_collection in {provider_method} blocked the event loop"
+        )
     async def test_local_image_read_runs_off_the_event_loop_thread(self, tmp_path):
         """
         Deterministic counterpart to the heartbeat tests.


### PR DESCRIPTION
Head: `b5721eb4f`

## Canonical issue

Closes #1204

## Outcome

boto3 is a **synchronous** SDK. Every Rekognition call sat directly inside an `async def`, so each blocked the event loop for a whole network round-trip. All 14 now dispatch through `await asyncio.to_thread(...)`.

| This PR does | This PR does **not** |
|---|---|
| Stop the event loop stalling during every Rekognition call | Make Rekognition calls themselves any faster |
| Keep the loop responsive across `_wait_for_job_completion`'s poll loop (up to 120 blocking calls per analysis) | Change polling cadence, timeouts or retry semantics |
| Move the local-image read in `_prepare_image_input` off the loop | Change the `http(s)` branch (already `httpx.AsyncClient`) |
| Preserve every response shape and error path byte-for-byte | Add concurrency between the four `detect_*` calls |

The win is **loop availability**, not latency. While one request waits on Rekognition, other requests, WebSocket frames and health checks now continue to be served.

## Scope

`src/youtube_extension/integrations/cloud_ai/providers/aws_rekognition.py` only.

- 14 call sites wrapped in `await asyncio.to_thread(...)` (`asyncio.to_thread` forwards `**kwargs`, so keyword arguments are unchanged).
- New module-level `_read_file_bytes(path) -> bytes` helper; `_prepare_image_input` now does `await asyncio.to_thread(_read_file_bytes, image_url)`.
- Plus 6 new tests. No other module touched.

## Design notes

**Why `to_thread` and not `gather`.** The four `detect_*` calls in `analyze_image` *could* run concurrently, but that changes AWS request-rate behaviour and per-call error attribution. This PR deliberately keeps them sequential and fixes only the loop-blocking defect. Parallelising them is a separate, arguable change.

**Cancellation / use-after-close.** `await asyncio.to_thread(...)` is not cancellation-safe when a caller tears the client down in a `finally` — that was a real regression in #1190. Here `AWSRekognition.cleanup()` only sets `self._rekognition_client = None` (its own comment: *"boto3 clients don't require explicit cleanup"*); it closes no transport. A thread already holds the bound method, so an in-flight call completes normally. **No shield is warranted** — adding one would be unfalsifiable ceremony.

**Serialisation.** These calls share no local mutable resource, so moving them off-loop removes no implicit ordering guarantee (contrast #1194, which needed a lock).

## Risk

Low. Behaviour-preserving; all 89 pre-existing tests pass **unmodified**. The residual risk is thread-pool saturation under very high concurrency — bounded by the default executor, same as the already-merged #1190/#1196.

## Verification

```
89 pre-existing tests ....................... pass, zero edits
95 total (89 + 6 new) ....................... pass
ruff .......................................  8 findings — exact parity with origin/main (0 added)
```

**Non-vacuity (both dimensions reverted simultaneously):** boto3 calls put back on the loop **and** `_read_file_bytes` called directly →

```
5 failed, 90 passed
```

Exactly the 5 heartbeat tests failed. The 6th new test is a **guard** (`test_local_image_bytes_are_read_correctly`) and correctly still passed, as did all 89 pre-existing tests — confirming the mutation was behavioural, not structural.

Each new test runs a heartbeat task alongside the work; blocking I/O on the loop yields **0 ticks**.

## Review round 2 — replaced a load-sensitive assertion

CI surfaced a single failure at `792604bd5`:
`TestRekognitionDoesNotBlockEventLoop::test_local_image_read_does_not_stall_the_event_loop`.

This was the exact risk I flagged as challenge 4 in the review request. Unlike the four
boto3 tests — which drive a controllable 0.12s mock and passed on CI — the local file read
is a few microseconds of real work, so "did the event loop tick while it ran" measures
scheduler behaviour under load rather than the property I care about.

Replaced it with a direct assertion of the property: record `threading.get_ident()` inside
`_read_file_bytes` and require it to differ from the thread running the event loop. That is
precisely what "dispatched off the loop" means, requires no sleeps, and cannot flake under
runner contention.

| | before | after |
|---|---|---|
| mechanism | elapsed heartbeat ticks > 0 | worker thread id != loop thread id |
| sleeps | 0.12s injected | none |
| flakes under load | yes (observed on CI) | no |
| discriminates the bug | yes | yes — 1 targeted failure / 94 passed |

Non-vacuity re-proven: reverting line 402 to call `_read_file_bytes(image_url)` directly
instead of via `asyncio.to_thread` produces exactly one targeted failure. The other five
tests in the class are unchanged and still pass. Suite: **95 passed**.

## Review round 3 — the deterministic test was patching the wrong namespace

Round 2's thread-identity test passed locally (including a full 7,731-test
single-process `tests/unit` run) but failed on CI with
`AssertionError: _read_file_bytes was never called` — while the result
assertion immediately above it passed. That combination is diagnostic: the
real helper ran and returned the right bytes, but the recording wrapper was
never invoked. The module object returned by a fresh `import` inside the test
was not the namespace `_prepare_image_input` resolves names from.

The wider unit suite makes that reachable. `tests/unit/test_core_mcp_registry.py`
re-registers canonical dotted names (`sys.modules[canonical] = mod`) and
`tests/unit/test_v1_router_extended.py` installs `MagicMock()` under
`youtube_extension.*` names. Either leaves a class imported earlier holding
`__globals__` pointing at a different dict than a later import returns, so
`patch.object(<freshly imported module>, ...)` silently patches nothing.

Fix: patch `type(provider)._prepare_image_input.__globals__` via `patch.dict`.
That is by definition the namespace the call site looks the name up in, so it
cannot drift no matter what sibling modules do to `sys.modules`, and it needs
no import at all.

The same round also parametrized the off-loop coverage so that **every**
converted SDK operation is asserted individually rather than in batches.

### Non-vacuity (re-proved for the expanded suite)
Reverting **all 15** `await asyncio.to_thread(...)` sites to direct calls
produces **exactly 15 targeted failures, 90 passed** — a 1:1 mapping of
converted call site to failing assertion. Restoring the source returns the
file to 105 passed.

| Run | Result |
|---|---|
| `test_aws_rekognition_provider.py` | 105 passed (89 pre-existing untouched + 16) |
| full `tests/unit`, one process | 7,731 passed, 0 failed |
| all 15 conversions reverted | 15 failed / 90 passed |
| ruff | parity with `origin/main` |

### Attribution
Commits `2c0fec7f7` and `af04aedb5` were pushed to this branch by another
agent while I was preparing an equivalent fix. Its diagnosis matched mine, and
its `patch.dict(method_globals, ...)` form is strictly better than the
hand-rolled `try/finally` I had written — it restores on exception and is
idiomatic. I adopted its commits rather than force-pushing over them, then
independently re-ran and re-proved the suite above.

## Production evidence

`...cloud_ai.providers.aws_rekognition` is in the transitive import closure of the primary production entrypoint `youtube_extension.main:app` (root `Dockerfile:93`), via `main.py:171` → `backend/cloud_ai_routes.py:89,141` → `integrations/cloud_ai/integrator.py:297-298`.

## Agent handoff

Review focus: the cancellation argument above, and whether keeping the four `detect_*` calls sequential is the right call.



## Review round 4 — bounding the work I moved into the shared thread pool

CodeRabbit raised two `Major` findings at `af04aedb5`. They were judged separately.

### Finding 2 — no botocore timeouts (`aws_rekognition.py:115`) — ACCEPTED, fixed in `b5721eb4f`

This one is a direct consequence of this PR and was fixed here.

`initialize()` built both clients with `session.client('rekognition')` / `session.client('s3')`
and no `botocore.config.Config`. On its own that is merely untidy. Combined with **this PR** it
is a real hazard: the 14 SDK calls now run via `asyncio.to_thread`, i.e. on the process-wide
default executor. botocore's defaults leave a request effectively unbounded, so a stalled AWS
call no longer blocks the event loop (the old, obvious failure) — it silently **pins one of that
pool's limited worker threads forever**. That pool is shared with the metrics persistence
(#1194), sqlite access (#1196) and result writes (#1203) already merged onto it, and
`_wait_for_job_completion` can issue up to 120 such calls per job. This is the same
pool-exhaustion class of regression caught on #1152.

Fix: both clients are constructed with an explicit `Config(connect_timeout, read_timeout,
retries={'max_attempts', 'mode': 'standard'})`. Values are overridable via
`AWS_REKOGNITION_CONNECT_TIMEOUT` / `_READ_TIMEOUT` / `_MAX_ATTEMPTS`, validated with
`math.isfinite` and **raising rather than clamping**, so `inf`, `nan`, `0` and negatives are
rejected outright.

Parsing is hoisted **above** `initialize()`'s `try`, because that method ends in a catch-all
`except Exception -> CloudAIError` which would otherwise bury a precise `ConfigurationError`
behind a generic init failure.

### Finding 1 — local path traversal (`aws_rekognition.py:37`) — REJECTED as out of scope, tracked in #1209

The finding is correct on the merits, but it is **pre-existing and unchanged by this PR**.
`origin/main` already read the value verbatim at line 373:

```python
with open(image_url, 'rb') as image_file:
```

This PR moved that read onto a worker thread. The set of readable paths is byte-for-byte
identical before and after — no widening. Fixing it properly means choosing and enforcing a
media-root policy, handling symlink escape as well as lexical `../`, and deciding whether the
local branch should exist in production at all. That is a behavioural security change that
deserves its own PR and its own tests, not a rider on a performance PR.

Filed as **#1209** with full acceptance criteria. This mirrors the scope objection CodeRabbit
itself raised on #1152, where an out-of-scope guard was reverted and tracked as #1162.

### Verification of round 4

| Dimension mutated | Expected failures | Observed |
|---|---|---|
| env helpers ignore the environment **and** `config=` dropped from both clients | 18 | **18 failed / 109 passed** |

Breakdown of the 18: 1 client-config assertion, 1 env-override assertion, 12 timeout-rejection
cases (2 vars x 6 bad values), 4 max-attempts rejection cases. The three "blank value falls back
to default" cases and the "defaults are finite" case correctly still pass — they are guards that
survive this mutation by design.

Suite: **127 passed** (105 pre-existing, unmodified except for adding a symmetric
`"botocore.config"` entry to the three existing `patch.dict("sys.modules", ...)` stubs, which
already stubbed `"botocore.exceptions"`; plus 22 new). ruff parity with `origin/main` unchanged
(8 = 8).
