### PR TITLE
perf: offload transcript download cleanup to a worker thread

### DIFF
--- a/src/youtube_extension/services/workflows/transcript_action_workflow.py
+++ b/src/youtube_extension/services/workflows/transcript_action_workflow.py
@@ -849,13 +849,7 @@ class TranscriptActionWorkflow:
                 if file_result.error:
                     errors.append(file_result.error)
             finally:
-                if video_path.exists():
-                    try:
-                        video_path.unlink()
-                    except OSError:
-                        pass
-                if temp_root and temp_root.exists():
-                    shutil.rmtree(temp_root, ignore_errors=True)
+                await self._cleanup_download_artifacts(video_path, temp_root)
 
         error_message = errors[0] if errors else "Gemini transcription failed"
         logger.warning("Gemini transcription fallback failed: %s", error_message)
@@ -866,6 +860,38 @@ class TranscriptActionWorkflow:
             "source": "gemini_video_failed",
             "error": error_message,
         }
+
+    @staticmethod
+    async def _cleanup_download_artifacts(
+        video_path: Path | None,
+        temp_root: Path | None,
+    ) -> None:
+        """Remove downloaded video artifacts without blocking the event loop.
+
+        The Gemini file fallback downloads a whole video into a temporary tree.
+        Because the format chain may fall back to separate video/audio streams,
+        that tree can hold the merged output plus unmerged ``.fNNN`` fragments,
+        so the removal is unbounded disk work. It therefore runs in a worker
+        thread using the same ``to_thread`` idiom as ``_download_video_file``.
+
+        The await is shielded because this runs from a ``finally`` block. The
+        previous inline implementation was synchronous and so uncancellable,
+        which meant cleanup always completed; an unshielded await would let a
+        cancellation delivered during the ``finally`` skip cleanup and leak the
+        tree. Shielding preserves that "always cleans up" property while still
+        yielding the loop, and still re-raises ``CancelledError`` to the caller.
+        """
+
+        def _cleanup() -> None:
+            if video_path is not None and video_path.exists():
+                try:
+                    video_path.unlink()
+                except OSError:
+                    pass
+            if temp_root is not None and temp_root.exists():
+                shutil.rmtree(temp_root, ignore_errors=True)
+
+        await asyncio.shield(asyncio.to_thread(_cleanup))
 
     async def _record_metric(
         self,

--- a/tests/unit/test_transcript_action_workflow.py
+++ b/tests/unit/test_transcript_action_workflow.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import datetime
+import pathlib
+import shutil
+import threading
+import time
 from dataclasses import asdict
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -1189,3 +1194,144 @@ class TestFallbackTranscriptWithGemini:
 
         assert result["text"] == "Gemini transcript"
         assert result["source"] == "gemini_video"
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_download_artifacts
+# ---------------------------------------------------------------------------
+
+class TestCleanupDownloadArtifactsOffEventLoop:
+    """The Gemini fallback must not delete downloaded video trees inline.
+
+    ``_fallback_transcript_with_gemini`` downloads a full video into a
+    temporary tree, so the ``finally`` cleanup is unbounded disk work. These
+    tests pin that work to a worker thread rather than the event loop.
+    """
+
+    async def test_cleanup_runs_off_event_loop(self, monkeypatch, tmp_path):
+        loop_thread = threading.get_ident()
+        seen: dict[str, int] = {}
+        calls = {"unlink": 0, "rmtree": 0}
+
+        real_unlink = pathlib.Path.unlink
+        real_rmtree = shutil.rmtree
+
+        def recording_unlink(self, *args, **kwargs):
+            seen["unlink"] = threading.get_ident()
+            calls["unlink"] += 1
+            return real_unlink(self, *args, **kwargs)
+
+        def recording_rmtree(path, *args, **kwargs):
+            seen["rmtree"] = threading.get_ident()
+            calls["rmtree"] += 1
+            return real_rmtree(path, *args, **kwargs)
+
+        monkeypatch.setattr(pathlib.Path, "unlink", recording_unlink)
+        monkeypatch.setattr(shutil, "rmtree", recording_rmtree)
+
+        temp_root = tmp_path / "gemini_video_abc"
+        temp_root.mkdir()
+        video_path = temp_root / "auJzb1D-fag.mp4"
+        video_path.write_bytes(b"video-bytes")
+
+        await TranscriptActionWorkflow._cleanup_download_artifacts(
+            video_path, temp_root
+        )
+
+        # Guard against a vacuous pass: both primitives must really have run.
+        assert calls == {"unlink": 1, "rmtree": 1}
+        assert seen["unlink"] != loop_thread
+        assert seen["rmtree"] != loop_thread
+
+    async def test_cleanup_does_not_block_event_loop(self, monkeypatch, tmp_path):
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_rmtree(path, *args, **kwargs):
+            started.set()
+            # Fail instead of hanging CI if the loop never gets to resume.
+            assert release.wait(timeout=10), "event loop blocked during cleanup"
+
+        monkeypatch.setattr(shutil, "rmtree", blocking_rmtree)
+
+        temp_root = tmp_path / "gemini_video_abc"
+        temp_root.mkdir()
+
+        cleanup = asyncio.create_task(
+            TranscriptActionWorkflow._cleanup_download_artifacts(None, temp_root)
+        )
+
+        for _ in range(500):
+            if started.is_set():
+                break
+            await asyncio.sleep(0.01)
+
+        # Reaching here while rmtree is still parked proves the loop kept
+        # running concurrently with the deletion.
+        assert started.is_set(), "cleanup never started"
+        assert not cleanup.done()
+
+        release.set()
+        await asyncio.wait_for(cleanup, timeout=10)
+
+    async def test_cleanup_removes_artifacts(self, tmp_path):
+        temp_root = tmp_path / "gemini_video_abc"
+        temp_root.mkdir()
+        video_path = temp_root / "auJzb1D-fag.mp4"
+        video_path.write_bytes(b"video-bytes")
+        fragment = temp_root / "auJzb1D-fag.f140.m4a"
+        fragment.write_bytes(b"audio-bytes")
+
+        await TranscriptActionWorkflow._cleanup_download_artifacts(
+            video_path, temp_root
+        )
+
+        assert not video_path.exists()
+        assert not fragment.exists()
+        assert not temp_root.exists()
+
+    async def test_cleanup_survives_missing_paths(self, tmp_path):
+        # Mirrors the pre-existing guards: absent artifacts are not an error.
+        await TranscriptActionWorkflow._cleanup_download_artifacts(
+            tmp_path / "gone.mp4", tmp_path / "gone_dir"
+        )
+        await TranscriptActionWorkflow._cleanup_download_artifacts(None, None)
+
+    async def test_cleanup_completes_when_task_cancelled(self, monkeypatch, tmp_path):
+        # The replaced inline code was synchronous and therefore uncancellable,
+        # so cleanup always ran. The shielded await must preserve that.
+        started = threading.Event()
+        finished = threading.Event()
+        real_rmtree = shutil.rmtree
+
+        def slow_rmtree(path, *args, **kwargs):
+            started.set()
+            time.sleep(0.3)
+            real_rmtree(path, *args, **kwargs)
+            finished.set()
+
+        monkeypatch.setattr(shutil, "rmtree", slow_rmtree)
+
+        temp_root = tmp_path / "gemini_video_abc"
+        temp_root.mkdir()
+        (temp_root / "auJzb1D-fag.mp4").write_bytes(b"video-bytes")
+
+        task = asyncio.create_task(
+            TranscriptActionWorkflow._cleanup_download_artifacts(None, temp_root)
+        )
+
+        for _ in range(500):
+            if started.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert started.is_set(), "cleanup never started"
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert finished.wait(timeout=10), "shielded cleanup did not finish"
+        assert not temp_root.exists()
+
+        # Let the shielded inner task settle before the loop closes.
+        await asyncio.sleep(0.1)


### PR DESCRIPTION
## Canonical issue

Closes # <!-- no dedicated issue; continues the event-loop-hygiene perf series (#1228, #1233, #1240) -->

## Outcome

The Gemini video transcription fallback no longer stalls the asyncio event loop while it deletes downloaded artifacts. Every request that reaches `_fallback_transcript_with_gemini` previously ran `Path.exists` / `Path.unlink` / `shutil.rmtree` — all blocking syscalls — inline in a `finally` block, over a temp tree that can hold a merged mp4 plus unmerged `.fNNN` fragments. That unbounded disk work now runs in a worker thread.

## Scope

- Included:
  - `src/youtube_extension/services/workflows/transcript_action_workflow.py` — extract inline cleanup into a static `_cleanup_download_artifacts` helper that runs under `asyncio.to_thread`, wrapped in `asyncio.shield`.
  - `tests/unit/test_transcript_action_workflow.py` — new `TestCleanupDownloadArtifactsOffEventLoop` coverage.
- Explicitly excluded: no change to request values, transcription behavior, or the format-selection chain.

## Risk

- Risk level: low
- Failure mode: a cancellation delivered during the `finally` could previously skip an unshielded await and leak the temp tree; `asyncio.shield` preserves the original "always cleans up" property while still yielding the loop and re-raising `CancelledError`.
- Rollback: revert this commit; the prior inline synchronous cleanup is restored verbatim (guards, `except OSError`, `ignore_errors=True` are unchanged).

## Verification

- [x] Focused logic verification — the extracted helper was exercised standalone in the sandbox: it removes the video + fragments + temp root, tolerates `None`/missing paths, and runs `rmtree` on a non-event-loop thread. The committed `pytest` suite (`TestCleanupDownloadArtifactsOffEventLoop`) asserts the same via `monkeypatch`, including a non-vacuous guard that both primitives actually ran and a concurrency test proving the loop keeps running during deletion.
- [ ] Required CI — could not run the full `pytest` suite in the sandbox (backend runtime deps such as `httpx`/`pydantic` are not installed); relying on repo CI on the current head.
- [ ] Review threads resolved

## Production evidence

Python-only change to backend workflow cleanup; not exercised by the Next.js Vercel preview. Behavior is identical to the prior synchronous path apart from where the deletion runs, so no new runtime surface is introduced.

## Agent handoff

- [ ] One canonical issue is linked — none exists yet; this is a perf follow-up in the event-loop-hygiene series.
- [x] No competing PR implements the same change
- [x] Acceptance criteria are satisfied (cleanup off the event loop, semantics preserved)
- [ ] Required checks pass on the current head — pending CI
- [x] Human decision is requested for final review / provenance finalization

## Agent provenance

Underlying commit is human-authored (`Hayden`, co-authored by Copilot App); provenance/agent-lock finalization is left to the maintainer. Kept as **draft** pending CI and human review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5WpNcNKibwFpNHEVSFnht)_