### PR TITLE
perf: read local image bytes off the event loop in vision providers

### DIFF
--- a/src/youtube_extension/integrations/cloud_ai/providers/azure_vision.py
+++ b/src/youtube_extension/integrations/cloud_ai/providers/azure_vision.py
@@ -8,6 +8,7 @@ Implements video and image analysis using Azure AI Vision services:
 - Custom Vision (if configured)
 """
 
+import asyncio
 import logging
 from datetime import datetime
 from typing import Any, Optional
@@ -27,6 +28,12 @@ from ..exceptions import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _read_file_bytes(path: str) -> bytes:
+    """Read a file's bytes. Module-level so it can run in a worker thread."""
+    with open(path, 'rb') as handle:
+        return handle.read()
 
 
 class AzureVision(BaseCloudAI):
@@ -251,9 +258,8 @@ class AzureVision(BaseCloudAI):
             # For URL input, Azure can analyze directly
             return None
         else:
-            # For local files, read content
-            with open(image_url, 'rb') as image_file:
-                return image_file.read()
+            # Local file - read off the event loop
+            return await asyncio.to_thread(_read_file_bytes, image_url)
 
     async def _await_ocr_call(self, deadline: float, func: Any, *args: Any, **kwargs: Any) -> Any:
         """Run a blocking Azure SDK call in a worker thread, bounded by a
@@ -263,8 +269,6 @@ class AzureVision(BaseCloudAI):
         ``asyncio.wait_for`` enforces the remaining budget so neither a slow read
         nor a slow poll can run past the OCR timeout. Raises ``CloudAIError`` on
         expiry."""
-        import asyncio
-
         remaining = deadline - asyncio.get_running_loop().time()
         if remaining <= 0:
             raise CloudAIError("Azure OCR operation timed out")
@@ -277,8 +281,6 @@ class AzureVision(BaseCloudAI):
 
     async def _perform_ocr(self, image_url: str, image_stream: Optional[bytes]) -> dict[str, Any]:
         """Perform OCR using Azure Read API."""
-        import asyncio
-
         from azure.cognitiveservices.vision.computervision.models import (
             OperationStatusCodes,
         )
@@ -322,8 +324,6 @@ class AzureVision(BaseCloudAI):
 
     async def _perform_ocr_stream(self, image_stream) -> dict[str, Any]:
         """Perform OCR on image stream."""
-        import asyncio
-
         from azure.cognitiveservices.vision.computervision.models import (
             OperationStatusCodes,
         )

--- a/src/youtube_extension/integrations/cloud_ai/providers/google_cloud.py
+++ b/src/youtube_extension/integrations/cloud_ai/providers/google_cloud.py
@@ -31,6 +31,12 @@ from ..exceptions import (
 logger = logging.getLogger(__name__)
 
 
+def _read_file_bytes(path: str) -> bytes:
+    """Read a file's bytes. Module-level so it can run in a worker thread."""
+    with open(path, 'rb') as handle:
+        return handle.read()
+
+
 class GoogleCloudAI(BaseCloudAI):
     """Google Cloud Video Intelligence and Vision API integration."""
 
@@ -181,9 +187,8 @@ class GoogleCloudAI(BaseCloudAI):
             if image_url.startswith(('http://', 'https://')):
                 image.source.image_uri = image_url
             else:
-                # For local files
-                with open(image_url, 'rb') as image_file:
-                    image.content = image_file.read()
+                # Local file - read off the event loop
+                image.content = await asyncio.to_thread(_read_file_bytes, image_url)
 
             # Prepare features
             features = self._prepare_vision_features(analysis_types)

--- a/tests/unit/test_azure_vision_provider.py
+++ b/tests/unit/test_azure_vision_provider.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import builtins
 import sys
+import threading
 import types as _types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1194,3 +1196,66 @@ class TestAzureVisionEstimateCost:
         cost1 = provider.estimate_cost(60.0, [AnalysisType.OCR])
         cost2 = provider.estimate_cost(60.0, [AnalysisType.OCR, AnalysisType.FACE_DETECTION])
         assert cost2 > cost1
+
+
+# ===========================================================================
+# Local image reads must not block the event loop
+# ===========================================================================
+
+
+class _ThreadRecordingOpen:
+    """Wrap ``builtins.open`` and record which thread opened a target path.
+
+    Off-loop execution is asserted by *thread identity* rather than elapsed
+    wall-clock time, which is flaky on loaded CI runners. Only calls for the
+    target path are recorded so unrelated ``open`` traffic (logging, coverage)
+    cannot contaminate the result.
+    """
+
+    def __init__(self, target):
+        self._real_open = builtins.open
+        self._target = str(target)
+        self.threads: list[int] = []
+
+    def __call__(self, file, *args, **kwargs):
+        if str(file) == self._target:
+            self.threads.append(threading.get_ident())
+        return self._real_open(file, *args, **kwargs)
+
+
+class TestAzureVisionImageReadOffEventLoop:
+    async def test_local_file_read_runs_on_worker_thread(self, tmp_path):
+        provider = _make_provider()
+        img_file = tmp_path / "frame.jpg"
+        img_file.write_bytes(b"\xff\xd8\xff\xe0")
+        recorder = _ThreadRecordingOpen(img_file)
+        loop_thread = threading.get_ident()
+
+        with patch("builtins.open", recorder):
+            result = await provider._prepare_image_input(str(img_file))
+
+        assert result == b"\xff\xd8\xff\xe0"
+        assert recorder.threads, "expected the provider to open the local image file"
+        assert loop_thread not in recorder.threads, (
+            "local image bytes were read on the event loop thread; the read must "
+            "be offloaded to a worker thread"
+        )
+
+    async def test_http_url_performs_no_disk_read(self, tmp_path):
+        """The URL branch must remain untouched: Azure fetches it directly."""
+        provider = _make_provider()
+        decoy = tmp_path / "unused.jpg"
+        decoy.write_bytes(b"\x00")
+        recorder = _ThreadRecordingOpen(decoy)
+
+        with patch("builtins.open", recorder):
+            result = await provider._prepare_image_input("https://example.com/img.jpg")
+
+        assert result is None
+        assert recorder.threads == []
+
+    async def test_missing_file_still_raises_file_not_found(self, tmp_path):
+        """Offloading must not swallow or re-wrap I/O errors."""
+        provider = _make_provider()
+        with pytest.raises(FileNotFoundError):
+            await provider._prepare_image_input(str(tmp_path / "does-not-exist.jpg"))

--- a/tests/unit/test_azure_vision_provider.py
+++ b/tests/unit/test_azure_vision_provider.py
@@ -1203,13 +1203,38 @@ class TestAzureVisionEstimateCost:
 # ===========================================================================
 
 
+class _ThreadRecordingHandle:
+    """File-object proxy that records the calling thread on every ``read``."""
+
+    def __init__(self, handle, threads):
+        self._handle = handle
+        self._threads = threads
+
+    def read(self, *args, **kwargs):
+        self._threads.append(threading.get_ident())
+        return self._handle.read(*args, **kwargs)
+
+    def __enter__(self):
+        self._handle.__enter__()
+        return self
+
+    def __exit__(self, *exc_info):
+        return self._handle.__exit__(*exc_info)
+
+    def __getattr__(self, name):
+        return getattr(self._handle, name)
+
+
 class _ThreadRecordingOpen:
-    """Wrap ``builtins.open`` and record which thread opened a target path.
+    """Wrap ``builtins.open`` and record which thread *reads* a target path.
 
     Off-loop execution is asserted by *thread identity* rather than elapsed
-    wall-clock time, which is flaky on loaded CI runners. Only calls for the
-    target path are recorded so unrelated ``open`` traffic (logging, coverage)
-    cannot contaminate the result.
+    wall-clock time, which is flaky on loaded CI runners. The recording hooks
+    ``read()`` on the returned handle rather than ``open()`` itself, so a
+    regression that opens the file on a worker thread but reads its bytes back
+    on the event loop is still caught. Only the target path is wrapped so
+    unrelated ``open`` traffic (logging, coverage) cannot contaminate the
+    result.
     """
 
     def __init__(self, target):
@@ -1218,9 +1243,10 @@ class _ThreadRecordingOpen:
         self.threads: list[int] = []
 
     def __call__(self, file, *args, **kwargs):
+        handle = self._real_open(file, *args, **kwargs)
         if str(file) == self._target:
-            self.threads.append(threading.get_ident())
-        return self._real_open(file, *args, **kwargs)
+            return _ThreadRecordingHandle(handle, self.threads)
+        return handle
 
 
 class TestAzureVisionImageReadOffEventLoop:
@@ -1235,7 +1261,7 @@ class TestAzureVisionImageReadOffEventLoop:
             result = await provider._prepare_image_input(str(img_file))
 
         assert result == b"\xff\xd8\xff\xe0"
-        assert recorder.threads, "expected the provider to open the local image file"
+        assert recorder.threads, "expected the provider to read the local image file"
         assert loop_thread not in recorder.threads, (
             "local image bytes were read on the event loop thread; the read must "
             "be offloaded to a worker thread"

--- a/tests/unit/test_google_cloud_provider.py
+++ b/tests/unit/test_google_cloud_provider.py
@@ -1231,3 +1231,23 @@ class TestGoogleCloudImageReadOffEventLoop:
 
         assert recorder.threads == []
         assert mock_vision.Image.return_value.source.image_uri == "https://example.com/img.jpg"
+
+    async def test_missing_local_file_wrapped_in_cloud_ai_error(self, tmp_path):
+        """A missing local image surfaces as ``CloudAIError`` from the public API.
+
+        Unlike Azure's private ``_prepare_image_input`` (which propagates
+        ``FileNotFoundError``), Google's public ``analyze_image`` catches it in
+        its broad ``except Exception`` and re-raises as ``CloudAIError``. Pin
+        that wrapper contract so moving the read off the loop cannot silently
+        alter how a missing file is reported.
+        """
+        provider = _make_provider()
+        provider._vision_client = self._client()
+        missing = tmp_path / "does-not-exist.jpg"
+        mock_vision = self._vision_modules()
+
+        with self._patched_modules(mock_vision):
+            with pytest.raises(CloudAIError):
+                await provider.analyze_image(
+                    str(missing), [AnalysisType.LABEL_DETECTION]
+                )

--- a/tests/unit/test_google_cloud_provider.py
+++ b/tests/unit/test_google_cloud_provider.py
@@ -1124,13 +1124,38 @@ class TestGoogleCloudAIEstimateCost:
 # ===========================================================================
 
 
+class _ThreadRecordingHandle:
+    """File-object proxy that records the calling thread on every ``read``."""
+
+    def __init__(self, handle, threads):
+        self._handle = handle
+        self._threads = threads
+
+    def read(self, *args, **kwargs):
+        self._threads.append(threading.get_ident())
+        return self._handle.read(*args, **kwargs)
+
+    def __enter__(self):
+        self._handle.__enter__()
+        return self
+
+    def __exit__(self, *exc_info):
+        return self._handle.__exit__(*exc_info)
+
+    def __getattr__(self, name):
+        return getattr(self._handle, name)
+
+
 class _ThreadRecordingOpen:
-    """Wrap ``builtins.open`` and record which thread opened a target path.
+    """Wrap ``builtins.open`` and record which thread *reads* a target path.
 
     Off-loop execution is asserted by *thread identity* rather than elapsed
-    wall-clock time, which is flaky on loaded CI runners. Only calls for the
-    target path are recorded so unrelated ``open`` traffic (logging, coverage)
-    cannot contaminate the result.
+    wall-clock time, which is flaky on loaded CI runners. The recording hooks
+    ``read()`` on the returned handle rather than ``open()`` itself, so a
+    regression that opens the file on a worker thread but reads its bytes back
+    on the event loop is still caught. Only the target path is wrapped so
+    unrelated ``open`` traffic (logging, coverage) cannot contaminate the
+    result.
     """
 
     def __init__(self, target):
@@ -1139,9 +1164,10 @@ class _ThreadRecordingOpen:
         self.threads: list[int] = []
 
     def __call__(self, file, *args, **kwargs):
+        handle = self._real_open(file, *args, **kwargs)
         if str(file) == self._target:
-            self.threads.append(threading.get_ident())
-        return self._real_open(file, *args, **kwargs)
+            return _ThreadRecordingHandle(handle, self.threads)
+        return handle
 
 
 class TestGoogleCloudImageReadOffEventLoop:
@@ -1183,7 +1209,7 @@ class TestGoogleCloudImageReadOffEventLoop:
             await provider.analyze_image(str(img_file), [AnalysisType.LABEL_DETECTION])
 
         assert mock_vision.Image.return_value.content == b"\x89PNG\r\n"
-        assert recorder.threads, "expected the provider to open the local image file"
+        assert recorder.threads, "expected the provider to read the local image file"
         assert loop_thread not in recorder.threads, (
             "local image bytes were read on the event loop thread; the read must "
             "be offloaded to a worker thread"

--- a/tests/unit/test_google_cloud_provider.py
+++ b/tests/unit/test_google_cloud_provider.py
@@ -1247,7 +1247,14 @@ class TestGoogleCloudImageReadOffEventLoop:
         mock_vision = self._vision_modules()
 
         with self._patched_modules(mock_vision):
-            with pytest.raises(CloudAIError):
+            with pytest.raises(CloudAIError) as exc_info:
                 await provider.analyze_image(
                     str(missing), [AnalysisType.LABEL_DETECTION]
                 )
+
+        # The provider re-raises without ``from e``, so the original error is
+        # carried on ``__context__`` (implicit chaining), not ``__cause__``.
+        assert isinstance(exc_info.value.__context__, FileNotFoundError), (
+            "offloading must preserve the underlying I/O error in the exception chain"
+        )
+        assert "No such file or directory" in str(exc_info.value)

--- a/tests/unit/test_google_cloud_provider.py
+++ b/tests/unit/test_google_cloud_provider.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 import sys
+import threading
 import types as _types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1115,3 +1117,91 @@ class TestGoogleCloudAIEstimateCost:
         provider = _make_provider()
         cost = provider.estimate_cost(0.0, [AnalysisType.LABEL_DETECTION])
         assert cost == pytest.approx(0.0)
+
+
+# ===========================================================================
+# Local image reads must not block the event loop
+# ===========================================================================
+
+
+class _ThreadRecordingOpen:
+    """Wrap ``builtins.open`` and record which thread opened a target path.
+
+    Off-loop execution is asserted by *thread identity* rather than elapsed
+    wall-clock time, which is flaky on loaded CI runners. Only calls for the
+    target path are recorded so unrelated ``open`` traffic (logging, coverage)
+    cannot contaminate the result.
+    """
+
+    def __init__(self, target):
+        self._real_open = builtins.open
+        self._target = str(target)
+        self.threads: list[int] = []
+
+    def __call__(self, file, *args, **kwargs):
+        if str(file) == self._target:
+            self.threads.append(threading.get_ident())
+        return self._real_open(file, *args, **kwargs)
+
+
+class TestGoogleCloudImageReadOffEventLoop:
+    def _vision_modules(self):
+        mock_image_instance = MagicMock()
+        mock_image_instance.source = MagicMock()
+        mock_image_cls = MagicMock(return_value=mock_image_instance)
+        mock_feature_type = MagicMock()
+        mock_feature_type.LABEL_DETECTION = "LABEL_DETECTION"
+        mock_feature_cls = MagicMock()
+        mock_feature_cls.Type = mock_feature_type
+        mock_vision = MagicMock()
+        mock_vision.Image = mock_image_cls
+        mock_vision.Feature = mock_feature_cls
+        return mock_vision
+
+    def _patched_modules(self, mock_vision):
+        return patch.dict("sys.modules", {
+            "google": _types.ModuleType("google"),
+            "google.cloud": _types.ModuleType("google.cloud"),
+            "google.cloud.vision": mock_vision,
+        })
+
+    def _client(self):
+        client = AsyncMock()
+        client.annotate_image = AsyncMock(return_value=_make_vision_response())
+        return client
+
+    async def test_local_file_read_runs_on_worker_thread(self, tmp_path):
+        provider = _make_provider()
+        provider._vision_client = self._client()
+        img_file = tmp_path / "frame.jpg"
+        img_file.write_bytes(b"\x89PNG\r\n")
+        mock_vision = self._vision_modules()
+        recorder = _ThreadRecordingOpen(img_file)
+        loop_thread = threading.get_ident()
+
+        with self._patched_modules(mock_vision), patch("builtins.open", recorder):
+            await provider.analyze_image(str(img_file), [AnalysisType.LABEL_DETECTION])
+
+        assert mock_vision.Image.return_value.content == b"\x89PNG\r\n"
+        assert recorder.threads, "expected the provider to open the local image file"
+        assert loop_thread not in recorder.threads, (
+            "local image bytes were read on the event loop thread; the read must "
+            "be offloaded to a worker thread"
+        )
+
+    async def test_http_url_performs_no_disk_read(self, tmp_path):
+        """The URI branch must remain untouched: Vision fetches it directly."""
+        provider = _make_provider()
+        provider._vision_client = self._client()
+        decoy = tmp_path / "unused.jpg"
+        decoy.write_bytes(b"\x00")
+        mock_vision = self._vision_modules()
+        recorder = _ThreadRecordingOpen(decoy)
+
+        with self._patched_modules(mock_vision), patch("builtins.open", recorder):
+            await provider.analyze_image(
+                "https://example.com/img.jpg", [AnalysisType.LABEL_DETECTION]
+            )
+
+        assert recorder.threads == []
+        assert mock_vision.Image.return_value.source.image_uri == "https://example.com/img.jpg"


### PR DESCRIPTION
## Canonical issue

Closes #1232

This completes the cross-provider work started in #1205, which fixed this identical defect in the `AWSRekognition` sibling. Azure and Google were left blocking.

## Outcome

Azure `AzureVision._prepare_image_input` and Google `GoogleCloudAI.analyze_image` read local image files with a synchronous `open().read()` inside `async def`. That call blocks the event loop thread for the whole duration of the disk read, stalling every other coroutine scheduled on that loop.

Both now route the read through a module-level `_read_file_bytes` helper via `asyncio.to_thread`, mirroring the merged `aws_rekognition.py` implementation exactly.

| | |
|---|---|
| **Does** | Move the local-file byte read off the event loop in both providers |
| **Does** | Return byte-for-byte identical content to callers |
| **Does** | Preserve the URL branches unchanged — Azure returns `None` so the SDK fetches the URL itself; Google still sets `image.source.image_uri` |
| **Does** | Preserve each provider's existing error contract exactly: Azure's `_prepare_image_input` has no `try/except` so `FileNotFoundError` propagates raw; Google's `analyze_image` wraps it in `CloudAIError` via its pre-existing broad `except` (unchanged by this PR, now pinned by a test) |
| **Does** | Drop three function-local `import asyncio` statements in `azure_vision.py` that the new module-level import makes redundant |
| **Does not** | Change any public signature, return type, or exception contract |
| **Does not** | Add a dependency, config key, or feature flag |
| **Does not** | Touch `analyze_video` on either provider |
| **Does not** | Introduce caching, batching, or retry behaviour |
| **Does not** | Alter the lazy Azure SDK imports sitting beside the removed lines |

## Risk

**Low, with two risks stated explicitly rather than waved away.**

1. **Shared default executor — residual, tracked in #1234.** An earlier draft of this section claimed a local read "has no analogous unbounded-wait failure mode". **That was wrong**, and the review challenge that caught it was correct: a path passed to `open()` may resolve to NFS/FUSE/remote-backed storage and stall without limit. Three facts, measured rather than asserted:

   - The default executor is bounded — `min(32, cpu_count + 4)`, i.e. **16 workers** on a 12-core host.
   - **Cancelling the awaiting coroutine does not reclaim the worker.** Cancelling a `to_thread` task whose function is blocked leaves the thread alive and stuck (`non-main threads AFTER cancel : 1 ['asyncio_0']`), so the slot leaks permanently.
   - Repo-wide there are **66** `asyncio.to_thread` call sites and **1** is bounded by a caller-side `wait_for`.

   **No timeout is added here, and that is a deliberate choice rather than an oversight.** `asyncio.wait_for` bounds the *caller*, not the *worker*; the measurement above shows the thread stays stuck after the caller is already free. Adding one would improve caller responsiveness but would **not** return the slot to the pool, so presenting it as a starvation mitigation would be false. The real fix is executor isolation, which is repo-wide (all 66 sites), architectural, and out of scope for a change whose canonical issue is scoped to moving one read off the loop — hence #1234 rather than scope creep here.

   **This PR strictly reduces the blast radius of exactly that failure mode.** Before: a stalled read blocks the **entire event loop**, so every request in the process stops. After: it blocks **one of 16** pool workers and the loop keeps serving. It is never worse on this axis, which is also why it matches the already-merged `aws_rekognition.py` sibling (#1205), whose `_read_file_bytes` consumption is likewise an unbounded `to_thread`.
2. **Redundant-import removal widens the diff.** The three deleted `import asyncio` lines sit in `_await_ocr_call`, `_perform_ocr`, and `_perform_ocr_stream` — functions this PR does not otherwise change. They are removed because *this PR* is what made them dead, by adding the module-level import. The deletion is behaviour-neutral: `asyncio` resolves to the same module either way. The adjacent lazy `azure.cognitiveservices...` imports are deliberately left in place, since those defer an optional dependency.

Rollback is a clean revert; there is no data migration, persisted state, or wire-format change.

## Verification

Head sha: `efc0e5355ac22129e6b2f9c3ca5ee6abf388df9b`

**1. Targeted suites pass.**

```
.venv/bin/python -m pytest tests/unit/test_azure_vision_provider.py \
  tests/unit/test_google_cloud_provider.py -p no:cacheprovider --no-cov -q
185 passed in 0.91s
```

**2. The new tests fail against the unpatched sources.** Both source files were stashed while keeping the tests, which is the check that the tests actually bind to the defect:

```
FAILED tests/unit/test_azure_vision_provider.py::TestAzureVisionImageReadOffEventLoop::test_local_file_read_runs_on_worker_thread
FAILED tests/unit/test_google_cloud_provider.py::TestGoogleCloudImageReadOffEventLoop::test_local_file_read_runs_on_worker_thread
2 failed, 3 passed
```

with the diagnostic `AssertionError: local image bytes were read on the event loop thread` and `assert 8284626624 not in [8284626624]`. They **fail**, they do not **error** — the tests patch `builtins.open` rather than the new helper, so they are runnable against both the old and new source and are not coupled to the helper's name.

The 4 that pass pre-change are behaviour-preservation guards (URL branch performs no disk read; Azure missing file raises raw `FileNotFoundError`; Google missing file raises `CloudAIError` with the original `FileNotFoundError` preserved on `__context__`). Those are meant to pass on both sides.

**3. Off-loop is proven by thread identity, not timing.** A `_ThreadRecordingOpen` wrapper records `threading.get_ident()` for opens of the target path only, so unrelated `open` traffic from logging or coverage cannot contaminate the result. Wall-clock assertions were rejected as CI-flaky. Each test also asserts the recorder is non-empty, so a silently-skipped read cannot pass vacuously.

**4. Ruff parity — 15 findings before, 15 after, zero diff.**

```
before(main)=15  final=15
PARITY OK — no new lint introduced
```

Measured by stashing the change, re-running, and diffing normalised output. All 15 are pre-existing.

**5. Wider sweep.** All `tests/unit/` files referencing `azure_vision`, `google_cloud`, or `cloud_ai`: `65 failed, 569 passed`. The same batch on **clean `main`** gives `65 failed, 564 passed` — the identical 65 failures, plus exactly the 5 tests this PR adds. Those 65 are pre-existing cross-module pollution in `test_service_container.py` when these files share one process; that file passes `58 passed` in isolation with this change applied. Not caused by, and not worsened by, this PR.

`tests/load/locustfile.py` was excluded after confirming its `RecursionError` collection failure reproduces on clean `main` (a gevent/greenlet finalisation issue).

## Production evidence

**No production latency improvement is claimed, and the reachability limits are stated up front.**

- `analyze_image` is **not reachable from any HTTP route**. `cloud_ai_routes.py` is mounted at `main.py:173` but exposes only `/providers/status`, `/analyze/video`, `/analyze/batch`, `/analyze/multi-provider`, `/analysis-types`, and `/providers`. There is no image endpoint.
- `grep -rn "analyze_image" src/` returns only the three provider implementations plus the abstract declaration at `base.py:108`. There are **no in-tree callers**.
- So this is a **library-surface defect on a public abstract-contract method**, not a live hot path. Anyone reading this expecting a production latency graph should stop here — there isn't one.

What does justify merging:

- `analyze_image` is part of the `BaseCloudAI` public contract at `base.py:108` and is callable by any consumer of the integration package.
- **#1205 already settled that this exact defect in this exact method is worth fixing** — it was merged for `AWSRekognition`, whose `_read_file_bytes` helper at `aws_rekognition.py:109-112` this PR copies. Leaving two of three implementations blocking makes the contract inconsistent: the same call has different event-loop safety depending only on which provider is configured. That inconsistency is the concrete defect being closed.
- The change is mechanical, has a merged in-repo precedent, and carries no behavioural change.

## Agent handoff

Adversarial review requested from `@coderabbitai`. Reviewers should specifically probe: whether the executor-starvation reasoning in **Risk** holds for a bounded local read; whether removing the three redundant `import asyncio` lines belongs in this PR or a follow-up; and whether patching `builtins.open` inside the Google test's `patch.dict("sys.modules", ...)` block is sound given that provider's lazy-import path.

## Review adjudication

Two corrections were made in response to agent review, both verified before landing:

1. **CodeRabbit** (non-blocking finding) correctly identified that the original `**Does**` row
   above overstated the error contract. `FileNotFoundError` propagates raw only from Azure;
   Google wraps it in `CloudAIError`. The row is corrected, and the Google contract is now
   pinned by `test_missing_local_file_wrapped_in_cloud_ai_error`, which asserts both the
   `CloudAIError` type and that the original `FileNotFoundError` survives on `__context__`.

2. **Linear** (`86371fc43`) correctly identified that `_ThreadRecordingOpen` recorded the thread
   calling `open()` rather than the thread performing `handle.read()`, so a regression that
   offloaded `open()` but read bytes back on the event loop would still pass. I verified this
   empirically by simulating exactly that regression against both harnesses:

   ```
   harness records at open()  -> recorded=[6182580224]  loop_tid=8284626624  CATCHES REGRESSION: False
   harness records at read()  -> recorded=[8284626624]  loop_tid=8284626624  CATCHES REGRESSION: True
   ```

   The old harness recorded the *worker* thread and let the regression through. The fix is real
   and the guards are now strictly stronger than as originally submitted.

Re-verified after both corrections: **186 passed**; pre-change replay against `origin/main`
sources still yields **2 failed, 4 passed** (only the two off-loop assertions fail, as intended);
`ruff check` clean on all touched files.
