### PR TITLE
fix(docker): install slowapi in Dockerfile.production so the image starts

### DIFF
--- a/infrastructure/docker/Dockerfile.production
+++ b/infrastructure/docker/Dockerfile.production
@@ -42,7 +42,8 @@ RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted
     "aiofiles>=23.2.1" \
     "httpx>=0.25.0" \
     "requests>=2.31.0" \
-    "python-multipart>=0.0.31"
+    "python-multipart>=0.0.31" \
+    "slowapi>=0.1.8"
 
 # Create necessary directories and set permissions
 RUN mkdir -p logs && \


### PR DESCRIPTION
## Summary

`main`'s production image crashes at startup with `ModuleNotFoundError: No module named 'slowapi'`. This is a one-line fix: add `slowapi>=0.1.8` to the `Dockerfile.production` install list.

## Why it's broken on `main`

- `src/youtube_extension/main.py:14-17` imports `slowapi` **unconditionally** at module top level (`Limiter`, `SlowAPIMiddleware`, `_rate_limit_exceeded_handler`, `get_remote_address`) and binds it at import time (`limiter = Limiter(...)`, `app.add_middleware(SlowAPIMiddleware)`).
- `Dockerfile.production`'s `CMD` is `youtube_extension.main:app`, so uvicorn imports that module at startup → `slowapi` must be importable in the image.
- The `RUN pip install` list shipped 8 packages and **omitted `slowapi`**; `requirements.txt` is copied but deliberately not `-r`-installed. So the container exits immediately on boot.
- `slowapi>=0.1.8` is a canonical dependency in both `requirements.txt:8` and `pyproject.toml:36`; the added floor matches.

This is the same "the production image was never actually verified to start" defect class the earlier `server:app` → `youtube_extension.main:app` CMD fix addressed — one import deeper. It was flagged by Vercel VADE review on #1122 and #1128, independently verified, and shipped to `main` when #1128 merged (that branch carried the `Dockerfile.production` change).

## Why the existing guard missed it

`test_dockerfile_production_pins_dependency_floors` only validates packages **already present** in the install list — it never asserts that every canonical runtime import resolves to an installed pin. So a *missing* required package is invisible to it. Worth hardening separately (e.g. a build-stage `python -c "import youtube_extension.main"` smoke check, or extending the entrypoint test to assert the CMD module's third-party imports are all installed) so this class can't recur; not done here to keep the fix minimal.

## Verification

```
tests/unit/test_security_fixes.py -k dockerfile  →  5 passed
```

## Risk

Minimal. Adds one required runtime dependency to the image; touches no application code and no other package floor.

## Note for maintainers (separate issue, not in this PR)

CI `gitleaks (working tree)` is red on `main` due to a **false positive**: `uv.lock:5129` is the `parso-0.8.7.tar.gz` `sha256:` package hash, matched by the `square-access-token` rule. Not a credential. Recommend an allowlist in `.gitleaks.toml` (path rule for `uv.lock` package hashes, or the fingerprint `uv.lock:square-access-token:5129`). Left out of this PR since editing the secret-scanner config is better done deliberately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6KJmeCL8QnxYEKuVimf9J)_