### PR TITLE
docs: reference GEMINI_API_KEY env var in curl examples so gitleaks can be bumped

### DIFF
--- a/docs/knowledge_prototypes/universal-automation-service/TECHNICAL_NOTES.md
+++ b/docs/knowledge_prototypes/universal-automation-service/TECHNICAL_NOTES.md
@@ -29,7 +29,7 @@ self.model = "gemini-2.0-flash-exp"
 ```bash
 curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent" \
   -H 'Content-Type: application/json' \
-  -H 'X-goog-api-key: REDACTED_GOOGLE_API_KEY_ROTATE' \
+  -H "X-goog-api-key: ${GEMINI_API_KEY}" \
   -X POST -d '{"contents": [{"parts": [{"text": "test"}]}]}'
 ```
 
@@ -200,7 +200,7 @@ EventRelay      : ❌ FAIL
 ```bash
 curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent" \
   -H 'Content-Type: application/json' \
-  -H 'X-goog-api-key: REDACTED_GOOGLE_API_KEY_ROTATE' \
+  -H "X-goog-api-key: ${GEMINI_API_KEY}" \
   -X POST \
   -d '{"contents": [{"parts": [{"text": "Hello"}]}]}'
 ```


### PR DESCRIPTION
## Canonical issue

Closes #1217

## Outcome

The `Secret Scan` workflow pins `GITLEAKS_VERSION="8.18.4"` (`.github/workflows/secret-scan.yml`). Any bump past that pin fails on `main` — not because a secret was introduced, but because newer gitleaks ships a default `curl-auth-header` rule that this repository's documentation trips.

Two `curl` snippets in the universal-automation-service prototype notes embedded a scrubbed credential marker directly in an auth header:

```bash
curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent" \
  -H 'Content-Type: application/json' \
  -H 'X-goog-api-key: REDACTED_GOOGLE_API_KEY_ROTATE' \
  ...
```

`REDACTED_GOOGLE_API_KEY_ROTATE` is a leftover marker from the credential purge, not a live key — but `curl-auth-header` matches on the *shape* of the invocation, not the value's entropy, so it fires regardless. Because the rule does not exist in 8.18.4, the failure is invisible today and only detonates for whoever bumps the pin, on a change unrelated to theirs.

This PR removes the trigger at its source: the snippets now read the key from the environment.

```diff
-  -H 'X-goog-api-key: REDACTED_GOOGLE_API_KEY_ROTATE' \
+  -H "X-goog-api-key: ${GEMINI_API_KEY}" \
```

That is a two-line change to a documentation file, and it is also simply better documentation — a runnable example that teaches sourcing the key from the environment rather than pasting it into a shell history.

### Why not an allowlist

Adding a `.gitleaks.toml` entry was the obvious alternative and was rejected on three grounds:

1. **It would suppress, not fix.** Any allowlist broad enough to cover this finding also covers a *future real* key pasted into the same file in the same shape. The whole point of the scanner is to catch that.
2. **It would probably not even work.** The finding's reported line is the `curl "https://..."` line, not the `-H` line — the rule matches across the multi-line invocation. The repo's single global `[allowlist]` block sets `regexTarget = "line"`, so a regex written against `REDACTED_` would be matched against a line that does not contain it. Making it work would mean a path allowlist for `docs/knowledge_prototypes/.*`, retiring an entire docs tree from scanning.
3. **It is permanent debt for a transient artifact.** The marker exists only because of a past incident cleanup. Deleting it costs nothing.

No `.gitleaks.toml` change is included in this PR.

## Scope

- **Included:** the two `-H` lines in `docs/knowledge_prototypes/universal-automation-service/TECHNICAL_NOTES.md` (lines 32 and 203). One file, two lines, no code.
- **Explicitly excluded — and deliberately so:** the other ~18 `REDACTED_GOOGLE_API_KEY_ROTATE` occurrences across `FINAL_STATUS.md`, `RUN_WITH_VENV.md`, `SETUP.md`, `COMPREHENSIVE_SYSTEMS_STATUS.md` and elsewhere in this file. I checked each: they are `export GEMINI_API_KEY="..."` lines and historical incident notes, they match **no** gitleaks rule at either version, and rewriting them would turn a targeted CI fix into a sprawling docs diff with no security benefit.
- **Excluded:** bumping `GITLEAKS_VERSION` itself. This PR proves the bump is *safe*; choosing the target version and re-pinning is a separate, deliberate maintenance decision that should not ride along with a docs change.

## Risk

- **Risk level: low.** Two lines in a Markdown file inside `docs/knowledge_prototypes/`. No source, config, workflow, test, or dependency is touched; nothing is imported, built, or executed from this path.
- **Failure mode:** the worst realistic outcome is a documentation regression — a reader copies the snippet without `GEMINI_API_KEY` exported and gets a 401 from Google instead of a 200. The previous snippet returned a 400/401 too, since the value it carried was a redaction marker rather than a working key, so the copy-paste experience is strictly improved, not degraded.
- **Rollback:** `git revert` of a single documentation commit. No migration, no state, no coupling to any other change.
- **Counter-risk of not merging:** the next person to touch `GITLEAKS_VERSION` gets a red `Secret Scan` on `main` and a false "we leaked a Google API key" signal, which is exactly the alarm-fatigue outcome a secret scanner must avoid.

## Verification

Run against head of this branch, using the exact command from `.github/workflows/secret-scan.yml`:

```
gitleaks detect --no-git --config .gitleaks.toml --redact --verbose --exit-code 1
```

Both the currently pinned version and a much newer one were executed locally, before and after the change, giving a full 2×2 matrix rather than a one-sided claim:

| gitleaks | before this PR | after this PR |
|---|---|---|
| **8.18.4** (current CI pin) | `no leaks found`, exit 0 | `no leaks found`, exit 0 |
| **8.30.0** (12 minor releases ahead) | **2 leaks**, exit 1, `RuleID: curl-auth-header`, `TECHNICAL_NOTES.md` lines 30 and 201 | `no leaks found`, exit 0 |

- [x] **Reproduced the reported failure first** — 8.30.0 on unmodified `main` produced exactly the two findings described in #1217, with the rule ID and both line numbers matching. The fix was written against a confirmed reproduction, not a hypothesis.
- [x] **Fix verified** — 8.30.0 now reports `no leaks found` and exits 0. This is the acceptance criterion in #1217: the pin can be bumped without the scan going red.
- [x] **No regression on the pinned version** — 8.18.4 still reports `no leaks found` and exits 0, so today's CI is unaffected. The stashed-vs-restored runs above confirm 8.18.4 was green both before and after, isolating the change's effect to the newer version only.
- [x] **Scan coverage unchanged** — 63.74 MB scanned across the working tree, identical to the pre-change run. Nothing was excluded to achieve the pass; the finding is gone because its cause is gone.
- [x] **8.18.4 binary provenance** — downloaded from `github.com/gitleaks/gitleaks/releases/download/v8.18.4/`, `gitleaks version` confirms `8.18.4`, matching the pin byte-for-byte rather than assuming a locally-installed build behaves the same.
- [x] **Lint / tests** — not applicable and not skipped: `git show --stat` confirms the commit touches exactly one `.md` file, so no Python, TypeScript, or workflow code paths are reachable by this diff.

Known-failing check, pre-existing and repo-wide: **Agent completion enforcement** requires a check run named `Agent Lock trusted publication` from a trusted GitHub App, and `.github/agent-lock/trusted-publishers.json` ships with empty allowlists under `custom_role_policy: "fail_closed"`, with a note stating this "intentionally blocks". It fails on every open PR here (verified on #1122, #1207, #1216) and is tracked separately in #1160, which explicitly asks for a human decision.

## Production evidence

Not applicable as a runtime artifact, for a specific rather than blanket reason: the diff is confined to a Markdown file under `docs/knowledge_prototypes/`, which is not imported by the Python package, not part of the Next.js build, and not served by any route. There is no deployed surface for this change to alter and therefore nothing to exercise in a preview environment.

The evidence that matters for a CI-hygiene fix is the CI behaviour itself, and it is recorded above as real command output from two independently downloaded gitleaks binaries run against the real working tree — a genuine before/after reproduction rather than an assertion that the change "should" work.

## Agent handoff

- [x] One canonical issue is linked (#1217)
- [x] No competing PR implements the same issue — no other open PR touches `TECHNICAL_NOTES.md` or `.gitleaks.toml`
- [x] Acceptance criteria satisfied — #1217 asked that a gitleaks bump not fail the scan; the 2×2 matrix above demonstrates exactly that
- [x] Required checks pass on this head, with the one pre-existing repo-wide exception documented under Verification
- [x] Follow-up left to a human by design: the actual `GITLEAKS_VERSION` bump. This PR makes it safe; it does not decide which version to move to.

---
🤖 Generated with Copilot CLI

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
