### PR TITLE
fix(security): raise brace-expansion override floors above the OOM backport

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     "sharp": "^0.35.0",
     "@hono/node-server": "^2.0.5",
     "minimatch@3.1.5": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.17"
     },
     "minimatch@9.0.9": {
-      "brace-expansion": "^2.1.2"
+      "brace-expansion": "^2.1.3"
     }
   },
   "dependencies": {

--- a/tests/unit/test_security_fixes.py
+++ b/tests/unit/test_security_fixes.py
@@ -26,6 +26,35 @@ PRODUCTION_DOCKERFILE = (
     project_root / "infrastructure" / "docker" / "Dockerfile.production"
 )
 
+# Root workspace manifests. The `overrides` block in package.json is the only
+# thing standing between the tree and a transitively-pulled vulnerable
+# brace-expansion, so both files are asserted directly.
+ROOT_PACKAGE_JSON = project_root / "package.json"
+ROOT_PACKAGE_LOCK = project_root / "package-lock.json"
+
+# brace-expansion GHSA-mh99-v99m-4gvg (unbounded expansion -> heap exhaustion).
+# The remediation is a hard 100000-entry cap on expansion output.
+#
+# GitHub's advisory record for this GHSA carries a single `<= 5.0.7` range and
+# -- unlike every other multi-line brace-expansion advisory -- no per-line 1.x
+# or 2.x entry, so neither `npm audit` nor the advisory metadata reveals where
+# the backports landed. They were measured directly instead: under
+# `--max-old-space-size=512`, 1.1.16 and 2.1.2 exhaust the heap on both the
+# numeric (`{1..50000000}`) and cartesian (`{a,b}` x 30) vectors, while 1.1.17
+# and 2.1.3 return a capped 100000 entries.
+#
+# Floors are therefore keyed by major line: a range must not admit any version
+# below the first patched release *of its own line*. This is exactly the defect
+# in #1115 -- `^1.1.16` and `^2.1.2` read as remediated (they do clear the
+# separate GHSA-3jxr-9vmj-r5cp) but still admit the OOM-vulnerable 1.1.16 and
+# 2.1.2 themselves. The tree resolved safely only because the carets happened
+# to float up.
+BRACE_EXPANSION_PATCHED = {
+    1: "1.1.17",
+    2: "2.1.3",
+    5: "5.0.8",
+}
+
 # Matches a PEP 508-ish requirement with a `>=` floor, with or without extras
 # and surrounding quotes, e.g. `"uvicorn[standard]>=0.24.0"` or `fastapi`.
 _REQUIREMENT_RE = re.compile(
@@ -48,6 +77,55 @@ def _version_key(version: str) -> tuple:
 
 def _fmt(key: tuple) -> str:
     return ".".join(str(value) for _, value in key)
+
+
+def _range_floor(spec: str) -> str:
+    """Lowest version a npm range literal admits.
+
+    Only the range operators actually used in this repo's ``overrides`` block
+    are recognised (``^``, ``~``, ``>=``, ``=``, bare exact). Anything else --
+    a union (``||``), a hyphen range, or a wildcard -- has no single
+    well-defined floor, so it is rejected rather than silently parsed into a
+    weaker assertion.
+    """
+    literal = spec.strip().lstrip("v")
+    for operator in ("^", "~", ">=", "="):
+        if literal.startswith(operator):
+            literal = literal[len(operator) :].strip()
+            break
+    if not re.fullmatch(r"\d+(?:\.\d+)*", literal):
+        raise AssertionError(
+            f"unsupported version range {spec!r}: this guard can only reason "
+            "about ranges with a single numeric floor"
+        )
+    return literal
+
+
+def _brace_expansion_minimum(version: str) -> str:
+    """First patched brace-expansion release on ``version``'s major line."""
+    major = int(version.split(".", 1)[0])
+    patched = BRACE_EXPANSION_PATCHED.get(major)
+    assert patched is not None, (
+        f"brace-expansion {version} is on major line {major}, which has no "
+        "recorded GHSA-mh99-v99m-4gvg remediation. Measure the cap on that "
+        "line and add it to BRACE_EXPANSION_PATCHED before allowing it."
+    )
+    return patched
+
+
+def _iter_brace_expansion_overrides(overrides: dict, path: str = "overrides"):
+    """Yield ``(json_path, range_literal)`` for every brace-expansion pin.
+
+    Overrides nest arbitrarily (``{"minimatch@3.1.5": {"brace-expansion": ...}}``),
+    so this walks the whole tree instead of reading known keys -- a pin added
+    under a new parent must be covered automatically.
+    """
+    for key, value in overrides.items():
+        child = f"{path}.{key}"
+        if isinstance(value, dict):
+            yield from _iter_brace_expansion_overrides(value, child)
+        elif key == "brace-expansion":
+            yield child, value
 
 
 def _pip_install_command(text: str) -> str:
@@ -517,6 +595,61 @@ class TestSecurityBestPractices:
             f"module {module!r} exists but defines no module-level {attr!r}; "
             f"'uvicorn {target}' would fail at startup"
         )
+
+    def test_brace_expansion_override_floors_exclude_oom_vulnerable_versions(self):
+        """Every brace-expansion override floor must be at or above the first
+        patched release on its own major line.
+
+        Asserting the *floor* rather than the resolved version is the point.
+        Resolution is checked separately below, but a safe resolution proves
+        nothing durable: it is a property of whatever the registry happened to
+        offer when the lockfile was written, not of what the manifest permits.
+        The floors in #1115 were `^1.1.16` / `^2.1.2` -- both admitting the
+        exact versions that OOM -- while the tree resolved to 1.1.18 / 2.1.4.
+        A lockfile refresh, a fresh `npm install`, or any consumer resolving
+        from package.json alone could legally land on the vulnerable version.
+        """
+        assert ROOT_PACKAGE_JSON.exists(), f"{ROOT_PACKAGE_JSON} not found"
+        manifest = json.loads(ROOT_PACKAGE_JSON.read_text())
+
+        pins = dict(_iter_brace_expansion_overrides(manifest.get("overrides", {})))
+        assert pins, (
+            "no brace-expansion override found in package.json; the transitive "
+            "pins guarding GHSA-mh99-v99m-4gvg have been dropped"
+        )
+
+        for json_path, spec in sorted(pins.items()):
+            floor = _range_floor(spec)
+            minimum = _brace_expansion_minimum(floor)
+            assert _version_key(floor) >= _version_key(minimum), (
+                f"{json_path} = {spec!r} admits brace-expansion {floor}, which "
+                f"predates the GHSA-mh99-v99m-4gvg cap introduced in {minimum}. "
+                f"Raise the floor to ^{minimum} or higher."
+            )
+
+    def test_brace_expansion_resolves_to_patched_versions(self):
+        """No copy of brace-expansion in the lockfile may sit below the cap.
+
+        The override floors constrain only the pins that are declared. This
+        catches any copy that arrives through a path no override covers.
+        """
+        assert ROOT_PACKAGE_LOCK.exists(), f"{ROOT_PACKAGE_LOCK} not found"
+        lock = json.loads(ROOT_PACKAGE_LOCK.read_text())
+
+        resolved = {
+            path: entry["version"]
+            for path, entry in lock.get("packages", {}).items()
+            if path.split("node_modules/")[-1] == "brace-expansion"
+            and "version" in entry
+        }
+        assert resolved, "lockfile contains no brace-expansion entry to verify"
+
+        for path, version in sorted(resolved.items()):
+            minimum = _brace_expansion_minimum(version)
+            assert _version_key(version) >= _version_key(minimum), (
+                f"{path} resolves to brace-expansion {version}, which predates "
+                f"the GHSA-mh99-v99m-4gvg cap introduced in {minimum}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1115

## The defect

The root `package.json` overrides pinned brace-expansion at `^1.1.16` and `^2.1.2`. Those floors correctly clear **GHSA-3jxr-9vmj-r5cp** (exponential-time expansion) but still **admit the exact versions that remain vulnerable to GHSA-mh99-v99m-4gvg** (unbounded expansion → OOM).

The tree resolved safely only *incidentally* — the carets happened to float up to 1.1.18 / 2.1.4. Nothing prevented a resolution back down to the vulnerable floor.

## Why this had to be measured, not looked up

GHSA-mh99-v99m-4gvg's GitHub record carries a **single `<= 5.0.7` range with no per-line 1.x/2.x entry**, unlike every other multi-line brace-expansion advisory. `npm audit` therefore cannot tell you where the 1.x/2.x backports landed. I measured both attack vectors directly under `node --max-old-space-size=512`:

| version | `{a,b}` × 30 | `{1..50000000}` |
|---|---|---|
| 1.1.16 | **OOM** | **OOM** |
| **1.1.17** | `len=100000` | `len=100000` |
| 1.1.18 | `len=100000` | `len=100000` |
| 2.1.2 | **OOM** | **OOM** |
| **2.1.3** | `len=100000` | `len=100000` |
| 2.1.4 | `len=100000` | `len=100000` |

The 100000-entry cap landed in **1.1.17** and **2.1.3** — exactly one patch above each pinned floor, confirming the issue's claim.

## The change

Two lines in `package.json`:

```diff
     "minimatch@3.1.5": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.17"
     },
     "minimatch@9.0.9": {
-      "brace-expansion": "^2.1.2"
+      "brace-expansion": "^2.1.3"
     }
```

## Regression guard

Added to `tests/unit/test_security_fixes.py`, which already owns repo-level manifest invariants (Dockerfile floors, install-failure masking, entrypoint module existence).

The guard asserts the **floor**, not the resolved version — the resolved version is the thing that drifts, so asserting it would be worthless. Design notes:

- `BRACE_EXPANSION_PATCHED` keys the minimum by **major line** (`{1: "1.1.17", 2: "2.1.3", 5: "5.0.8"}`) so it reasons per-line rather than hardcoding a literal.
- It raises a descriptive failure if a **new major line** (3.x, 4.x) ever appears with no recorded remediation — forcing a measurement instead of silently passing.
- `_iter_brace_expansion_overrides` walks the whole nested overrides tree, so a pin added under a new parent is covered automatically.
- `_range_floor` deliberately **rejects** unions / hyphen ranges / wildcards instead of quietly parsing them into a weaker assertion.

**Proven non-vacuous.** Reverting `^1.1.17` → `^1.1.16` fails with the offending path named:

```
overrides.minimatch@3.1.5.brace-expansion = '^1.1.16' admits brace-expansion 1.1.16,
which predates the GHSA-mh99-v99m-4gvg cap introduced in 1.1.17.
```

## Verification

| check | result |
|---|---|
| `npm install --package-lock-only` | **"up to date"** — lockfile byte-identical, zero tree movement |
| `npm ci --legacy-peer-deps` | exit 0 (748 packages) |
| `npm run build:web` | exit 0 |
| `apps/web` lint | exit 0 |
| new tests | 2 passed |
| `tests/unit/test_security_fixes.py` | 14 passed, 4 skipped |

Because the lockfile does not move, this change **only removes vulnerable versions from the permitted set** — it does not alter any resolution.

PoC re-run against every copy actually installed by `npm ci`, using exports-aware entry resolution (5.x is a dist-based dual package with no `index.js`):

```
5.0.9   node_modules/brace-expansion                          cartesian=100000 numeric=100000
1.1.18  node_modules/minimatch/node_modules/brace-expansion   cartesian=100000 numeric=100000
2.1.4   node_modules/rimraf/node_modules/brace-expansion      cartesian=100000 numeric=100000
```

<sub>One pre-existing failure, `TestSecurityAgentEvalFix::test_security_agent_distinguishes_eval_from_literal_eval`, is a missing `aiohttp` in my ephemeral venv. Confirmed it fails identically with these changes stashed, so it is unrelated.</sub>

## Accepted residual

Residual GHSA-mh99-v99m-4gvg `npm audit` entries against 1.1.18 / 2.1.4 have **no upgrade path** — 5.x is a breaking ESM-only rewrite. Both installed copies are empirically capped (table above), so the runtime risk is remediated even though the advisory range still matches.