### PR TITLE
fix(ci): allowlist uv.lock SHA-256 digests in gitleaks (working tree)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -5,7 +5,10 @@
 useDefault = true
 
 [allowlist]
-description = "Paths excluded from secret scanning"
+description = "Paths and patterns excluded from secret scanning"
+# `regexTarget = "line"` so the digest allowlist below matches against the full
+# source line (the SHA-256 follows `hash = "sha256:`), not just the captured token.
+regexTarget = "line"
 paths = [
   # Vendored saved web pages from Google (AI Studio / APIs Explorer): contain
   # Google's own public page keys, not EventRelay credentials.
@@ -14,4 +17,13 @@ paths = [
   '''docs/security/.*''',
   # Test fixtures use obvious dummy keys (e.g. "xai-secret-123"), not real secrets.
   '''tests/.*''',
+]
+regexes = [
+  # Lockfiles (e.g. uv.lock) record package artifact digests as
+  # `hash = "sha256:<64 hex>"`. The high-entropy hex trips the bundled
+  # square-access-token rule -- e.g. parso 0.8.7's sdist digest "sha256:eaaac4c9..."
+  # shares the "eaaa" shape of a Square token. These are integrity digests for
+  # public PyPI artifacts, not credentials, so suppress the digest lines
+  # specifically while leaving the rest of every lockfile scanned.
+  '''hash = "sha256:[0-9a-f]{64}"''',
 ]


### PR DESCRIPTION
## Canonical issue

Closes # _(none pre-existing — CI-hygiene fix surfaced while remediating the `ready_for_review` on #1122; a human may open/link a canonical issue if the governance contract requires one)_

## Outcome

The `gitleaks (working tree)` check currently fails **repo-wide on `main`**, so every open PR inherits a red secret-scanning gate. Root cause: the bundled `square-access-token` rule flags `uv.lock:5129` — parso 0.8.7's sdist digest `hash = "sha256:eaaac4c9…"` — because the 64-char hex shares the `eaaa` shape of a Square access token. It is a package integrity digest for a public PyPI artifact, not a credential.

This adds a narrow allowlist so lockfile SHA-256 digest lines stop being reported, unblocking the gitleaks gate everywhere, while leaving the rest of every lockfile scanned.

## Scope

- **Included:** `.gitleaks.toml` only — one `regexes` entry (`regexTarget = "line"`) matching `hash = "sha256:<64 hex>"`.
- **Explicitly excluded:** no change to the ruleset, no path-level exclusion of `uv.lock` (the file stays scanned for everything except digest lines), no application/lockfile content changes.

## Risk

- **Risk level: low.** The allowlist targets one specific line shape (`hash = "sha256:` + 64 lowercase hex). A real leaked credential would have to be formatted exactly as a SHA-256 digest to be suppressed, which is not a realistic exfiltration format.
- **Failure mode:** at worst, a future digest-shaped string elsewhere is not flagged; the rest of secret scanning is untouched.
- **Rollback:** revert the single commit; config returns to the prior paths-only allowlist.

## Verification

Verified with **gitleaks 8.18.4** (the exact version the CI job pins), whole-tree `detect --no-git`, matching the CI invocation:

- [x] **Reproduced the failure** — pre-change config (`main`'s `.gitleaks.toml`): `WRN leaks found: 1`.
- [x] **Fix confirmed** — post-change config: `INF no leaks found`, exit 0.
- [x] **Non-vacuous** — the sole delta between the two runs is this allowlist entry; it is what flips `1 → 0`.
- [x] **Targeting confirmed** — the regex matches `uv.lock:5129` exactly (`hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1"`).

## Production evidence

Not applicable — this changes only a CI secret-scanning config. It touches no `apps/web` file, no route, no dependency, and no lockfile, so the Vercel preview build is byte-identical to `main`.

## Agent handoff

- [x] Required check reproduced and fixed on the current head (gitleaks).
- [ ] Canonical-issue / `PR Governance` contract — this repo requires an *open* canonical issue; none exists for this hygiene fix, so that gate (and the systemic `missing_trusted_publication` gate seen on every PR here) will need a human disposition.
- [x] Human decision requested only for the governance/merge step.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dd7XSrbKejHMAH3cUjnKkh)_