### PR TITLE
fix(transcript): preserve process_video error over cleanup cancellation (for #1245)

### DIFF
--- a/src/youtube_extension/services/workflows/transcript_action_workflow.py
+++ b/src/youtube_extension/services/workflows/transcript_action_workflow.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import logging
 import shutil
+import sys
 import tempfile
 from dataclasses import asdict
 from pathlib import Path
@@ -849,7 +850,23 @@ class TranscriptActionWorkflow:
                 if file_result.error:
                     errors.append(file_result.error)
             finally:
-                await self._cleanup_download_artifacts(video_path, temp_root)
+                # Preserve exception precedence across the cleanup await. Cleanup
+                # is shielded and still runs to completion, but the await it adds
+                # is a cancellation point the previous inline (synchronous)
+                # cleanup did not have. Per ``finally`` semantics a
+                # ``CancelledError`` raised here would replace an exception
+                # already unwinding from the ``try`` body, turning a
+                # ``process_video`` error that the caller's ``except Exception``
+                # handles into an uncaught ``BaseException``. Capture any
+                # in-flight exception before the await and, if one exists, keep
+                # it primary; only let a cancellation propagate when it is not
+                # masking one.
+                pending_exc = sys.exc_info()[1]
+                try:
+                    await self._cleanup_download_artifacts(video_path, temp_root)
+                except asyncio.CancelledError:
+                    if pending_exc is None:
+                        raise
 
         error_message = errors[0] if errors else "Gemini transcription failed"
         logger.warning("Gemini transcription fallback failed: %s", error_message)

--- a/tests/unit/test_transcript_action_workflow.py
+++ b/tests/unit/test_transcript_action_workflow.py
@@ -1344,3 +1344,80 @@ class TestCleanupDownloadArtifactsOffEventLoop:
 
         # Let the shielded inner task settle before the loop closes.
         await asyncio.sleep(0.1)
+
+    async def test_fallback_finally_keeps_process_video_error_over_cancellation(
+        self, monkeypatch, tmp_path
+    ):
+        """A cancellation during cleanup must not mask a ``process_video`` error.
+
+        The cleanup ``await`` in ``_fallback_transcript_with_gemini``'s ``finally``
+        is a cancellation point the previous synchronous cleanup did not have. If
+        ``process_video`` raises and the task is cancelled while cleanup is still
+        running, ``finally`` semantics would let ``CancelledError`` replace the
+        original error — turning an exception the caller's ``except Exception``
+        handles into an uncaught ``BaseException``. This pins the original
+        exception as primary while cleanup still completes.
+        """
+        gemini_service = MagicMock()
+        gemini_service.is_available.return_value = True
+        gemini_service.select_model = MagicMock()
+        # process_youtube fails cleanly so control falls through to the download
+        # path; error is None so no transient retry fires.
+        gemini_service.process_youtube = AsyncMock(
+            return_value=SimpleNamespace(
+                success=False, response=None, error=None, latency=0.0
+            )
+        )
+        original_error = ValueError("boom from process_video")
+        gemini_service.process_video = AsyncMock(side_effect=original_error)
+
+        hybrid = MagicMock()
+        hybrid.gemini = gemini_service
+        wf = _make_workflow(hybrid_processor=hybrid)
+
+        temp_root = tmp_path / "gemini_video_abc"
+        temp_root.mkdir()
+        video_file = temp_root / "auJzb1D-fag.mp4"
+        video_file.write_bytes(b"video-bytes")
+        wf._download_video_file = AsyncMock(return_value=(video_file, temp_root))
+
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        real_rmtree = shutil.rmtree
+
+        def blocking_rmtree(path, *args, **kwargs):
+            started.set()
+            assert release.wait(timeout=10), "cleanup was never released"
+            real_rmtree(path, *args, **kwargs)
+            finished.set()
+
+        monkeypatch.setattr(shutil, "rmtree", blocking_rmtree)
+
+        task = asyncio.create_task(
+            wf._fallback_transcript_with_gemini(
+                "https://www.youtube.com/watch?v=auJzb1D-fag",
+                language="en",
+                video_metadata=None,
+            )
+        )
+
+        deadline = time.monotonic() + 30.0
+        while not started.is_set():
+            assert time.monotonic() < deadline, "cleanup never started"
+            await asyncio.sleep(0.01)
+
+        # Cancel while cleanup is parked, then let cleanup finish.
+        task.cancel()
+        release.set()
+
+        # The original process_video error wins, not CancelledError.
+        with pytest.raises(ValueError) as excinfo:
+            await task
+        assert excinfo.value is original_error
+
+        # Cleanup still ran to completion despite the cancellation.
+        assert finished.wait(timeout=10), "shielded cleanup did not finish"
+        assert not temp_root.exists()
+
+        await asyncio.sleep(0.1)


### PR DESCRIPTION
## Canonical issue

No competing issue claimed. **#1245** remains the canonical PR for #1244; this PR targets **#1245's own branch** (`perf/transcript-cleanup-off-loop`) so its diff is exactly the single follow-up fix commit, which #1245 can absorb by merging this. It does **not** open a second PR against `main` for #1244.

## Outcome

Resolves the one confirmed HIGH review finding holding #1245: the worker-thread cleanup offload changed exception precedence under cancellation. This restores the documented "raised-exception behaviour does not change" contract so a recoverable per-source transcript failure is still caught by the caller instead of escaping as an uncaught cancellation.

## Scope

- Included:
  - `transcript_action_workflow.py` — the `finally` in `_fallback_transcript_with_gemini` now captures any in-flight exception via `sys.exc_info()` before the cleanup `await` and suppresses a cleanup-time `CancelledError` **only** when an exception is already unwinding; adds `import sys`.
  - One regression test that drives the real fallback `finally` (process_video raises, task cancelled mid-cleanup) and asserts the original `ValueError` — not `CancelledError` — surfaces while the temp tree is still removed.
- Explicitly excluded:
  - No change to `_cleanup_download_artifacts`, the shield, or which paths are removed — cleanup still runs to completion and still re-raises `CancelledError` on the normal (no-exception) path.

## Risk

- Risk level: low
- Failure mode: narrow — requires both a `process_video` raise **and** a cancellation delivered during cleanup. Fix is a targeted precedence guard at the call site; shield semantics are untouched.
- Rollback: revert this commit; #1245 returns to its prior (flagged) state.

## Verification

Tied to head `ff19580`.

- [x] Focused tests — `pytest tests/unit/test_transcript_action_workflow.py` → **114 passed**
- [x] Control experiment — reverting the guard to the pre-fix bare `await` makes the new test fail with `asyncio.CancelledError` (proving it catches the exact bug); restored
- [x] `ruff check` on both changed files → All checks passed
- [ ] Required CI — will run on push
- [ ] Review threads resolved — defer to #1245's threads

## Production evidence

No runtime surface change; the fix only alters which exception propagates on the cancellation-during-cleanup edge. Behaviour is pinned by the new async regression test rather than a deployment.

## Agent handoff

- [x] One canonical issue is linked (#1244 via #1245; this PR claims none)
- [x] No competing PR implements the same issue — targets #1245's branch, not `main`
- [x] Acceptance criteria are satisfied (finding resolved + regression test)
- [ ] Required checks pass on the current head — pending CI
- [x] Human decision requested only for merge approval

## Agent provenance

Human-authored sections may be trimmed by the owner. This is an agent-authored follow-up; the authoritative scope and canonical issue live in #1245 / #1244.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUEMeY1ZBRmF5jXrRYPre2)_