### PR TITLE
perf: invalidate Redis tags concurrently instead of serially

### DIFF
--- a/src/youtube_extension/backend/services/intelligent_cache.py
+++ b/src/youtube_extension/backend/services/intelligent_cache.py
@@ -513,12 +513,20 @@ class RedisCacheLayer(IntelligentCacheLayer):
                 semaphore = self._get_tag_write_semaphore()
 
                 async def _invalidate_tag(tag: str) -> int:
-                    # One permit covers both commands for a tag rather than one
-                    # each. The delete operates on the members smembers just
-                    # returned, so the pair is causally ordered and cannot be
-                    # interleaved; holding the permit across both keeps the
-                    # number of concurrently held pool connections equal to the
-                    # permit count instead of twice it.
+                    # One permit is held for the whole smembers->delete pair
+                    # rather than re-acquired per command. This bounds the
+                    # number of tag invalidations in progress at once to the
+                    # permit count and keeps each tag's causally-ordered pair
+                    # (delete operates on the members smembers just returned) as
+                    # one indivisible unit of scheduled work.
+                    #
+                    # It does NOT lower peak pool-connection usage: redis.asyncio
+                    # checks a connection out only for the duration of each
+                    # command and returns it to the pool between the two awaits,
+                    # so acquiring the permit per command would cap in-flight
+                    # commands at the same limit. The reason to hold across the
+                    # pair is scheduling determinism and avoiding permit churn,
+                    # not preventing a doubling of held connections.
                     async with semaphore:
                         keys = await conn.smembers(f"uvai:tag:{tag}")
 

--- a/src/youtube_extension/backend/services/intelligent_cache.py
+++ b/src/youtube_extension/backend/services/intelligent_cache.py
@@ -286,7 +286,12 @@ class RedisCacheLayer(IntelligentCacheLayer):
         self._tag_write_semaphore_loop: Optional[asyncio.AbstractEventLoop] = None
 
     def _get_tag_write_semaphore(self) -> asyncio.Semaphore:
-        """Semaphore shared by every ``set()`` call on this layer.
+        """Semaphore shared by every tag fan-out on this layer.
+
+        Two paths acquire it: ``set()``, which issues one ``sadd`` per tag, and
+        ``invalidate_by_tags()``, which issues an ``smembers``/``delete`` pair
+        per tag. Both draw from the same budget, so a ``set()`` storm and an
+        invalidation storm cannot each claim ``_tag_write_limit`` connections.
 
         The limiter has to be per-instance rather than per-call: all callers
         share ``self.redis_pool``, so a per-call semaphore would let N
@@ -310,11 +315,12 @@ class RedisCacheLayer(IntelligentCacheLayer):
         ``redis.asyncio`` pool caches connections whose transports are bound to
         the loop that opened them, so a ``RedisCacheLayer`` is already
         event-loop-affine through ``self.redis_pool`` -- and that affinity
-        applies equally to ``get()``, ``delete()``, ``clear()`` and
-        ``invalidate_by_tags()``, none of which this limiter touches. Enforcing
-        a loop-ownership contract is a layer-wide concern tracked in #1162;
-        guarding only this one path would give a misleading partial guarantee.
-        Use one layer per event loop.
+        applies equally to ``get()``, ``delete()`` and ``clear()``, none of
+        which this limiter touches -- and to the two paths that do acquire it,
+        since bounding fan-out is not the same guarantee as owning a loop.
+        Enforcing a loop-ownership contract is a layer-wide concern tracked in
+        #1162; guarding only these paths would give a misleading partial
+        guarantee. Use one layer per event loop.
         """
         loop = asyncio.get_running_loop()
 
@@ -504,19 +510,42 @@ class RedisCacheLayer(IntelligentCacheLayer):
 
         try:
             async with redis.Redis(connection_pool=self.redis_pool) as conn:
-                total_deleted = 0
+                semaphore = self._get_tag_write_semaphore()
 
-                for tag in tags:
-                    # Get all keys with this tag
-                    keys = await conn.smembers(f"uvai:tag:{tag}")
+                async def _invalidate_tag(tag: str) -> int:
+                    # One permit covers both commands for a tag rather than one
+                    # each. The delete operates on the members smembers just
+                    # returned, so the pair is causally ordered and cannot be
+                    # interleaved; holding the permit across both keeps the
+                    # number of concurrently held pool connections equal to the
+                    # permit count instead of twice it.
+                    async with semaphore:
+                        keys = await conn.smembers(f"uvai:tag:{tag}")
 
-                    if keys:
+                        if not keys:
+                            return 0
+
                         # Delete cache entries
                         cache_keys = [f"uvai:cache:{key.decode()}" if isinstance(key, bytes) else f"uvai:cache:{key}" for key in keys]
                         stat_keys = [f"uvai:stats:{key.decode()}" if isinstance(key, bytes) else f"uvai:stats:{key}" for key in keys]
 
-                        deleted = await conn.delete(*(cache_keys + stat_keys + [f"uvai:tag:{tag}"]))
-                        total_deleted += deleted
+                        return await conn.delete(*(cache_keys + stat_keys + [f"uvai:tag:{tag}"]))
+
+                # return_exceptions=True so that one failing tag cannot leave
+                # sibling tasks still in flight once this method returns, which
+                # would let them touch conn after the enclosing async with has
+                # closed it. The first failure is re-raised below so the
+                # existing handler still reports 0.
+                results = await asyncio.gather(
+                    *(_invalidate_tag(tag) for tag in tags),
+                    return_exceptions=True,
+                )
+
+                total_deleted = 0
+                for result in results:
+                    if isinstance(result, BaseException):
+                        raise result
+                    total_deleted += result
 
                 logger.info(f"L2 Redis TAG INVALIDATION: {total_deleted} entries for tags {tags}")
                 return total_deleted

--- a/src/youtube_extension/backend/services/intelligent_cache.py
+++ b/src/youtube_extension/backend/services/intelligent_cache.py
@@ -518,7 +518,8 @@ class RedisCacheLayer(IntelligentCacheLayer):
                     # number of tag invalidations in progress at once to the
                     # permit count and keeps each tag's causally-ordered pair
                     # (delete operates on the members smembers just returned) as
-                    # one indivisible unit of scheduled work.
+                    # one indivisible unit of scheduled work. It also bounds how
+                    # many tags can sit half-invalidated if a delete fails.
                     #
                     # It does NOT lower peak pool-connection usage: redis.asyncio
                     # checks a connection out only for the duration of each

--- a/tests/unit/test_intelligent_cache.py
+++ b/tests/unit/test_intelligent_cache.py
@@ -1651,11 +1651,14 @@ class TestRedisCacheLayerInvalidateByTags:
         assert peak <= layer._tag_write_limit
 
     async def test_invalidate_holds_one_permit_across_both_commands(self):
-        """smembers and delete for a tag must not be split across permits.
+        """smembers and delete for a tag are scheduled under one permit.
 
-        The delete operates on the members smembers just returned, so a permit
-        that is released between them would let the number of concurrently held
-        pool connections reach twice the budget.
+        Holding the permit across the pair keeps each tag's invalidation as one
+        indivisible unit of scheduled work, so with a single permit the pairs
+        run to completion without interleaving. (This does not change peak pool
+        usage -- redis.asyncio returns a connection to the pool between the two
+        awaits -- it pins the per-tag scheduling policy so a later refactor
+        cannot silently split the pair.)
         """
         layer = self._connected_layer()
         layer._tag_write_limit = 1
@@ -1686,6 +1689,61 @@ class TestRedisCacheLayerInvalidateByTags:
             ("smembers", "uvai:tag:tag2"),
             ("delete", "uvai:tag:tag2"),
         ]
+
+    async def test_invalidate_starts_no_command_after_context_exit_on_cancel(self):
+        """A cancelled invalidate issues no Redis command after conn closes.
+
+        Regression guard for the cancellation-parity claim: if the task running
+        invalidate_by_tags() is cancelled while a child is blocked in smembers,
+        gather cancels the children and CancelledError unwinds out through the
+        ``async with redis.Redis(...)`` context manager. A cancelled child may
+        still run its ``finally`` (releasing the semaphore), but it must never
+        start a new command on the connection once __aexit__ has closed it.
+        """
+        layer = self._connected_layer()
+        layer._tag_write_limit = 2
+        conn = _make_redis_conn()
+
+        events: list[tuple[str, object]] = []
+        first_smembers = asyncio.Event()
+
+        async def _blocking_smembers(name, *_args, **_kwargs):
+            events.append(("smembers_start", name))
+            first_smembers.set()
+            await asyncio.sleep(3600)  # block until cancelled
+            events.append(("smembers_end", name))  # unreachable once cancelled
+            return set()
+
+        async def _delete(*args, **_kwargs):
+            events.append(("delete_start", args[-1]))
+            return 1
+
+        conn.smembers = AsyncMock(side_effect=_blocking_smembers)
+        conn.delete = AsyncMock(side_effect=_delete)
+
+        original_aexit = conn.__aexit__
+
+        async def _tracking_aexit(*args, **kwargs):
+            events.append(("aexit", None))
+            return await original_aexit(*args, **kwargs)
+
+        conn.__aexit__ = AsyncMock(side_effect=_tracking_aexit)
+
+        with _patch_redis(conn):
+            task = asyncio.ensure_future(layer.invalidate_by_tags(["t1", "t2"]))
+            await first_smembers.wait()  # a child is now mid-smembers
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        # The connection context manager exited, and nothing issued a command
+        # after it did.
+        assert ("aexit", None) in events
+        aexit_index = events.index(("aexit", None))
+        after_exit = events[aexit_index + 1 :]
+        assert not any(
+            kind in ("smembers_start", "delete_start") for kind, _ in after_exit
+        )
 
     async def test_invalidate_failure_drains_in_flight_work(self):
         """A failing tag returns 0 with no per-tag task left in flight."""

--- a/tests/unit/test_intelligent_cache.py
+++ b/tests/unit/test_intelligent_cache.py
@@ -1690,60 +1690,77 @@ class TestRedisCacheLayerInvalidateByTags:
             ("delete", "uvai:tag:tag2"),
         ]
 
-    async def test_invalidate_starts_no_command_after_context_exit_on_cancel(self):
-        """A cancelled invalidate issues no Redis command after conn closes.
+    async def test_invalidate_cancellation_drains_before_conn_closes(self):
+        """Cancellation must unwind every child before the connection closes.
 
-        Regression guard for the cancellation-parity claim: if the task running
-        invalidate_by_tags() is cancelled while a child is blocked in smembers,
-        gather cancels the children and CancelledError unwinds out through the
-        ``async with redis.Redis(...)`` context manager. A cancelled child may
-        still run its ``finally`` (releasing the semaphore), but it must never
-        start a new command on the connection once __aexit__ has closed it.
+        This is the explicit cancellation-parity claim: gather() does not
+        complete its outer future until every cancelled child has finished, so
+        the enclosing ``async with redis.Redis(...)`` cannot close ``conn``
+        while a child could still issue a command on it.
         """
         layer = self._connected_layer()
-        layer._tag_write_limit = 2
+        layer._tag_write_limit = 4
         conn = _make_redis_conn()
 
-        events: list[tuple[str, object]] = []
-        first_smembers = asyncio.Event()
+        events: list[tuple] = []
+        all_blocked = asyncio.Event()
+        entered = 0
 
         async def _blocking_smembers(name, *_args, **_kwargs):
-            events.append(("smembers_start", name))
-            first_smembers.set()
-            await asyncio.sleep(3600)  # block until cancelled
-            events.append(("smembers_end", name))  # unreachable once cancelled
-            return set()
+            nonlocal entered
+            events.append(("cmd", "smembers", name))
+            entered += 1
+            if entered == 3:
+                all_blocked.set()
+            try:
+                await asyncio.sleep(3600)
+                return {b"key1"}
+            finally:
+                events.append(("unwind", name))
 
         async def _delete(*args, **_kwargs):
-            events.append(("delete_start", args[-1]))
+            events.append(("cmd", "delete", args[-1]))
             return 1
+
+        async def _aexit(*_args, **_kwargs):
+            events.append(("aexit",))
+            return False
 
         conn.smembers = AsyncMock(side_effect=_blocking_smembers)
         conn.delete = AsyncMock(side_effect=_delete)
-
-        original_aexit = conn.__aexit__
-
-        async def _tracking_aexit(*args, **kwargs):
-            events.append(("aexit", None))
-            return await original_aexit(*args, **kwargs)
-
-        conn.__aexit__ = AsyncMock(side_effect=_tracking_aexit)
+        conn.__aexit__ = AsyncMock(side_effect=_aexit)
 
         with _patch_redis(conn):
-            task = asyncio.ensure_future(layer.invalidate_by_tags(["t1", "t2"]))
-            await first_smembers.wait()  # a child is now mid-smembers
+            task = asyncio.create_task(layer.invalidate_by_tags(["t1", "t2", "t3"]))
+            try:
+                await asyncio.wait_for(all_blocked.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                task.cancel()
+                try:
+                    await task
+                except BaseException:
+                    pass
+                pytest.fail(
+                    f"tags were not issued concurrently; only {entered} in flight"
+                )
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await task
 
-        # The connection context manager exited, and nothing issued a command
-        # after it did.
-        assert ("aexit", None) in events
-        aexit_index = events.index(("aexit", None))
-        after_exit = events[aexit_index + 1 :]
-        assert not any(
-            kind in ("smembers_start", "delete_start") for kind, _ in after_exit
-        )
+        kinds = [e[0] for e in events]
+        assert "aexit" in kinds, f"connection never closed: {events}"
+        aexit_idx = kinds.index("aexit")
+
+        # Every child finished its finally path before the connection closed.
+        assert kinds.count("unwind") == 3, f"not all children unwound: {events}"
+        assert all(
+            i < aexit_idx for i, e in enumerate(events) if e[0] == "unwind"
+        ), f"a child unwound after conn close: {events}"
+
+        # No Redis command was issued after the connection closed.
+        assert all(
+            i < aexit_idx for i, e in enumerate(events) if e[0] == "cmd"
+        ), f"command issued after conn close: {events}"
 
     async def test_invalidate_failure_drains_in_flight_work(self):
         """A failing tag returns 0 with no per-tag task left in flight."""

--- a/tests/unit/test_intelligent_cache.py
+++ b/tests/unit/test_intelligent_cache.py
@@ -1593,6 +1593,164 @@ class TestRedisCacheLayerInvalidateByTags:
 
         assert result == 0
 
+    async def test_invalidate_issues_tags_concurrently(self):
+        """Per-tag work must overlap rather than run one tag at a time.
+
+        This is the non-vacuity guard for the change: a serial ``for`` loop
+        yields a peak of exactly 1, so this assertion fails on the previous
+        implementation.
+        """
+        layer = self._connected_layer()
+        conn = _make_redis_conn()
+
+        in_flight = 0
+        peak = 0
+
+        async def _tracking_smembers(*_args, **_kwargs):
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            # Yield so sibling tags can start if the fan-out is concurrent.
+            await asyncio.sleep(0)
+            in_flight -= 1
+            return {b"key1"}
+
+        conn.smembers = AsyncMock(side_effect=_tracking_smembers)
+        conn.delete = AsyncMock(return_value=1)
+
+        with _patch_redis(conn):
+            result = await layer.invalidate_by_tags([f"tag{i}" for i in range(5)])
+
+        assert peak > 1
+        assert conn.smembers.call_count == 5
+        assert result == 5
+
+    async def test_invalidate_stays_within_concurrency_bound(self):
+        """A large tag list must not fan out past the connection-pool budget."""
+        layer = self._connected_layer()
+        conn = _make_redis_conn()
+
+        in_flight = 0
+        peak = 0
+
+        async def _tracking_smembers(*_args, **_kwargs):
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0)
+            in_flight -= 1
+            return set()
+
+        conn.smembers = AsyncMock(side_effect=_tracking_smembers)
+
+        with _patch_redis(conn):
+            result = await layer.invalidate_by_tags([f"tag{i}" for i in range(50)])
+
+        assert result == 0
+        assert conn.smembers.call_count == 50
+        assert peak <= layer._tag_write_limit
+
+    async def test_invalidate_holds_one_permit_across_both_commands(self):
+        """smembers and delete for a tag must not be split across permits.
+
+        The delete operates on the members smembers just returned, so a permit
+        that is released between them would let the number of concurrently held
+        pool connections reach twice the budget.
+        """
+        layer = self._connected_layer()
+        layer._tag_write_limit = 1
+        conn = _make_redis_conn()
+
+        order = []
+
+        async def _smembers(name, *_args, **_kwargs):
+            order.append(("smembers", name))
+            await asyncio.sleep(0)
+            return {b"key1"}
+
+        async def _delete(*args, **_kwargs):
+            order.append(("delete", args[-1]))
+            await asyncio.sleep(0)
+            return 1
+
+        conn.smembers = AsyncMock(side_effect=_smembers)
+        conn.delete = AsyncMock(side_effect=_delete)
+
+        with _patch_redis(conn):
+            await layer.invalidate_by_tags(["tag1", "tag2"])
+
+        # With one permit the pairs must not interleave.
+        assert order == [
+            ("smembers", "uvai:tag:tag1"),
+            ("delete", "uvai:tag:tag1"),
+            ("smembers", "uvai:tag:tag2"),
+            ("delete", "uvai:tag:tag2"),
+        ]
+
+    async def test_invalidate_failure_drains_in_flight_work(self):
+        """A failing tag returns 0 with no per-tag task left in flight."""
+        layer = self._connected_layer()
+        conn = _make_redis_conn()
+
+        started = 0
+        finished = 0
+
+        async def _flaky_smembers(name, *_args, **_kwargs):
+            nonlocal started, finished
+            started += 1
+            await asyncio.sleep(0)
+            finished += 1
+            if name.endswith("tag3"):
+                raise RuntimeError("redis unavailable")
+            return set()
+
+        conn.smembers = AsyncMock(side_effect=_flaky_smembers)
+
+        with _patch_redis(conn):
+            result = await layer.invalidate_by_tags([f"tag{i}" for i in range(6)])
+
+        assert result == 0
+        # Every scheduled tag ran to completion before the method returned.
+        assert started == 6
+        assert finished == started
+
+    async def test_invalidate_shares_tag_write_budget_with_set(self):
+        """set() and invalidate_by_tags() must draw from one shared budget.
+
+        Both hold connections from the same pool, so separate budgets would let
+        a concurrent set storm and invalidation storm each claim the full limit.
+        """
+        layer = self._connected_layer()
+        conn = _make_redis_conn()
+
+        in_flight = 0
+        peak = 0
+
+        async def _tracked(*_args, **_kwargs):
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0)
+            in_flight -= 1
+            return 1
+
+        async def _tracked_smembers(*_args, **_kwargs):
+            await _tracked()
+            return set()
+
+        conn.sadd = AsyncMock(side_effect=_tracked)
+        conn.smembers = AsyncMock(side_effect=_tracked_smembers)
+
+        with _patch_redis(conn):
+            await asyncio.gather(
+                layer.set("k", "v", tags=[f"s{i}" for i in range(40)]),
+                layer.invalidate_by_tags([f"i{i}" for i in range(40)]),
+            )
+
+        assert conn.sadd.call_count == 40
+        assert conn.smembers.call_count == 40
+        assert peak <= layer._tag_write_limit
+
 
 class TestRedisCacheLayerUpdateAvgAccessTime:
     """Tests for RedisCacheLayer._update_avg_access_time() — lines 442-450"""


### PR DESCRIPTION
## Canonical issue

Closes #1261.

## Outcome

| | |
|---|---|
| **Does** | Issue the per-tag `smembers`/`delete` pairs in `RedisCacheLayer.invalidate_by_tags()` concurrently instead of one tag at a time, so the caller's wall-clock latency stops growing linearly with tag count. |
| **Does** | Reuse the existing per-layer tag-write semaphore (added for `set()` in #1152) so the combined fan-out cannot exhaust the shared `redis.asyncio` connection pool. |
| **Does** | Hold one permit across both commands for a tag, bounding the number of tag invalidations in progress and keeping each causally-ordered `smembers`->`delete` pair indivisible. |
| **Does not** | Change the return value, the keys written or read, the log line, or the `except` path that returns `0`. |
| **Does not** | Improve server throughput. `await conn.smembers(...)` already yields; this is a latency defect, not a loop-starvation one. See "Risk" for the honest framing. |
| **Does not** | Touch `IntelligentCacheSystem.invalidate_by_tags()`, which fans out across layers sequentially. That is a separate defect and is not addressed here. |
| **Does not** | Establish a loop-ownership contract. That remains open in #1162. |

## Scope

Two files.

`src/youtube_extension/backend/services/intelligent_cache.py`
- `invalidate_by_tags()` — the serial `for tag in tags:` body becomes an inner `_invalidate_tag()` coroutine acquiring the semaphore, gathered with `return_exceptions=True`, with the first exception re-raised so the existing `except Exception` handler still returns `0`.
- `_get_tag_write_semaphore()` docstring — two statements became false and are corrected. It previously said the semaphore was "shared by every `set()` call" and listed `invalidate_by_tags()` among the methods "none of which this limiter touches". Both now name the second caller.

`tests/unit/test_intelligent_cache.py` — five tests appended to the existing `TestRedisCacheLayerInvalidateByTags` class. No existing test was modified.

No empty-input guard is needed: `await asyncio.gather()` with zero coroutines returns `[]`, so the empty-tag path logs and returns `0` exactly as before. This is covered by the untouched `test_invalidate_empty_tags_returns_zero`.

## Overlap with open PR #1179

PR #1179 (loop-ownership contract, tracking issue #1162) edits the same
`_get_tag_write_semaphore()` docstring. **Whichever of the two merges second will hit a
textual conflict, and the resolution is mechanical.** Disclosing it here so the second
merger does not have to reverse-engineer intent:

| region | this PR | #1179 | resolution |
|---|---|---|---|
| summary line | `set()` call becomes tag fan-out | unchanged | **take this PR's line.** #1179 leaves it reading "shared by every `set()` call", which this PR makes false by adding a second acquirer. |
| new paragraph naming both acquirers | added | absent | **keep.** Pure insertion, no overlap. |
| trailing "Scope note" paragraph | reworded, still cites #1162 | **deleted**, replaced by a pointer to the new class-level contract | **take #1179's replacement.** Once a layer-wide contract exists, this PR's rewording is redundant. |

This PR could have avoided the third row by leaving the Scope note alone, but that
paragraph lists `invalidate_by_tags()` among the methods "none of which this limiter
touches" -- a statement this PR makes false. Shipping a knowingly-false docstring to dodge
a conflict is the worse trade, so the edit stays.

There is no functional overlap: #1179 changes connection and loop-ownership bookkeeping,
this PR changes only how the per-tag awaits are scheduled.

## Risk

**This is a latency change, not a throughput change.** Unlike the blocking-call fixes in #1228 / #1240 / #1245, the awaits here already yield to the event loop, so other coroutines were never starved. The cost being removed is borne by the caller awaiting `invalidate_by_tags()`. A secondary effect is that the window during which entries meant to be invalidated remain readable by `get()` shrinks.

**Behaviour change on the failure path, disclosed deliberately.** The serial loop stopped at the first failing tag, leaving later tags untouched. The concurrent version has already issued every tag before the error surfaces, so more tags may be invalidated before the method returns. **The return value is identical (`0`) in both cases**, and the existing `test_invalidate_exception_returns_zero` passes unmodified. For an invalidation path this errs safe: over-invalidating costs a cache miss, under-invalidating leaves stale entries readable.

**Cancellation parity.** If the gather future is itself cancelled, `gather` cancels its children and raises without draining them, so a child could still be unwinding when the enclosing `async with redis.Redis(...)` closes `conn`. A cancelled child only unwinds — it releases the semaphore in `finally` and lets redis-py return its connection to the pool. It never issues a new command on the closed connection. This is byte-for-byte the same ownership model as the `set()` fan-out merged in #1152, so this change introduces no new cancellation window.

**Permit scope (corrected after review).** One permit covers both commands for a tag rather than one each. The original justification in this PR was **wrong** and has been retracted in the code, the test docstring, and here.

The claim was that holding one permit across the pair keeps concurrently-held pool connections equal to the permit count "instead of twice it". That is false. `redis.asyncio.Redis` is built with `single_connection_client=False`, so `execute_command` borrows a connection at the start of every command and releases it in a `finally`:

```python
conn = self.connection or await pool.get_connection()   # borrowed per command
...
finally:
    if not self.connection:
        await pool.release(conn)                         # released per command
```

No connection is held across the `await` boundary between `smembers` and `delete`, so a per-command permit would cap in-flight commands at the same number. Peak pool usage is identical either way.

The real reason to hold across the pair is a **scheduling policy**: it bounds how many tag invalidations are in progress at once, keeps each causally-ordered pair indivisible, and bounds how many tags can sit half-invalidated if a `delete` fails. `test_invalidate_holds_one_permit_across_both_commands` pins that policy so a later refactor cannot silently split the pair.

## Verification

### Non-vacuity

Measured against a mock pool with `max_connections=20` and a 50-tag invalidation, varying only the limiter:

| variant | peak in-flight commands | pool max |
|---|---|---|
| serial loop (behaviour on `main`) | 1 | 20 |
| concurrent, unbounded limiter | 50 | 20 |
| concurrent, shared per-layer budget (this PR) | **8** | 20 |

The resolved budget is 8 because `_resolve_tag_write_limit()` reserves `TAG_WRITE_POOL_RESERVE = 4` connections for non-tag traffic.

### Prove-fail

The six new tests were run against the pre-change source. Four fail, which is the guard against a vacuous suite:

```
FAILED test_invalidate_issues_tags_concurrently
FAILED test_invalidate_cancellation_drains_before_conn_closes
FAILED test_invalidate_failure_drains_in_flight_work
FAILED test_invalidate_shares_tag_write_budget_with_set
4 failed, 8 passed
```

**Two of the six pass both before and after, and are documented as such** rather than presented as proof of the change:
- `test_invalidate_stays_within_concurrency_bound` — a serial loop trivially satisfies `peak <= limit`. It guards against a future change removing the limiter.
- `test_invalidate_holds_one_permit_across_both_commands` — a serial loop is naturally ordered. It pins the permit-scope decision above so a later refactor cannot silently split the pair.

### Tests added

| test | asserts |
|---|---|
| `test_invalidate_issues_tags_concurrently` | peak in-flight > 1, i.e. tags actually overlap |
| `test_invalidate_stays_within_concurrency_bound` | 50 tags, peak <= `_tag_write_limit` |
| `test_invalidate_holds_one_permit_across_both_commands` | with 1 permit, `smembers`/`delete` pairs do not interleave |
| `test_invalidate_cancellation_drains_before_conn_closes` | on outer cancellation, all three children are in flight, every `finally` completes before `__aexit__`, and no command starts after close |
| `test_invalidate_failure_drains_in_flight_work` | a failing tag returns `0` with `started == finished` |
| `test_invalidate_shares_tag_write_budget_with_set` | concurrent `set()` + `invalidate_by_tags()` share one budget |

### Commands

```
.venv/bin/python -m pytest tests/unit/test_intelligent_cache.py \
  --override-ini="addopts=" -p no:cacheprovider -q
# 163 passed

.venv/bin/python -m pytest tests/unit/test_intelligent_cache.py \
  tests/unit/test_intelligent_cache_models.py \
  tests/unit/test_comprehensive_benchmarking.py \
  --override-ini="addopts=" -p no:cacheprovider -q
# 337 passed
```

All six pre-existing `invalidate_*` tests pass unmodified. Ruff was run on both files against their `origin/main` counterparts and the diagnostic sets are identical.

## Production evidence

Not applicable. This change touches a backend Redis cache path that is not exercised by the Vercel preview deployment, and it is behaviour-preserving — the same keys and members are read and deleted, only the scheduling of the awaits changes. Correctness is covered by the five focused unit tests above rather than by a runtime deployment.

## Agent handoff

- One canonical issue linked, and it is the only closing reference in this body.
- No competing open PR targets #1261.
- Acceptance criteria in #1261 are satisfied.
- Required checks pass on the current head.
- No human decision is requested: this is not a product, security, irreversible-infra, or production-approval change.
