### PR TITLE
test(rekognition): green up PR #1205 — make off-loop read test robust to sys.modules eviction

### DIFF
--- a/tests/unit/test_aws_rekognition_provider.py
+++ b/tests/unit/test_aws_rekognition_provider.py
@@ -1132,23 +1132,30 @@ class TestRekognitionDoesNotBlockEventLoop:
         """
         import threading
 
-        from youtube_extension.integrations.cloud_ai.providers import (
-            aws_rekognition as _rek_mod,
-        )
-
         image = tmp_path / "frame.jpg"
         image.write_bytes(b"BINARY-IMAGE-PAYLOAD")
         provider = _make_provider()
 
+        # Patch the exact namespace `_prepare_image_input` resolves
+        # `_read_file_bytes` from — the method's own module globals — instead of a
+        # freshly re-imported module object. Sibling test modules (notably
+        # test_cloud_ai_integrator) evict the cloud_ai modules from sys.modules at
+        # collection time, so a late `import ... as _rek_mod` here can bind a
+        # *different* module object than the one whose globals this provider's
+        # method actually uses, leaving the patch on a stale module and the read
+        # unintercepted (correct bytes returned, but the wrapper never runs).
+        # `__globals__` is ground truth and cannot drift.
+        method_globals = type(provider)._prepare_image_input.__globals__
+        real_read = method_globals['_read_file_bytes']
+
         loop_thread_id = threading.get_ident()
         observed: dict[str, int] = {}
-        real_read = _rek_mod._read_file_bytes
 
         def _recording_read(path):
             observed['thread_id'] = threading.get_ident()
             return real_read(path)
 
-        with patch.object(_rek_mod, '_read_file_bytes', _recording_read):
+        with patch.dict(method_globals, {'_read_file_bytes': _recording_read}):
             result = await provider._prepare_image_input(str(image))
 
         assert result == {'Bytes': b"BINARY-IMAGE-PAYLOAD"}


### PR DESCRIPTION
## Canonical issue

Remediates the failing `test` check on **#1205** (`perf/rekognition-offloop`). This PR targets `perf/rekognition-offloop` directly, so merging it lands the fix on #1205's head and turns its CI green. It carries a **single commit** (`c375307`) — no duplication of #1205's perf changes.

## Outcome

`tests/unit/test_aws_rekognition_provider.py::TestRekognitionDoesNotBlockEventLoop::test_local_image_read_runs_off_the_event_loop_thread` fails in the full CI suite (`AssertionError: _read_file_bytes was never called`) while passing in isolation. This makes the failure deterministic-green by fixing the test's module resolution. The production change in #1205 is correct and untouched.

**Root cause — cross-module test pollution, not the diff.** `tests/unit/test_cloud_ai_integrator.py` deletes every `youtube_extension.*cloud_ai*` key from `sys.modules` at collection time. The `aws_rekognition` module key matches, so after that eviction the failing test's late `import ... as _rek_mod` binds a *fresh* module object, while the provider instance's `_prepare_image_input` still resolves `_read_file_bytes` from the *original* module's globals. The `patch.object` landed on the stale module and the read ran unintercepted — correct bytes were returned, but the recording wrapper never fired, so the thread-identity assertion saw an empty `observed`.

## Scope

- Included: patch the method's own `__globals__` via `patch.dict` (the exact namespace `_prepare_image_input` resolves names from) instead of a re-imported module attribute; drop the now-unused late import.
- Explicitly excluded: no production code change; no other test touched; the sibling `test_cloud_ai_integrator.py` eviction pattern is left as-is (its `del sys.modules[...]` is intentional for its own stubbing).

## Risk

- Risk level: low
- Failure mode: test-only; `__globals__` is a stable CPython attribute of the bound function, immune to `sys.modules` churn.
- Rollback: revert commit `c375307`.

## Verification

Tied to head `c375307`:

- [x] Focused test passes in isolation and **under the real polluting order** (`test_cloud_ai_integrator.py` first, then the target, one session) — before this change that ordering reproduces the exact CI failure (`1 failed`); after, `62 passed`.
- [x] Full file: `95 passed`.
- [x] `ruff check` on the file: parity with base (the one pre-existing `F841` at line 820 is unrelated and unchanged; zero added).
- [ ] Required CI — will run on this PR's head.
- [ ] Review threads resolved.

Reproduction (local):
```
# old test, real ordering
pytest tests/unit/test_cloud_ai_integrator.py \
       tests/unit/test_aws_rekognition_provider.py::TestRekognitionDoesNotBlockEventLoop::test_local_image_read_runs_off_the_event_loop_thread
# -> 1 failed: AssertionError: _read_file_bytes was never called
# with this change -> 62 passed
```

## Production evidence

Not applicable — test-only change. The production behaviour (all 14 Rekognition calls off the event loop) is #1205's and is unchanged here.

## Agent handoff

- [x] Linked to the PR it remediates (#1205)
- [x] No competing PR implements the same fix
- [x] Required check (`test`) reproduced red and driven green locally
- [ ] **Human decision requested:** merging this into `perf/rekognition-offloop` (or cherry-picking `c375307` onto it) is left to you — I did not push to #1205's branch directly. #1205 still needs your merge approval to `main` after CI re-runs green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsFV8zYRLJREAT4ptny8Vz)_