### PR TITLE
test: expand BigQuery export coverage from 29.89% to 100%

### DIFF
--- a/tests/unit/test_bigquery_export.py
+++ b/tests/unit/test_bigquery_export.py
@@ -1,12 +1,548 @@
-"""Tests for BigQuery export functionality."""
+"""Tests for BigQuery export functionality.
 
-from unittest.mock import patch
+Focused unit coverage for :mod:`uvai.ml.bigquery_export`.
 
-from uvai.ml.bigquery_export import _get_bq_client
+Every Google Cloud, network, and metadata-server boundary is mocked, so these
+tests never reach an external service and run deterministically offline.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from uvai.ml import bigquery_export
+from uvai.ml.bigquery_export import (
+    ACTION_FEEDBACK_TABLE,
+    MODEL_CHECKPOINTS_TABLE,
+    PIPELINE_RUNS_TABLE,
+    TRANSCRIPT_OUTCOMES_TABLE,
+    _get_bq_client,
+    _insert_rows,
+    _insert_via_rest,
+    export_action_feedback,
+    export_model_checkpoint,
+    export_pipeline_run,
+    export_transcript_outcome,
+)
+
+MODULE = "uvai.ml.bigquery_export"
 
 
-def test_get_bq_client_import_error() -> None:
-    """Test that _get_bq_client returns None when google.cloud.bigquery is missing."""
-    with patch.dict("sys.modules", {"google.cloud.bigquery": None}):
-        client = _get_bq_client()
-        assert client is None
+def _fake_http_response(payload: dict[str, Any]) -> MagicMock:
+    """Build a urlopen() context-manager double returning ``payload`` as JSON."""
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(payload).encode("utf-8")
+    ctx = MagicMock()
+    ctx.__enter__.return_value = resp
+    ctx.__exit__.return_value = False
+    return ctx
+
+
+def _assert_iso_utc(value: str) -> None:
+    """The exported timestamp must be a timezone-aware ISO-8601 UTC string."""
+    parsed = datetime.fromisoformat(value)
+    assert parsed.tzinfo is not None, "exported_at must be timezone-aware"
+    offset = parsed.utcoffset()
+    assert offset is not None and offset.total_seconds() == 0, "exported_at must be UTC"
+
+
+class TestGetBqClient:
+    """`_get_bq_client` degrades to None instead of raising."""
+
+    def test_returns_none_when_bigquery_not_installed(self) -> None:
+        """ImportError is swallowed regardless of interpreter import state.
+
+        Poisoning ``sys.modules["google.cloud.bigquery"]`` alone is not enough:
+        ``from google.cloud import bigquery`` resolves by ``getattr`` on an
+        already-imported ``google.cloud``, so a real or mocked parent package
+        left behind by another test bypasses the poisoned entry entirely.
+        Denying the import at ``__import__`` level is order-independent.
+        """
+        real_import = builtins.__import__
+
+        def _deny_bigquery(name: str, *args: Any, **kwargs: Any) -> Any:
+            fromlist = args[2] if len(args) > 2 else kwargs.get("fromlist") or ()
+            if name == "google.cloud.bigquery" or (
+                name == "google.cloud" and "bigquery" in fromlist
+            ):
+                raise ImportError("No module named 'google.cloud.bigquery'")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=_deny_bigquery):
+            assert _get_bq_client() is None
+
+    def test_returns_none_when_client_construction_raises(self) -> None:
+        bigquery = MagicMock()
+        bigquery.Client.side_effect = RuntimeError("no credentials")
+        google_cloud = MagicMock(bigquery=bigquery)
+        with patch.dict(
+            "sys.modules",
+            {
+                "google": MagicMock(cloud=google_cloud),
+                "google.cloud": google_cloud,
+                "google.cloud.bigquery": bigquery,
+            },
+        ):
+            assert _get_bq_client() is None
+
+    def test_returns_client_and_passes_project_id(self) -> None:
+        sentinel = object()
+        bigquery = MagicMock()
+        bigquery.Client.return_value = sentinel
+        google_cloud = MagicMock(bigquery=bigquery)
+        with patch.dict(
+            "sys.modules",
+            {
+                "google": MagicMock(cloud=google_cloud),
+                "google.cloud": google_cloud,
+                "google.cloud.bigquery": bigquery,
+            },
+        ):
+            assert _get_bq_client() is sentinel
+        bigquery.Client.assert_called_once_with(project=bigquery_export.PROJECT_ID)
+
+
+class TestInsertRows:
+    """`_insert_rows` returns a bool and never propagates client failures."""
+
+    def test_returns_false_when_client_unavailable(self) -> None:
+        with patch(f"{MODULE}._get_bq_client", return_value=None):
+            assert _insert_rows("some_table", [{"a": 1}]) is False
+
+    def test_returns_true_when_no_errors_reported(self) -> None:
+        client = MagicMock()
+        client.insert_rows_json.return_value = []
+        with patch(f"{MODULE}._get_bq_client", return_value=client):
+            assert _insert_rows("some_table", [{"a": 1}]) is True
+
+    def test_builds_fully_qualified_table_reference(self) -> None:
+        client = MagicMock()
+        client.insert_rows_json.return_value = []
+        rows = [{"a": 1}]
+        with patch(f"{MODULE}._get_bq_client", return_value=client):
+            _insert_rows("some_table", rows)
+        expected = (
+            f"{bigquery_export.PROJECT_ID}.{bigquery_export.DATASET_ID}.some_table"
+        )
+        client.insert_rows_json.assert_called_once_with(expected, rows)
+
+    def test_returns_false_when_backend_reports_row_errors(self) -> None:
+        client = MagicMock()
+        client.insert_rows_json.return_value = [{"index": 0, "errors": ["bad row"]}]
+        with patch(f"{MODULE}._get_bq_client", return_value=client):
+            assert _insert_rows("some_table", [{"a": 1}]) is False
+
+    def test_returns_false_when_insert_raises(self) -> None:
+        client = MagicMock()
+        client.insert_rows_json.side_effect = RuntimeError("network down")
+        with patch(f"{MODULE}._get_bq_client", return_value=client):
+            assert _insert_rows("some_table", [{"a": 1}]) is False
+
+    def test_empty_row_list_is_forwarded_verbatim(self) -> None:
+        """Empty input is not special-cased; it is still handed to the client."""
+        client = MagicMock()
+        client.insert_rows_json.return_value = []
+        with patch(f"{MODULE}._get_bq_client", return_value=client):
+            assert _insert_rows("some_table", []) is True
+        assert client.insert_rows_json.call_args[0][1] == []
+
+
+class TestInsertViaRest:
+    """`_insert_via_rest` is the Cloud Run metadata-server fallback."""
+
+    def test_returns_false_when_token_missing(self) -> None:
+        with patch("urllib.request.urlopen", return_value=_fake_http_response({})):
+            assert _insert_via_rest("t", [{"a": 1}]) is False
+
+    def test_returns_false_when_token_is_empty_string(self) -> None:
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_fake_http_response({"access_token": ""}),
+        ):
+            assert _insert_via_rest("t", [{"a": 1}]) is False
+
+    def test_returns_true_on_successful_insert(self) -> None:
+        responses = [
+            _fake_http_response({"access_token": "tok"}),
+            _fake_http_response({"kind": "bigquery#tableDataInsertAllResponse"}),
+        ]
+        with patch("urllib.request.urlopen", side_effect=responses):
+            assert _insert_via_rest("t", [{"a": 1}]) is True
+
+    def test_returns_false_when_insert_errors_present(self) -> None:
+        responses = [
+            _fake_http_response({"access_token": "tok"}),
+            _fake_http_response({"insertErrors": [{"index": 0}]}),
+        ]
+        with patch("urllib.request.urlopen", side_effect=responses):
+            assert _insert_via_rest("t", [{"a": 1}]) is False
+
+    def test_returns_false_when_network_raises(self) -> None:
+        with patch("urllib.request.urlopen", side_effect=OSError("unreachable")):
+            assert _insert_via_rest("t", [{"a": 1}]) is False
+
+    def test_requests_token_from_metadata_server_with_required_header(self) -> None:
+        responses = [
+            _fake_http_response({"access_token": "tok"}),
+            _fake_http_response({}),
+        ]
+        with patch("urllib.request.urlopen", side_effect=responses) as urlopen:
+            _insert_via_rest("t", [{"a": 1}])
+        token_req = urlopen.call_args_list[0][0][0]
+        assert token_req.full_url.startswith("http://metadata.google.internal/")
+        # urllib normalizes header names to title-case.
+        assert token_req.get_header("Metadata-flavor") == "Google"
+
+    def test_sends_bearer_token_and_targets_insert_all_endpoint(self) -> None:
+        responses = [
+            _fake_http_response({"access_token": "tok"}),
+            _fake_http_response({}),
+        ]
+        with patch("urllib.request.urlopen", side_effect=responses) as urlopen:
+            _insert_via_rest("my_table", [{"a": 1}])
+        insert_req = urlopen.call_args_list[1][0][0]
+        assert insert_req.get_header("Authorization") == "Bearer tok"
+        assert insert_req.get_header("Content-type") == "application/json"
+        assert insert_req.get_method() == "POST"
+        assert insert_req.full_url == (
+            "https://bigquery.googleapis.com/bigquery/v2/projects/"
+            f"{bigquery_export.PROJECT_ID}/datasets/"
+            f"{bigquery_export.DATASET_ID}/tables/my_table/insertAll"
+        )
+
+    def test_wraps_each_row_with_a_unique_insert_id(self) -> None:
+        responses = [
+            _fake_http_response({"access_token": "tok"}),
+            _fake_http_response({}),
+        ]
+        rows = [{"a": 1}, {"b": 2}, {"c": 3}]
+        with patch("urllib.request.urlopen", side_effect=responses) as urlopen:
+            _insert_via_rest("t", rows)
+        body = json.loads(urlopen.call_args_list[1][0][0].data.decode("utf-8"))
+        assert [entry["json"] for entry in body["rows"]] == rows
+        insert_ids = [entry["insertId"] for entry in body["rows"]]
+        assert len(set(insert_ids)) == len(rows), "insertIds must be unique"
+
+
+class TestExportTranscriptOutcome:
+    """Serialization and fallback wiring for `export_transcript_outcome`."""
+
+    METADATA = {
+        "duration_seconds": 321.0,
+        "has_captions": True,
+        "language": "en",
+        "category": "Education",
+        "subscriber_count": 1000,
+        "view_count": 50_000,
+    }
+
+    def test_returns_true_and_skips_rest_when_primary_insert_succeeds(self) -> None:
+        with (
+            patch(f"{MODULE}._insert_rows", return_value=True) as rows,
+            patch(f"{MODULE}._insert_via_rest") as rest,
+        ):
+            result = export_transcript_outcome(
+                video_url="https://youtu.be/auJzb1D-fag",
+                metadata=self.METADATA,
+                actual_source="captions",
+                actual_quality=0.93,
+                success=True,
+            )
+        assert result is True
+        rows.assert_called_once()
+        rest.assert_not_called()
+
+    def test_falls_back_to_rest_when_primary_insert_fails(self) -> None:
+        with (
+            patch(f"{MODULE}._insert_rows", return_value=False),
+            patch(f"{MODULE}._insert_via_rest", return_value=True) as rest,
+        ):
+            result = export_transcript_outcome(
+                video_url="https://youtu.be/auJzb1D-fag",
+                metadata=self.METADATA,
+                actual_source="captions",
+                actual_quality=0.93,
+                success=True,
+            )
+        assert result is True
+        rest.assert_called_once()
+
+    def test_returns_false_when_both_paths_fail(self) -> None:
+        with (
+            patch(f"{MODULE}._insert_rows", return_value=False),
+            patch(f"{MODULE}._insert_via_rest", return_value=False),
+        ):
+            assert (
+                export_transcript_outcome(
+                    video_url="https://youtu.be/auJzb1D-fag",
+                    metadata=self.METADATA,
+                    actual_source="captions",
+                    actual_quality=0.93,
+                    success=True,
+                )
+                is False
+            )
+
+    def test_serializes_all_fields_and_targets_outcomes_table(self) -> None:
+        with patch(f"{MODULE}._insert_rows", return_value=True) as rows:
+            export_transcript_outcome(
+                video_url="https://youtu.be/auJzb1D-fag",
+                metadata=self.METADATA,
+                actual_source="captions",
+                actual_quality=0.93,
+                success=True,
+                predicted_source="whisper",
+                predicted_quality=0.81,
+            )
+        table_id, payload = rows.call_args[0]
+        assert table_id == TRANSCRIPT_OUTCOMES_TABLE
+        assert len(payload) == 1
+        row = payload[0]
+        _assert_iso_utc(row.pop("exported_at"))
+        assert row == {
+            "video_url": "https://youtu.be/auJzb1D-fag",
+            "actual_source": "captions",
+            "actual_quality": 0.93,
+            "success": True,
+            "predicted_source": "whisper",
+            "predicted_quality": 0.81,
+            "duration_seconds": 321.0,
+            "has_captions": True,
+            "language": "en",
+            "category": "Education",
+            "subscriber_count": 1000,
+            "view_count": 50_000,
+        }
+
+    def test_absent_metadata_keys_serialize_as_none(self) -> None:
+        with patch(f"{MODULE}._insert_rows", return_value=True) as rows:
+            export_transcript_outcome(
+                video_url="https://youtu.be/auJzb1D-fag",
+                metadata={},
+                actual_source="whisper",
+                actual_quality=0.4,
+                success=False,
+            )
+        row = rows.call_args[0][1][0]
+        for key in (
+            "duration_seconds",
+            "has_captions",
+            "language",
+            "category",
+            "subscriber_count",
+            "view_count",
+            "predicted_source",
+            "predicted_quality",
+        ):
+            assert row[key] is None, f"{key} should default to None"
+
+    def test_falsy_quality_and_failure_flags_are_preserved(self) -> None:
+        """0.0 and False must survive serialization rather than becoming None."""
+        with patch(f"{MODULE}._insert_rows", return_value=True) as rows:
+            export_transcript_outcome(
+                video_url="https://youtu.be/auJzb1D-fag",
+                metadata={"has_captions": False},
+                actual_source="none",
+                actual_quality=0.0,
+                success=False,
+                predicted_quality=0.0,
+            )
+        row = rows.call_args[0][1][0]
+        assert row["actual_quality"] == 0.0
+        assert row["success"] is False
+        assert row["has_captions"] is False
+        assert row["predicted_quality"] == 0.0
+
+
+class TestExportActionFeedback:
+    def test_serializes_and_targets_feedback_table(self) -> None:
+        with patch(f"{MODULE}._insert_rows", return_value=True) as rows:
+            assert (
+                export_action_feedback(
+                    action_text="Draft the summary",
+                    clicked=True,
+                    completed=False,
+                    time_to_complete_seconds=12.5,
+                    priority_score=0.7,
+                    tier="high",
+                    video_url="https://youtu.be/auJzb1D-fag",
+                )
+                is True
+            )
+        table_id, payload = rows.call_args[0]
+        assert table_id == ACTION_FEEDBACK_TABLE
+        row = payload[0]
+        _assert_iso_utc(row.pop("exported_at"))
+        assert row == {
+            "action_text": "Draft the summary",
+            "clicked": True,
+            "completed": False,
+            "time_to_complete_seconds": 12.5,
+            "priority_score": 0.7,
+            "tier": "high",
+            "video_url": "https://youtu.be/auJzb1D-fag",
+        }
+
+    def test_falls_back_to_rest(self) -> None:
+        with (
+            patch(f"{MODULE}._insert_rows", return_value=False),
+            patch(f"{MODULE}._insert_via_rest", return_value=True) as rest,
+        ):
+            assert export_action_feedback("a", clicked=False, completed=False) is True
+        rest.assert_called_once()
+
+
+class TestExportModelCheckpoint:
+    SCORER = {
+        "version": "1.2.0",
+        "training_samples": 10,
+        "source_adjustments": {"captions": 0.1},
+    }
+    RANKER = {
+        "version": "0.9.0",
+        "training_samples": 20,
+        "verb_feedback_weights": {"draft": 0.5},
+        "global_feedback_bias": 0.25,
+    }
+
+    def test_json_encodes_nested_state_and_targets_checkpoints_table(self) -> None:
+        with patch(f"{MODULE}._insert_rows", return_value=True) as rows:
+            assert export_model_checkpoint(self.SCORER, self.RANKER) is True
+        table_id, payload = rows.call_args[0]
+        assert table_id == MODEL_CHECKPOINTS_TABLE
+        row = payload[0]
+        _assert_iso_utc(row.pop("exported_at"))
+        # Nested dicts must be JSON strings, not raw dicts, for BigQuery.
+        assert json.loads(row["scorer_source_adjustments"]) == {"captions": 0.1}
+        assert json.loads(row["ranker_verb_weights"]) == {"draft": 0.5}
+        assert row["scorer_version"] == "1.2.0"
+        assert row["ranker_global_bias"] == 0.25
+
+    def test_missing_state_keys_use_documented_defaults(self) -> None:
+        with patch(f"{MODULE}._insert_rows", return_value=True) as rows:
+            export_model_checkpoint({}, {})
+        row = rows.call_args[0][1][0]
+        assert row["scorer_version"] == "unknown"
+        assert row["ranker_version"] == "unknown"
+        assert row["scorer_training_samples"] == 0
+        assert row["ranker_training_samples"] == 0
+        assert row["ranker_global_bias"] == 0.0
+        assert json.loads(row["scorer_source_adjustments"]) == {}
+
+
+class TestExportPipelineRun:
+    def test_serializes_stage_list_as_json_and_targets_runs_table(self) -> None:
+        with patch(f"{MODULE}._insert_rows", return_value=True) as rows:
+            assert (
+                export_pipeline_run(
+                    video_url="https://youtu.be/auJzb1D-fag",
+                    workflow_template="default",
+                    total_duration_seconds=42.0,
+                    stages_completed=["capture", "analyze"],
+                    success=True,
+                    transcript_quality_score=0.88,
+                    actions_generated=3,
+                )
+                is True
+            )
+        table_id, payload = rows.call_args[0]
+        assert table_id == PIPELINE_RUNS_TABLE
+        row = payload[0]
+        _assert_iso_utc(row.pop("exported_at"))
+        assert json.loads(row["stages_completed"]) == ["capture", "analyze"]
+        assert row["error_message"] is None
+        assert row["actions_generated"] == 3
+
+    def test_omitted_stage_list_becomes_empty_json_array(self) -> None:
+        with patch(f"{MODULE}._insert_rows", return_value=True) as rows:
+            export_pipeline_run(video_url="https://youtu.be/auJzb1D-fag")
+        row = rows.call_args[0][1][0]
+        assert json.loads(row["stages_completed"]) == []
+        assert row["success"] is True
+
+    def test_failure_details_are_recorded(self) -> None:
+        with patch(f"{MODULE}._insert_rows", return_value=True) as rows:
+            export_pipeline_run(
+                video_url="https://youtu.be/auJzb1D-fag",
+                success=False,
+                error_message="transcript unavailable",
+            )
+        row = rows.call_args[0][1][0]
+        assert row["success"] is False
+        assert row["error_message"] == "transcript unavailable"
+
+
+@pytest.mark.parametrize(
+    ("exporter", "kwargs", "table"),
+    [
+        (
+            export_transcript_outcome,
+            {
+                "video_url": "https://youtu.be/auJzb1D-fag",
+                "metadata": {},
+                "actual_source": "captions",
+                "actual_quality": 0.5,
+                "success": True,
+            },
+            TRANSCRIPT_OUTCOMES_TABLE,
+        ),
+        (
+            export_action_feedback,
+            {"action_text": "a", "clicked": True, "completed": True},
+            ACTION_FEEDBACK_TABLE,
+        ),
+        (
+            export_model_checkpoint,
+            {"scorer_state": {}, "ranker_state": {}},
+            MODEL_CHECKPOINTS_TABLE,
+        ),
+        (
+            export_pipeline_run,
+            {"video_url": "https://youtu.be/auJzb1D-fag"},
+            PIPELINE_RUNS_TABLE,
+        ),
+    ],
+)
+class TestExporterContract:
+    """Behavior every public exporter shares."""
+
+    def test_returns_false_when_both_transports_fail(
+        self, exporter: Any, kwargs: dict[str, Any], table: str
+    ) -> None:
+        with (
+            patch(f"{MODULE}._insert_rows", return_value=False),
+            patch(f"{MODULE}._insert_via_rest", return_value=False),
+        ):
+            assert exporter(**kwargs) is False
+
+    def test_rest_fallback_retries_the_identical_row(
+        self, exporter: Any, kwargs: dict[str, Any], table: str
+    ) -> None:
+        """The retry must reuse the same row object, not rebuild it.
+
+        Rebuilding would mint a fresh ``exported_at``, so the fallback would
+        record a different event time than the attempt it is retrying.
+        """
+        with (
+            patch(f"{MODULE}._insert_rows", return_value=False) as rows,
+            patch(f"{MODULE}._insert_via_rest", return_value=True) as rest,
+        ):
+            exporter(**kwargs)
+        assert rows.call_args[0][0] == table
+        assert rest.call_args[0][0] == table
+        assert rest.call_args[0][1][0] is rows.call_args[0][1][0]
+
+    def test_emits_exactly_one_row_stamped_in_utc(
+        self, exporter: Any, kwargs: dict[str, Any], table: str
+    ) -> None:
+        with patch(f"{MODULE}._insert_rows", return_value=True) as rows:
+            exporter(**kwargs)
+        payload = rows.call_args[0][1]
+        assert len(payload) == 1
+        _assert_iso_utc(payload[0]["exported_at"])


### PR DESCRIPTION
## Canonical issue

Closes #909

`src/uvai/ml/bigquery_export.py` had a single test covering 29.89% of the module. Both transports (BigQuery client and REST fallback), all four `export_*` entry points, and every failure path were unverified.

## Outcome

Replaced the 1-test file with 42 tests. Statement coverage of `src/uvai/ml/bigquery_export.py` goes **29.89% -> 100%** (61 previously-missed statements now covered, 0 missed).

| Class | Tests | Covers |
| --- | --- | --- |
| `TestGetBqClient` | 3 | ImportError -> `None`; construction raises -> `None`; success passes `project=PROJECT_ID` |
| `TestInsertRows` | 6 | no client -> `False`; success -> `True`; fully-qualified `table_ref`; backend row errors -> `False`; exception -> `False`; empty-list behaviour |
| `TestInsertViaRest` | 8 | missing/empty token -> `False`; success -> `True`; `insertErrors` -> `False`; network error -> `False`; metadata-server URL and header; bearer auth + insertAll URL; unique `insertId` per row |
| `TestExportTranscriptOutcome` | 6 | skips REST on success; falls back on failure; both fail -> `False`; field serialization; absent metadata -> `None`; falsy `0.0`/`False` preserved |
| `TestExportActionFeedback` | 2 | field serialization; REST fallback |
| `TestExportModelCheckpoint` | 2 | nested dicts JSON-encoded; documented defaults |
| `TestExportPipelineRun` | 3 | stage list -> JSON; omitted list -> `[]`; failure details recorded |
| `TestExporterContract` | 12 | 3 shared invariants x 4 exporters, parametrized |

The suite also fixes a **pre-existing order-dependent failure**. The old test poisoned `sys.modules["google.cloud.bigquery"]`, but `from google.cloud import bigquery` resolves via `getattr` on an already-imported parent package, so a mocked `google.cloud` left behind by another test bypassed the poison entirely. It passed in isolation (vacuously - `google` is not installed) and failed in a full-suite run. The replacement denies the import at `__import__` level, which is order-independent.

No production code is modified. All public signatures are unchanged, as the issue requires.

## Risk

- Risk level: low
- Test-only change; `src/uvai/ml/bigquery_export.py` is untouched (`git status` clean for that path after every mutation run).
- Every Google Cloud, network, and metadata-server boundary is mocked, so the suite never reaches an external service and runs offline in 0.06s.
- The one behavioural claim about existing code - that the old test was already failing in full-suite runs - is demonstrated below rather than asserted.

## Verification

Run on branch `groupthinking-bigquery-export-coverage`, branched from `origin/main` at `b664e9227` per the issue's "start from current main" criterion.

```
$ .venv/bin/python -m pytest tests/unit/test_bigquery_export.py
42 passed in 0.06s

$ .venv/bin/python -m pytest tests/unit/test_bigquery_export.py --cov=uvai.ml.bigquery_export
src/uvai/ml/bigquery_export.py      87      0  100.0000%

$ .venv/bin/python -m ruff check tests/unit/test_bigquery_export.py
All checks passed!

$ .venv/bin/python -m black --check tests/unit/test_bigquery_export.py
1 file would be left unchanged.
```

Coverage baseline captured by stashing the new file and re-running:

```
before:  87 stmts   61 missed   29.8851%
after:   87 stmts    0 missed  100.0000%
```

Full `tests/unit` run, mine vs. baseline (same command, same machine):

```
with change:  133 failed, 6062 passed, 41 errors
baseline:     134 failed, 6020 passed, 41 errors
```

Passed count rises by exactly 42 (my tests) and failures drop by exactly 1 - the pre-existing `test_get_bq_client_import_error`. All other counts are identical, confirming nothing else is affected. The remaining 133 failures and 41 errors are pre-existing and unrelated (collection errors reproduce identically at 36 with and without this change).

## Production evidence

**1. The tests detect regressions.** Passing tests are not the same as detecting tests, so each assertion was verified by mutating the source and confirming a failure. 10/10 mutations caught, source verified restored after each:

| # | Mutation | Caught |
| --- | --- | --- |
| 1 | Drop the bearer prefix from the auth header | yes |
| 2 | Wrong metadata-server header key | yes |
| 3 | Remove the REST fallback from `export_pipeline_run` | yes |
| 4 | Constant `insertId` instead of per-row unique | yes |
| 5 | Ignore `insertErrors` in the REST response | yes |
| 6 | Wrong metadata-flavor header value | yes |
| 7 | Wrong `export_model_checkpoint` default | yes |
| 8 | Naive (non-UTC) `exported_at` timestamp | yes |
| 9 | Write outcomes to the wrong table | yes |
| 10 | Rebuild the row on fallback instead of reusing it | yes |

**2. The order-dependence fix is demonstrated, not asserted.** A temporary harness reproduced the exact pollution condition (a mocked `google.cloud` in `sys.modules`), then was removed:

```
old approach + pollution:  1 failed
new approach + pollution:  43 passed
```

And on unmodified `origin/main`, the pre-existing test is confirmed already failing in a full-suite run:

```
$ git stash push tests/unit/test_bigquery_export.py
$ .venv/bin/python -m pytest tests/unit/ --continue-on-collection-errors
FAILED tests/unit/test_bigquery_export.py::test_get_bq_client_import_error
```

**3. The replacement test is not vacuous.** Because `google` is not installed in this environment, an import-denial test can pass without exercising anything. Mutating the `ImportError` branch to return a truthy sentinel fails the test, proving the branch is genuinely reached:

```
mutated: ImportError branch returns truthy sentinel
FAILED tests/unit/test_bigquery_export.py::TestGetBqClient::test_returns_none_when_bigquery_not_installed
```

A behaviour-preserving mutation (`except ImportError` -> `except ZeroDivisionError`) is correctly *not* flagged, since the generic `except Exception` handler still returns `None` - the tests assert on contract, not on incidental structure.
