### PR TITLE
fix(security): neutralize CWE-117 log forging in StructuredFormatter

### DIFF
--- a/src/youtube_extension/backend/config/logging_config.py
+++ b/src/youtube_extension/backend/config/logging_config.py
@@ -15,6 +15,23 @@ from datetime import datetime
 from pathlib import Path
 
 
+# CWE-117 (log injection / log forging): line-breaking characters that let a
+# user-controlled value spawn a second, forged log line. Neutralized in the
+# FINAL rendered record — see StructuredFormatter.format() — so exc_info
+# tracebacks and structured ``extra`` fields are covered even when a value was
+# not sanitized at the call site. Escaping (rather than dropping) keeps the
+# content greppable while guaranteeing one log call renders as one physical line.
+_LOG_FORGERY_ESCAPES = {
+    0x0A: "\\n",       # line feed
+    0x0D: "\\r",       # carriage return
+    0x0B: "\\v",       # vertical tab
+    0x0C: "\\f",       # form feed
+    0x85: "\\x85",     # NEL (Unicode next line)
+    0x2028: "\\u2028",  # line separator
+    0x2029: "\\u2029",  # paragraph separator
+}
+
+
 class StructuredFormatter(logging.Formatter):
     """
     Custom formatter for structured logging with enhanced metadata.
@@ -39,7 +56,12 @@ class StructuredFormatter(logging.Formatter):
         # Format the base message
         formatted_message = super().format(record)
 
-        return formatted_message
+        # CWE-117: neutralize CR/LF (and other line separators) in the fully
+        # rendered record. This covers the message, any exc_info traceback text
+        # (including ``str(exc)``) and structured ``extra`` fields the format
+        # string references, so a user-controlled value carrying "\r\n" cannot
+        # forge an additional log line even when it was not sanitized inline.
+        return formatted_message.translate(_LOG_FORGERY_ESCAPES)
 
     def formatException(self, ei) -> str:
         """Format exception with enhanced stack trace"""

--- a/tests/unit/test_logging_config_crlf.py
+++ b/tests/unit/test_logging_config_crlf.py
@@ -1,0 +1,55 @@
+"""CWE-117 regression: StructuredFormatter must neutralize log forging.
+
+These tests assert against the *rendered* handler output (not a sanitizer's
+return value), covering the exc_info / logger.exception sinks that append raw
+traceback and exception text after the formatted message.
+"""
+
+import io
+import logging
+
+import pytest
+
+from youtube_extension.backend.config.logging_config import StructuredFormatter
+
+
+def _render(logger_call) -> str:
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(StructuredFormatter("%(levelname)s - %(message)s"))
+    logger = logging.getLogger("crlf-regression")
+    logger.handlers[:] = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    logger_call(logger)
+    handler.flush()
+    return buf.getvalue()
+
+
+def test_crlf_in_message_cannot_forge_a_line():
+    out = _render(lambda lg: lg.info("video %s captured", "abc\r\nCRITICAL - FORGED"))
+    # Exactly one physical line (plus the trailing newline the handler adds).
+    assert out.count("\n") == 1
+    assert "\r" not in out
+    assert "FORGED" in out  # content preserved, just neutralized
+    assert "CRITICAL - FORGED" not in out.splitlines()  # not a standalone line
+
+
+def test_exc_info_traceback_cannot_forge_log_lines():
+    def call(lg):
+        try:
+            raise ValueError("boom\r\nCRITICAL - FORGED ADMIN LINE")
+        except ValueError:
+            lg.error("Error in chat endpoint", exc_info=True)
+
+    out = _render(call)
+    assert "\r" not in out
+    # The forged text must never appear as its own rendered line.
+    assert "CRITICAL - FORGED ADMIN LINE" not in out.splitlines()
+
+
+@pytest.mark.parametrize("sep", [" ", " ", "\x0b", "\x0c", "\x85"])
+def test_unicode_line_separators_are_neutralized(sep):
+    out = _render(lambda lg: lg.info("session %s", "s" + sep + "INJECTED"))
+    assert sep not in out
+    assert "INJECTED" in out


### PR DESCRIPTION
## Canonical issue

Progresses #898 (CWE-117 log-injection hardening). Addresses the **confirmed, previously-unmitigated** `exc_info` finding raised on #810 — this is the central, formatter-level remediation that complements #810's per-sink message sanitization (not competing: #810 scrubs individual `router.py` sinks; this scrubs the final rendered record for every logger).

> **De-duplicated (2026-08-02):** an earlier revision of this PR also carried the `code_generator.py` info-disclosure fix. That fix is owned by the canonical Sentinel PR **#1259** — I force-pushed to drop those commits, so this PR is now scoped **solely** to the `StructuredFormatter` CWE-117 fix and does not compete with #1259.

## Outcome

A user-controlled value containing `\r\n` (or other line separators) can no longer forge or corrupt a log line — not via the message, not via an `exc_info` traceback, and not via structured `extra` fields. One logging call renders as exactly one physical line.

## Scope

- Included:
  - `src/youtube_extension/backend/config/logging_config.py` — scrub CR/LF, VT, FF, NEL, U+2028, U+2029 from the fully rendered record in `StructuredFormatter.format()`.
  - `tests/unit/test_logging_config_crlf.py` — new regression suite (asserts *rendered* handler output).
- Explicitly excluded: `router.py` per-sink sanitization (#810's scope); `code_generator.py` info-disclosure (#1259's scope).

## Risk

- Risk level: low
- Failure mode: multi-line tracebacks now render on a single physical line (newlines escaped to `\n`). Content is fully preserved and greppable; separators are escaped, not dropped.
- Rollback: revert the `logging_config.py` hunk; formatter reverts to prior passthrough behavior.

## Verification

- [x] Focused tests — `tests/unit/test_logging_config_crlf.py`: **7 passed** on head `d88875d` (message forging, `exc_info` traceback forging, and 5 Unicode/control separators), asserted against rendered handler output.
- [ ] Required CI — pending on head `d88875d`.
- [x] Review threads resolved — none open.

Standalone evidence:
```
MESSAGE  lines=1  forged-standalone=False  content-kept=True
EXC_INFO forged-standalone=False  has_CR=False  traceback-present=True
```

## Production evidence

Not applicable to runtime behavior: Python-only logging-format change. Vercel builds the Next.js `apps/web` root and does not exercise this path (exact-head preview was Ready on the prior revision).

## Agent handoff

- [x] One canonical issue is linked (#898; addresses #810's finding)
- [x] No competing PR — de-duplicated against #1259; no open PR touches this formatter
- [x] Acceptance criteria satisfied for the code change (focused tests green)
- [ ] Required checks pass on the current head — pending; several repo gates are infra/human-gated (see CI triage comment)
- [x] Human decision requested for security approval and merge to protected `main`

> **Unattended-run disclosure:** produced by a scheduled, non-interactive remediation pass. Not authorized to merge to protected `main` autonomously, and the `agent-completion/truth-gate` needs provenance an unattended run can't supply. Expected terminal state: **`HALTED(awaiting_owner)`** — code complete and verified; only sign-off/merge remain.

## Agent provenance

<!-- agent-lock-manifest
{"issue_number": 898, "agent_login": "claude", "run_id": "session_01KDtvQR6b5JXkAStGbTCTxL"}
-->

<!-- agent-lock-event
{"kind": "artifact_ready", "run_id": "session_01KDtvQR6b5JXkAStGbTCTxL", "head_sha": "d88875df866473a4f523a6169d8b314c52964880"}
-->