### PR TITLE
perf: offload transcript download cleanup to a worker thread

### DIFF
--- a/src/youtube_extension/services/workflows/transcript_action_workflow.py
+++ b/src/youtube_extension/services/workflows/transcript_action_workflow.py
@@ -849,13 +849,7 @@ class TranscriptActionWorkflow:
                 if file_result.error:
                     errors.append(file_result.error)
             finally:
-                if video_path.exists():
-                    try:
-                        video_path.unlink()
-                    except OSError:
-                        pass
-                if temp_root and temp_root.exists():
-                    shutil.rmtree(temp_root, ignore_errors=True)
+                await self._cleanup_download_artifacts(video_path, temp_root)
 
         error_message = errors[0] if errors else "Gemini transcription failed"
         logger.warning("Gemini transcription fallback failed: %s", error_message)
@@ -866,6 +860,38 @@ class TranscriptActionWorkflow:
             "source": "gemini_video_failed",
             "error": error_message,
         }
+
+    @staticmethod
+    async def _cleanup_download_artifacts(
+        video_path: Path | None,
+        temp_root: Path | None,
+    ) -> None:
+        """Remove downloaded video artifacts without blocking the event loop.
+
+        The Gemini file fallback downloads a whole video into a temporary tree.
+        Because the format chain may fall back to separate video/audio streams,
+        that tree can hold the merged output plus unmerged ``.fNNN`` fragments,
+        so the removal is unbounded disk work. It therefore runs in a worker
+        thread using the same ``to_thread`` idiom as ``_download_video_file``.
+
+        The await is shielded because this runs from a ``finally`` block. The
+        previous inline implementation was synchronous and so uncancellable,
+        which meant cleanup always completed; an unshielded await would let a
+        cancellation delivered during the ``finally`` skip cleanup and leak the
+        tree. Shielding preserves that "always cleans up" property while still
+        yielding the loop, and still re-raises ``CancelledError`` to the caller.
+        """
+
+        def _cleanup() -> None:
+            if video_path is not None and video_path.exists():
+                try:
+                    video_path.unlink()
+                except OSError:
+                    pass
+            if temp_root is not None and temp_root.exists():
+                shutil.rmtree(temp_root, ignore_errors=True)
+
+        await asyncio.shield(asyncio.to_thread(_cleanup))
 
     async def _record_metric(
         self,

--- a/src/youtube_extension/services/workflows/transcript_action_workflow.py
+++ b/src/youtube_extension/services/workflows/transcript_action_workflow.py
@@ -880,15 +880,31 @@ class TranscriptActionWorkflow:
         cancellation delivered during the ``finally`` skip cleanup and leak the
         tree. Shielding preserves that "always cleans up" property while still
         yielding the loop, and still re-raises ``CancelledError`` to the caller.
+
+        ``CancelledError`` is deliberately allowed to propagate rather than
+        being suppressed in favour of any exception already in flight. Python
+        chains the in-flight exception onto it as ``__context__``, so no
+        diagnostic information is lost, whereas swallowing it would report a
+        cancelled task as ``cancelled() is False`` and defeat
+        ``asyncio.timeout``. The caller in ``_extract_transcript`` catches
+        ``Exception``, so a suppressed cancellation would be downgraded to a
+        per-source error and the pipeline would keep issuing network calls
+        after the request was abandoned.
         """
 
         def _cleanup() -> None:
-            if video_path is not None and video_path.exists():
+            # Both branches are total. This runs from a ``finally``, so raising
+            # here would replace whatever exception is already propagating.
+            # Note the absence of ``exists()`` probes: ``exists()`` performs a
+            # stat and can itself raise ``OSError``, which is exactly the
+            # masking this must avoid. ``unlink`` already raises
+            # ``FileNotFoundError`` for absent paths and ``rmtree`` is a no-op.
+            if video_path is not None:
                 try:
                     video_path.unlink()
                 except OSError:
                     pass
-            if temp_root is not None and temp_root.exists():
+            if temp_root is not None:
                 shutil.rmtree(temp_root, ignore_errors=True)
 
         await asyncio.shield(asyncio.to_thread(_cleanup))

--- a/src/youtube_extension/services/workflows/transcript_action_workflow.py
+++ b/src/youtube_extension/services/workflows/transcript_action_workflow.py
@@ -876,10 +876,15 @@ class TranscriptActionWorkflow:
 
         The await is shielded because this runs from a ``finally`` block. The
         previous inline implementation was synchronous and so uncancellable,
-        which meant cleanup always completed; an unshielded await would let a
-        cancellation delivered during the ``finally`` skip cleanup and leak the
-        tree. Shielding preserves that "always cleans up" property while still
+        which meant cleanup ran to completion once entered; an unshielded await
+        would let a cancellation delivered during the ``finally`` skip cleanup
+        and leak the tree. Shielding preserves that property while still
         yielding the loop, and still re-raises ``CancelledError`` to the caller.
+
+        The bound is process lifetime, not an absolute guarantee: cleanup
+        continues unless the process exits. A ``SIGKILL``, a hard crash, or
+        interpreter shutdown before the worker thread finishes still leaves the
+        tree behind, and nothing in this helper can prevent that.
 
         ``CancelledError`` is deliberately allowed to propagate rather than
         being suppressed in favour of any exception already in flight. Python

--- a/src/youtube_extension/services/workflows/transcript_action_workflow.py
+++ b/src/youtube_extension/services/workflows/transcript_action_workflow.py
@@ -895,17 +895,28 @@ class TranscriptActionWorkflow:
         def _cleanup() -> None:
             # Both branches are total. This runs from a ``finally``, so raising
             # here would replace whatever exception is already propagating.
+            #
             # Note the absence of ``exists()`` probes: ``exists()`` performs a
-            # stat and can itself raise ``OSError``, which is exactly the
-            # masking this must avoid. ``unlink`` already raises
-            # ``FileNotFoundError`` for absent paths and ``rmtree`` is a no-op.
+            # stat and can itself raise, which is exactly the masking this must
+            # avoid. ``unlink`` already raises ``FileNotFoundError`` for absent
+            # paths and ``rmtree`` tolerates them.
+            #
+            # The guards catch ``Exception``, not ``OSError``, because neither
+            # call is OSError-total. A path holding a NUL byte makes ``unlink``
+            # raise ``ValueError: embedded null character``, and makes
+            # ``rmtree`` raise the same from its internal ``lstat`` despite
+            # ``ignore_errors=True`` -- that flag only suppresses ``OSError``.
+            # ``CancelledError`` is a ``BaseException``, so it still propagates.
             if video_path is not None:
                 try:
                     video_path.unlink()
-                except OSError:
-                    pass
+                except Exception:  # noqa: BLE001 - must not mask in-flight error
+                    logger.debug("Cleanup failed for %s", video_path, exc_info=True)
             if temp_root is not None:
-                shutil.rmtree(temp_root, ignore_errors=True)
+                try:
+                    shutil.rmtree(temp_root, ignore_errors=True)
+                except Exception:  # noqa: BLE001 - must not mask in-flight error
+                    logger.debug("Cleanup failed for %s", temp_root, exc_info=True)
 
         await asyncio.shield(asyncio.to_thread(_cleanup))
 

--- a/tests/unit/test_transcript_action_workflow.py
+++ b/tests/unit/test_transcript_action_workflow.py
@@ -1384,3 +1384,27 @@ class TestCleanupDownloadArtifactsOffEventLoop:
         # The original exception survives; no OSError leaks out of cleanup.
         with pytest.raises(Boom, match="the real error"):
             await failing_operation()
+
+    async def test_cleanup_is_total_for_non_oserror_failures(self):
+        """A NUL byte in either path must not escape as ``ValueError``.
+
+        ``shutil.rmtree(..., ignore_errors=True)`` only suppresses ``OSError``:
+        a NUL byte makes its internal ``lstat`` raise ``ValueError``, and
+        ``Path.unlink`` raises the same directly. Because the helper runs from
+        a ``finally``, either escape would replace the in-flight exception --
+        the exact defect the removal of the ``exists()`` probes fixed. No
+        mocking is used, so this exercises the real stdlib behaviour.
+        """
+        nul_video = pathlib.Path("/tmp/eventrelay-nul\x00.mp4")
+        nul_root = pathlib.Path("/tmp/eventrelay-nul\x00-dir")
+
+        # Premise: the bare calls really are not OSError-total.
+        with pytest.raises(ValueError, match="null"):
+            nul_video.unlink()
+        with pytest.raises(ValueError, match="null"):
+            shutil.rmtree(nul_root, ignore_errors=True)
+
+        # Contract: the helper swallows both and returns normally.
+        await TranscriptActionWorkflow._cleanup_download_artifacts(
+            nul_video, nul_root
+        )

--- a/tests/unit/test_transcript_action_workflow.py
+++ b/tests/unit/test_transcript_action_workflow.py
@@ -1329,11 +1329,12 @@ class TestCleanupDownloadArtifactsOffEventLoop:
             TranscriptActionWorkflow._cleanup_download_artifacts(None, temp_root)
         )
 
-        for _ in range(500):
-            if started.is_set():
-                break
+        # Wall-clock deadline rather than a fixed iteration budget: a loaded
+        # CI runner can stretch each sleep well past 10ms.
+        deadline = time.monotonic() + 30.0
+        while not started.is_set():
+            assert time.monotonic() < deadline, "cleanup never started"
             await asyncio.sleep(0.01)
-        assert started.is_set(), "cleanup never started"
 
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
@@ -1344,3 +1345,42 @@ class TestCleanupDownloadArtifactsOffEventLoop:
 
         # Let the shielded inner task settle before the loop closes.
         await asyncio.sleep(0.1)
+
+    async def test_cleanup_does_not_mask_in_flight_exception(
+        self, monkeypatch, tmp_path
+    ):
+        """A cleanup failure must never replace the exception being propagated.
+
+        The helper runs from a ``finally``. If it raised, it would discard the
+        real error and report a spurious filesystem fault instead. Both removal
+        primitives are therefore total.
+        """
+
+        def exploding_unlink(self, *args, **kwargs):
+            raise PermissionError("read-only filesystem")
+
+        def exploding_stat(self, *args, **kwargs):
+            raise OSError("stat exploded")
+
+        monkeypatch.setattr(pathlib.Path, "unlink", exploding_unlink)
+        # ``Path.exists()`` is implemented via ``stat()``. Patching stat proves
+        # the helper never probes a path in a way that could itself raise.
+        # ``shutil.rmtree`` is left real: its ``ignore_errors=True`` is the
+        # documented mechanism that makes the directory removal total, so
+        # patching it away would test a guarantee the code never claimed.
+        monkeypatch.setattr(pathlib.Path, "stat", exploding_stat)
+
+        class Boom(Exception):
+            pass
+
+        async def failing_operation():
+            try:
+                raise Boom("the real error")
+            finally:
+                await TranscriptActionWorkflow._cleanup_download_artifacts(
+                    tmp_path / "video.mp4", tmp_path / "absent_tree"
+                )
+
+        # The original exception survives; no OSError leaks out of cleanup.
+        with pytest.raises(Boom, match="the real error"):
+            await failing_operation()

--- a/tests/unit/test_transcript_action_workflow.py
+++ b/tests/unit/test_transcript_action_workflow.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import datetime
+import pathlib
+import shutil
+import threading
+import time
 from dataclasses import asdict
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -1189,3 +1194,144 @@ class TestFallbackTranscriptWithGemini:
 
         assert result["text"] == "Gemini transcript"
         assert result["source"] == "gemini_video"
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_download_artifacts
+# ---------------------------------------------------------------------------
+
+class TestCleanupDownloadArtifactsOffEventLoop:
+    """The Gemini fallback must not delete downloaded video trees inline.
+
+    ``_fallback_transcript_with_gemini`` downloads a full video into a
+    temporary tree, so the ``finally`` cleanup is unbounded disk work. These
+    tests pin that work to a worker thread rather than the event loop.
+    """
+
+    async def test_cleanup_runs_off_event_loop(self, monkeypatch, tmp_path):
+        loop_thread = threading.get_ident()
+        seen: dict[str, int] = {}
+        calls = {"unlink": 0, "rmtree": 0}
+
+        real_unlink = pathlib.Path.unlink
+        real_rmtree = shutil.rmtree
+
+        def recording_unlink(self, *args, **kwargs):
+            seen["unlink"] = threading.get_ident()
+            calls["unlink"] += 1
+            return real_unlink(self, *args, **kwargs)
+
+        def recording_rmtree(path, *args, **kwargs):
+            seen["rmtree"] = threading.get_ident()
+            calls["rmtree"] += 1
+            return real_rmtree(path, *args, **kwargs)
+
+        monkeypatch.setattr(pathlib.Path, "unlink", recording_unlink)
+        monkeypatch.setattr(shutil, "rmtree", recording_rmtree)
+
+        temp_root = tmp_path / "gemini_video_abc"
+        temp_root.mkdir()
+        video_path = temp_root / "auJzb1D-fag.mp4"
+        video_path.write_bytes(b"video-bytes")
+
+        await TranscriptActionWorkflow._cleanup_download_artifacts(
+            video_path, temp_root
+        )
+
+        # Guard against a vacuous pass: both primitives must really have run.
+        assert calls == {"unlink": 1, "rmtree": 1}
+        assert seen["unlink"] != loop_thread
+        assert seen["rmtree"] != loop_thread
+
+    async def test_cleanup_does_not_block_event_loop(self, monkeypatch, tmp_path):
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_rmtree(path, *args, **kwargs):
+            started.set()
+            # Fail instead of hanging CI if the loop never gets to resume.
+            assert release.wait(timeout=10), "event loop blocked during cleanup"
+
+        monkeypatch.setattr(shutil, "rmtree", blocking_rmtree)
+
+        temp_root = tmp_path / "gemini_video_abc"
+        temp_root.mkdir()
+
+        cleanup = asyncio.create_task(
+            TranscriptActionWorkflow._cleanup_download_artifacts(None, temp_root)
+        )
+
+        for _ in range(500):
+            if started.is_set():
+                break
+            await asyncio.sleep(0.01)
+
+        # Reaching here while rmtree is still parked proves the loop kept
+        # running concurrently with the deletion.
+        assert started.is_set(), "cleanup never started"
+        assert not cleanup.done()
+
+        release.set()
+        await asyncio.wait_for(cleanup, timeout=10)
+
+    async def test_cleanup_removes_artifacts(self, tmp_path):
+        temp_root = tmp_path / "gemini_video_abc"
+        temp_root.mkdir()
+        video_path = temp_root / "auJzb1D-fag.mp4"
+        video_path.write_bytes(b"video-bytes")
+        fragment = temp_root / "auJzb1D-fag.f140.m4a"
+        fragment.write_bytes(b"audio-bytes")
+
+        await TranscriptActionWorkflow._cleanup_download_artifacts(
+            video_path, temp_root
+        )
+
+        assert not video_path.exists()
+        assert not fragment.exists()
+        assert not temp_root.exists()
+
+    async def test_cleanup_survives_missing_paths(self, tmp_path):
+        # Mirrors the pre-existing guards: absent artifacts are not an error.
+        await TranscriptActionWorkflow._cleanup_download_artifacts(
+            tmp_path / "gone.mp4", tmp_path / "gone_dir"
+        )
+        await TranscriptActionWorkflow._cleanup_download_artifacts(None, None)
+
+    async def test_cleanup_completes_when_task_cancelled(self, monkeypatch, tmp_path):
+        # The replaced inline code was synchronous and therefore uncancellable,
+        # so cleanup always ran. The shielded await must preserve that.
+        started = threading.Event()
+        finished = threading.Event()
+        real_rmtree = shutil.rmtree
+
+        def slow_rmtree(path, *args, **kwargs):
+            started.set()
+            time.sleep(0.3)
+            real_rmtree(path, *args, **kwargs)
+            finished.set()
+
+        monkeypatch.setattr(shutil, "rmtree", slow_rmtree)
+
+        temp_root = tmp_path / "gemini_video_abc"
+        temp_root.mkdir()
+        (temp_root / "auJzb1D-fag.mp4").write_bytes(b"video-bytes")
+
+        task = asyncio.create_task(
+            TranscriptActionWorkflow._cleanup_download_artifacts(None, temp_root)
+        )
+
+        for _ in range(500):
+            if started.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert started.is_set(), "cleanup never started"
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert finished.wait(timeout=10), "shielded cleanup did not finish"
+        assert not temp_root.exists()
+
+        # Let the shielded inner task settle before the loop closes.
+        await asyncio.sleep(0.1)

--- a/tests/unit/test_transcript_action_workflow.py
+++ b/tests/unit/test_transcript_action_workflow.py
@@ -1261,14 +1261,23 @@ class TestCleanupDownloadArtifactsOffEventLoop:
             TranscriptActionWorkflow._cleanup_download_artifacts(None, temp_root)
         )
 
-        for _ in range(500):
-            if started.is_set():
-                break
+        # Poll against a wall-clock deadline rather than a fixed iteration
+        # count: a loaded CI box may take a while to hand the cleanup closure a
+        # worker thread, and a fixed budget would fail for scheduling reasons
+        # rather than for the behaviour under test. The polling itself is the
+        # assertion -- each completed tick is one turn of the event loop taken
+        # while rmtree is parked -- so this cannot be replaced by a blocking
+        # wait without destroying what the test proves.
+        deadline = time.monotonic() + 30.0
+        ticks = 0
+        while not started.is_set():
+            assert time.monotonic() < deadline, "cleanup never started"
             await asyncio.sleep(0.01)
+            ticks += 1
 
         # Reaching here while rmtree is still parked proves the loop kept
         # running concurrently with the deletion.
-        assert started.is_set(), "cleanup never started"
+        assert ticks >= 1, "event loop never yielded while cleanup was running"
         assert not cleanup.done()
 
         release.set()


### PR DESCRIPTION
Head sha: `627ebe20ef504db3b760b4b8b03fc12657fe75cb`

## Canonical issue

Closes #1244.

`TranscriptActionWorkflow._fallback_transcript_with_gemini` performs its download
cleanup inline in a `finally` block. `Path.exists`, `Path.unlink` and
`shutil.rmtree` are blocking syscalls, so the entire deletion runs on the event
loop and stalls every other coroutine in the process for its duration.

```python
# before -- src/youtube_extension/services/workflows/transcript_action_workflow.py:851
finally:
    if video_path.exists():
        try:
            video_path.unlink()
        except OSError:
            pass
    if temp_root and temp_root.exists():
        shutil.rmtree(temp_root, ignore_errors=True)
```

The tree being removed is not small. `_download_video_file` requests
`best[ext=mp4]/bestvideo[ext=mp4]+bestaudio[ext=m4a]/best` with
`merge_output_format: mp4`, so at cleanup time it can hold the merged output
**plus** unmerged `.fNNN` fragments — potentially hundreds of megabytes spread
over several files, all unlinked while the loop is held.

## Outcome

| | |
|---|---|
| **Does** | Move the cleanup into `_cleanup_download_artifacts`, a static helper that runs the identical logic inside `asyncio.to_thread`, so the loop stays free while the filesystem work proceeds. |
| **Does** | Preserve which paths are removed and in what order. |
| **Does** | Make the helper *total*, so it can never replace an in-flight exception. It runs from a `finally`, so anything it raises would displace the exception already propagating. Two changes were needed, both found in review and both covered by regression tests. |
| **Does** | Drop the two `exists()` probes. `Path.exists()` is `stat()` under a filter that re-raises any errno outside ENOENT/ENOTDIR/EBADF/ELOOP, so the probe itself could raise from inside the `finally`. `unlink` already reports absent paths and `rmtree` already tolerates them, so the probes bought nothing and cost totality. |
| **Does** | Catch `Exception` rather than `OSError` in both guards, logging at `debug` with `exc_info`. Neither call is OSError-total: a NUL byte in a path makes `Path.unlink` raise `ValueError: embedded null character`, and makes `shutil.rmtree` raise the same from its internal `lstat` **despite `ignore_errors=True`** — that flag suppresses `OSError` alone. |
| **Does** | Wrap the await in `asyncio.shield` so cleanup still completes if the surrounding task is cancelled, matching the uncancellable behaviour of the code it replaces. |
| **Does not** | Change which paths are removed, in what order, or under what conditions. |
| **Does not** | Change any return value, raised exception, log line or metric. |
| **Does not** | Touch `_download_video_file`, which already does its own cleanup inside a worker thread. |
| **Does not** | Add a timeout, retry, or any new failure mode. |

### On removing the `exists()` guards

My first draft kept them, on the reasoning that dropping them is a behaviour change
rather than a performance change. Review showed that reasoning was wrong in one
specific way, and the correction is worth stating plainly.

The guards are not neutral inside a `finally`. `Path.exists()` calls `stat()` and
re-raises any errno outside the ignored set, so on a permission or I/O error the
probe raises *from the cleanup path* and replaces whatever exception was already
travelling. That is a correctness bug, and it was pre-existing — moving the block
off-loop neither introduced nor fixed it, but it sits inside the code this PR is
rewriting, so it is fixed here rather than left behind.

One real behaviour difference follows, and it is intentional: a **broken symlink**
reports `exists() is False` and survives today, but is now unlinked. That is the
correct outcome for a routine that exists to delete the download tree, and the
symlink lives inside `temp_root`, which `rmtree` removes moments later regardless.

`video_path` living *inside* `temp_root` still makes the explicit `unlink()`
redundant — `_download_video_file` builds it as `temp_dir / "%(id)s.%(ext)s"`. That
redundancy is **left exactly as it is**, since removing it is a behaviour change
with no performance benefit.

### Scope of the totality fix

The `Exception`-vs-`OSError` change is **contract correctness, not a live bug fix**.
No claim is made that a NUL-byte path reaches this helper in production today:
`temp_root` comes from `tempfile.mkdtemp(prefix="gemini_video_")`, and a NUL
`video_path` is rejected earlier by the `filename.exists()` guard in `_download`,
whose `except Exception` handler cleans up and re-raises. The code carried an inline
comment asserting both branches were total; that assertion was false, and it is the
kind of claim later changes get built on.

## Risk

**Low, with one deliberate design decision worth stating plainly.**

The one semantic difference between an inline call and an `await` is
cancellability. The code being replaced is straight-line synchronous, so once the
`finally` is entered the deletion *always* runs to completion. A bare
`await` in a `finally` does not have that property: if the task is cancelled a
second time — a client disconnect followed by a server shutdown, say — the await
raises immediately and the tree is never removed. That converts a loop stall into a
disk leak of a multi-hundred-megabyte video plus its temp tree, which is a strictly
worse failure than the one being fixed.

`asyncio.shield` restores the original guarantee: the worker keeps running to
completion while `CancelledError` still propagates to the caller. Stated precisely,
`shield` does not make cleanup unconditional — the accurate claim is that **cleanup
keeps running unless the process itself dies**, since a `SIGKILL` or interpreter exit
takes the worker thread with it. That is the same bound the current inline code has.
Because
`CancelledError` is a `BaseException`, the `except Exception` handler upstream at
line 336 does not swallow it, so cancellation semantics as seen by callers are
unchanged. On the normal path `shield` is behaviourally identical to a bare await.

Shielding is only safe if the shielded coroutine cannot itself hang or raise.
`_cleanup` is total: `unlink` is wrapped in `except OSError` and `rmtree` uses
`ignore_errors=True`, and it is a bounded filesystem walk. The two `.exists()`
guards the original code used were **removed rather than carried over**. Because
this runs from a `finally`, anything it raises replaces the exception already
propagating — and `Path.exists()` is not safe there: it performs a `stat`, and
CPython re-raises any `OSError` whose errno is outside
`ENOENT/ENOTDIR/EBADF/ELOOP`, so an `EIO` or `EACCES` would surface as a spurious
filesystem fault in place of the real error. The guards were redundant as well as
unsafe — `unlink` already raises `FileNotFoundError` for absent paths and `rmtree`
is a no-op — so dropping them makes this helper strictly safer than the inline code
it replaces. The residual cost is
that a cancellation during cleanup may leave a worker thread running briefly past the
caller's return, which can surface as a "Task was destroyed but it is pending" warning
at interpreter shutdown. That is cosmetic; this repository does not configure
`filterwarnings = error`, so it cannot fail a run.

No caller signature, return type or exception contract changes, so there is nothing for
callers to adapt to.

## Verification

```
.venv/bin/python -m pytest tests/unit/test_transcript_action_workflow.py \
  -p no:cacheprovider --no-cov -q
115 passed in 2.99s
```

108 of those existed before this change and still pass unmodified. Seven are new.

**The new tests were proved to fail against the previous behaviour.** Rather than
reverting the whole file — which would only produce an `AttributeError` on a
missing method and prove nothing about behaviour — the helper body was reduced to a
direct `_cleanup()` call, which is exactly the code path this PR replaces:

```
-        await asyncio.shield(asyncio.to_thread(_cleanup))
+        _cleanup()

3 failed, 4 passed
FAILED ...::test_cleanup_runs_off_event_loop
FAILED ...::test_cleanup_does_not_block_event_loop
FAILED ...::test_cleanup_completes_when_task_cancelled
```

The other four pass under both variants, which is correct — they assert filesystem
outcomes and totality, which off-loading does not affect.

The three failures are the three tests that assert the off-loop property. The three
that pass under both versions are the behaviour-preservation tests, which is the result they are
designed to produce — they exist to catch a semantic regression, so passing on both
sides is the signal, not a gap.

What each test pins down:

- `test_cleanup_runs_off_event_loop` — wraps `Path.unlink` and `shutil.rmtree`
  in recorders that capture `threading.get_ident()` and delegate to the real
  implementation, then asserts both idents differ from the loop thread. It first
  asserts a call count of exactly one each, so the test cannot pass vacuously by
  never reaching the instrumented calls.
- `test_cleanup_does_not_block_event_loop` — parks `rmtree` on an unset
  `threading.Event` and shows the loop still makes progress while it is parked,
  which is the property that distinguishes off-loop work from a fast on-loop delete.
  It polls against a `time.monotonic()` deadline rather than a fixed iteration count,
  so a loaded runner that is slow to hand `to_thread` a worker polls more times
  instead of failing, and it asserts the tick count directly. The polling is
  deliberate and is *not* replaced by a blocking wait on the `Event`: blocking the
  loop to prove the loop is not blocked would invert the test.
- `test_cleanup_removes_artifacts` — real files under `tmp_path`, including an
  `auJzb1D-fag.f140.m4a` fragment, asserting the video, the fragment and the
  directory are all gone.
- `test_cleanup_survives_missing_paths` — nonexistent paths and `(None, None)`
  must not raise.
- `test_cleanup_completes_when_task_cancelled` — the shield property: cancel mid
  cleanup, expect `CancelledError` at the caller, and assert the tree is still
  removed. Uses the same `time.monotonic()` deadline as the test above.
- `test_cleanup_does_not_mask_in_flight_exception` — patches `Path.stat` to raise
  and `Path.unlink` to raise `PermissionError`, then calls the helper from a
  `finally` while a different exception is propagating, asserting the original
  exception is what reaches the caller. `shutil.rmtree` is deliberately left
  unpatched: `ignore_errors=True` is the mechanism that makes directory removal
  total, so patching it away would test a guarantee the code never made.

That last test carries its own prove-fail. Restoring only the two `.exists()`
guards, with everything else untouched:

```
-            if video_path is not None:
+            if video_path is not None and video_path.exists():

test_cleanup_does_not_mask_in_flight_exception FAILED
E       OSError: stat exploded
1 failed, 5 passed
```

`OSError` had replaced the in-flight exception. The other five are unaffected,
which is correct — masking is orthogonal to off-loading.

The seventh test, `test_cleanup_is_total_for_non_oserror_failures`, covers the
`Exception`-vs-`OSError` guards. It uses **no mocking at all**: it passes real paths
containing a NUL byte and first asserts the premise against the bare stdlib calls,
so the test would start failing if CPython ever made these calls total.

```
with pytest.raises(ValueError, match="null"):
    nul_video.unlink()
with pytest.raises(ValueError, match="null"):
    shutil.rmtree(nul_root, ignore_errors=True)   # ignore_errors does NOT cover this

await TranscriptActionWorkflow._cleanup_download_artifacts(nul_video, nul_root)
```

Its prove-fail restores only the previous guards, everything else untouched:

```
-                except Exception:  # noqa: BLE001
-                    logger.debug(...)
+                except OSError:
+                    pass
-                try:
-                    shutil.rmtree(temp_root, ignore_errors=True)
-                except Exception: ...
+                shutil.rmtree(temp_root, ignore_errors=True)

test_cleanup_is_total_for_non_oserror_failures FAILED
E       ValueError: unlink: embedded null character in path
1 failed, 6 passed
```

After each prove-fail the file was restored from a pre-image and confirmed byte
identical with `diff`, plus `grep -c` on the three invariants
(`asyncio.shield(asyncio.to_thread(...))` = 1, `video_path.exists()` = 0,
`except OSError:` = 0).

Lint parity against `origin/main`, comparing the pristine file through stdin so the
working tree is never disturbed:

```
ruff check --stdin-filename $F - < (git show origin/main:$F)   # All checks passed!
ruff check $F                                                   # All checks passed!
diff before after                                               # PARITY OK (source and tests)
```

Wider sweep — `grep -rln --include="*.py" "transcript_action_workflow\|TranscriptActionWorkflow" tests/unit/`
returns one other file, `tests/unit/test_v1_router_extended.py`: **121 passed**
standalone. Running that file together with this one hits a collection error, and that
is **pre-existing**: checking out `origin/main`'s copy of the test file reproduces the
identical `ModuleNotFoundError` on line 19, an import this PR does not touch. It is an
instance of the known cross-module `sys.modules` interference in this suite, not a
regression introduced here.

## Production evidence

This path is reachable from two HTTP endpoints. Every hop below was confirmed at call
level, not merely by import graph:

```
POST /api/v1/transcript-action        router.py:456 (decorator) -> :462 run_transcript_action
POST /api/v1/videos/process           router.py:1489 (decorator) -> :1515 _run_video_job
   (router mounted in main.py:190-192)
  -> TranscriptActionWorkflow(...)              router.py:475   /  router.py:1532
  -> await workflow.run(...)                    router.py:500   /  router.py:1537
  -> TranscriptActionWorkflow.run               transcript_action_workflow.py:99
  -> await self._extract_transcript(...)        :132  -> def at :307
  -> await self._fallback_transcript_with_gemini  :335  -> def at :708
  -> finally: blocking filesystem calls         :851-858        <-- the defect
```

`transcript_action_workflow` is imported at `router.py:49`, the only import site in
`src/`, so this is the whole production surface.

Honest framing of the magnitude: this is best described as **a moderate improvement to
responsiveness on the Gemini file-fallback path, not a general performance
improvement**. It is narrower than the subprocess offload in #1240 because it only
triggers on the Gemini video fallback rather than on every request, and a delete on
warm cache is fast. Nothing here makes the endpoint itself faster — the request does
the same work in the same order and returns at the same time. What changes is that
*other* coroutines are no longer held hostage while it happens. It matters because the
fallback is exactly the slow, large-file path — it only runs after a full video
download — so the tree being removed is at its largest precisely when this code runs,
and the loop is held for all of it.


