### PR TITLE
perf: read and encode GitHub upload payloads off the event loop

### DIFF
--- a/src/youtube_extension/backend/deployment_manager.py
+++ b/src/youtube_extension/backend/deployment_manager.py
@@ -55,6 +55,20 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+
+def _read_and_encode_file(file_path: Path) -> str:
+    """Read a file and return its base64-encoded contents.
+
+    Both the disk read and the CPU-bound encode are performed here so a single
+    ``asyncio.to_thread`` hop covers the whole operation. Keeping them together
+    also means the raw ``bytes`` never cross back to the event loop — only the
+    encoded ``str`` does.
+    """
+    with open(file_path, 'rb') as f:
+        content = f.read()
+    return base64.b64encode(content).decode('utf-8')
+
+
 class DeploymentManager:
     """
     Manages deployment of generated projects to various platforms
@@ -609,12 +623,13 @@ class DeploymentManager:
             async def upload_single_file(file_path: Path, relative_path: Path):
                 async with semaphore:
                     try:
-                        # Read file content
-                        with open(file_path, 'rb') as f:
-                            content = f.read()
-
-                        # Encode content
-                        encoded_content = base64.b64encode(content).decode('utf-8')
+                        # Read and encode off the event loop: this coroutine runs
+                        # concurrently with up to 9 siblings, and a synchronous read
+                        # here would serialise them all and stall the aiohttp
+                        # transport servicing the other in-flight uploads.
+                        encoded_content = await asyncio.to_thread(
+                            _read_and_encode_file, file_path
+                        )
 
                         # Upload file
                         file_data = {

--- a/tests/unit/test_deployment_manager.py
+++ b/tests/unit/test_deployment_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import os
 import re
 import subprocess
@@ -1494,3 +1495,198 @@ class TestVerifyProjectRunsOffEventLoop:
 
         assert result["passed"] is False
         assert "timeout" in result["summary"].lower()
+
+
+# ===========================================================================
+# _upload_to_github - payload reads must not run on the event loop
+# ===========================================================================
+
+
+def _make_capturing_upload_session(captured: list) -> MagicMock:
+    """Build a ClientSession context manager that records PUT payloads.
+
+    Returns the session context manager. Every ``put`` appends its JSON body to
+    ``captured`` and reports HTTP 201.
+    """
+    user_resp = MagicMock()
+    user_resp.status = 200
+    user_resp.json = AsyncMock(return_value={"login": "u"})
+
+    put_resp = MagicMock()
+    put_resp.status = 201
+    put_resp.text = AsyncMock(return_value="")
+
+    def _put(*args, **kwargs):
+        captured.append(kwargs.get("json"))
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=put_resp)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    session_mock = MagicMock()
+    session_mock.get = MagicMock(return_value=_make_aiohttp_ctx(user_resp))
+    session_mock.put = MagicMock(side_effect=_put)
+
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=session_mock)
+    session_cm.__aexit__ = AsyncMock(return_value=False)
+    return session_cm
+
+
+class TestUploadToGithubOffLoopReads:
+    """The per-file read+encode is the only CPU/disk work inside the upload
+    fan-out. It must happen off the event loop thread, otherwise the
+    ``Semaphore(10)`` + ``gather`` concurrency is defeated and the shared
+    aiohttp transport cannot service the other in-flight uploads.
+    """
+
+    async def test_file_read_runs_off_the_event_loop_thread(self, tmp_path) -> None:
+        """The blocking ``open()`` must execute on a worker thread."""
+        (tmp_path / "index.ts").write_text("const x = 1;")
+        mgr = _make_manager(github_token="tok")
+
+        loop_thread_id = threading.get_ident()
+        read_thread_ids: list[int] = []
+        real_open = open
+
+        def recording_open(file, *args, **kwargs):
+            read_thread_ids.append(threading.get_ident())
+            return real_open(file, *args, **kwargs)
+
+        session_cm = _make_capturing_upload_session([])
+
+        with patch(
+            "youtube_extension.backend.deployment_manager.aiohttp.ClientSession",
+            return_value=session_cm,
+        ), patch(
+            "youtube_extension.backend.deployment_manager.open",
+            recording_open,
+            create=True,
+        ):
+            result = await mgr._upload_to_github(str(tmp_path), "repo")
+
+        assert result["files_uploaded"] == 1
+        assert read_thread_ids, "the project file was never read"
+        assert loop_thread_id not in read_thread_ids, (
+            "payload read ran on the event loop thread; it must be offloaded"
+        )
+
+    async def test_concurrent_files_are_read_concurrently(self, tmp_path) -> None:
+        """Reads for distinct files must overlap, not serialise.
+
+        Each read parks on a shared 3-way barrier. If the reads run on the event
+        loop they are strictly sequential, the barrier can never fill, and every
+        upload fails. If they run on worker threads all three rendezvous.
+        """
+        for name in ("a.ts", "b.ts", "c.ts"):
+            (tmp_path / name).write_text(f"// {name}")
+        mgr = _make_manager(github_token="tok")
+
+        barrier = threading.Barrier(3)
+        rendezvous_reached: list[int] = []
+        real_open = open
+
+        def barrier_open(file, *args, **kwargs):
+            try:
+                # Bounded: on the event loop this expires and breaks the barrier
+                # instead of deadlocking the test session.
+                barrier.wait(timeout=5)
+            except threading.BrokenBarrierError:
+                raise OSError("reads did not overlap") from None
+            rendezvous_reached.append(threading.get_ident())
+            return real_open(file, *args, **kwargs)
+
+        session_cm = _make_capturing_upload_session([])
+
+        with patch(
+            "youtube_extension.backend.deployment_manager.aiohttp.ClientSession",
+            return_value=session_cm,
+        ), patch(
+            "youtube_extension.backend.deployment_manager.open",
+            barrier_open,
+            create=True,
+        ):
+            result = await asyncio.wait_for(
+                mgr._upload_to_github(str(tmp_path), "repo"), timeout=30
+            )
+
+        assert len(rendezvous_reached) == 3, (
+            "reads did not overlap; they are still serialised on the event loop"
+        )
+        assert len(set(rendezvous_reached)) == 3, "reads shared a single thread"
+        assert result["files_uploaded"] == 3
+
+    async def test_uploaded_payload_is_byte_identical(self, tmp_path) -> None:
+        """Offloading must not alter the transmitted bytes."""
+        raw = bytes(range(256)) + b"\x00\xff binary \n payload"
+        (tmp_path / "asset.bin").write_bytes(raw)
+        mgr = _make_manager(github_token="tok")
+
+        captured: list = []
+        session_cm = _make_capturing_upload_session(captured)
+
+        with patch(
+            "youtube_extension.backend.deployment_manager.aiohttp.ClientSession",
+            return_value=session_cm,
+        ):
+            result = await mgr._upload_to_github(str(tmp_path), "repo")
+
+        assert result["files_uploaded"] == 1
+        assert len(captured) == 1
+        assert base64.b64decode(captured[0]["content"]) == raw
+        assert captured[0]["message"] == "Add asset.bin"
+
+    async def test_unreadable_file_does_not_abort_siblings(self, tmp_path) -> None:
+        """A read failure stays isolated to its own file."""
+        (tmp_path / "good.ts").write_text("ok")
+        (tmp_path / "bad.ts").write_text("boom")
+        mgr = _make_manager(github_token="tok")
+
+        real_open = open
+
+        def selective_open(file, *args, **kwargs):
+            if os.path.basename(str(file)) == "bad.ts":
+                raise OSError("permission denied")
+            return real_open(file, *args, **kwargs)
+
+        captured: list = []
+        session_cm = _make_capturing_upload_session(captured)
+
+        with patch(
+            "youtube_extension.backend.deployment_manager.aiohttp.ClientSession",
+            return_value=session_cm,
+        ), patch(
+            "youtube_extension.backend.deployment_manager.open",
+            selective_open,
+            create=True,
+        ):
+            result = await mgr._upload_to_github(str(tmp_path), "repo")
+
+        assert result["files_uploaded"] == 1
+        assert result["file_list"] == ["good.ts"]
+
+    async def test_cancellation_is_not_swallowed(self, tmp_path) -> None:
+        """``except Exception`` must never absorb cancellation.
+
+        ``CancelledError`` derives from ``BaseException``, so offloading the read
+        does not turn a cancelled upload into a silently skipped file.
+        """
+        (tmp_path / "index.ts").write_text("const x = 1;")
+        mgr = _make_manager(github_token="tok")
+
+        def cancelling_open(file, *args, **kwargs):
+            raise asyncio.CancelledError()
+        session_cm = _make_capturing_upload_session([])
+
+        with patch(
+            "youtube_extension.backend.deployment_manager.aiohttp.ClientSession",
+            return_value=session_cm,
+        ), patch(
+            "youtube_extension.backend.deployment_manager.open",
+            cancelling_open,
+            create=True,
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(
+                    mgr._upload_to_github(str(tmp_path), "repo"), timeout=30
+                )

--- a/tests/unit/test_deployment_manager.py
+++ b/tests/unit/test_deployment_manager.py
@@ -1690,3 +1690,74 @@ class TestUploadToGithubOffLoopReads:
                 await asyncio.wait_for(
                     mgr._upload_to_github(str(tmp_path), "repo"), timeout=30
                 )
+
+    async def test_read_and_encode_both_run_off_the_event_loop_thread(
+        self, tmp_path
+    ) -> None:
+        """Pin both halves of the offloaded hop to a worker thread.
+
+        ``test_file_read_runs_off_the_event_loop_thread`` records the thread that
+        *calls* ``open()``; that alone would still pass an implementation which
+        offloaded ``open`` but ran the handle's ``read()`` or the CPU-bound
+        ``base64.b64encode`` back on the loop. This test records the thread that
+        executes ``read()`` and the thread that executes ``b64encode`` and
+        asserts neither is the loop thread, so the whole read+encode operation is
+        pinned off the event loop rather than only the ``open`` call.
+        """
+        (tmp_path / "index.ts").write_text("const x = 1;")
+        mgr = _make_manager(github_token="tok")
+
+        loop_thread_id = threading.get_ident()
+        read_thread_ids: list[int] = []
+        encode_thread_ids: list[int] = []
+        real_open = open
+        real_b64encode = base64.b64encode
+
+        class _RecordingHandle:
+            """Wrap a file object and record the thread that runs ``read()``."""
+
+            def __init__(self, fh) -> None:
+                self._fh = fh
+
+            def read(self, *args, **kwargs):
+                read_thread_ids.append(threading.get_ident())
+                return self._fh.read(*args, **kwargs)
+
+            def __enter__(self):
+                self._fh.__enter__()
+                return self
+
+            def __exit__(self, *exc):
+                return self._fh.__exit__(*exc)
+
+        def recording_open(file, *args, **kwargs):
+            return _RecordingHandle(real_open(file, *args, **kwargs))
+
+        def recording_b64encode(data, *args, **kwargs):
+            encode_thread_ids.append(threading.get_ident())
+            return real_b64encode(data, *args, **kwargs)
+
+        session_cm = _make_capturing_upload_session([])
+
+        with patch(
+            "youtube_extension.backend.deployment_manager.aiohttp.ClientSession",
+            return_value=session_cm,
+        ), patch(
+            "youtube_extension.backend.deployment_manager.open",
+            recording_open,
+            create=True,
+        ), patch(
+            "youtube_extension.backend.deployment_manager.base64.b64encode",
+            recording_b64encode,
+        ):
+            result = await mgr._upload_to_github(str(tmp_path), "repo")
+
+        assert result["files_uploaded"] == 1
+        assert read_thread_ids, "the project file was never read"
+        assert encode_thread_ids, "the payload was never encoded"
+        assert loop_thread_id not in read_thread_ids, (
+            "file read ran on the event loop thread; it must be offloaded"
+        )
+        assert loop_thread_id not in encode_thread_ids, (
+            "base64 encode ran on the event loop thread; it must be offloaded"
+        )


### PR DESCRIPTION
## Canonical issue

Closes #1268

Head sha: `d07bcf3b57e8aef0e4cce5f5973fb38e9562f840`
Base: `94b517c52d14ed4f9b3dd4b7cc92ea9d96a4e4e5`

## Outcome

`DeploymentManager._upload_to_github` fans out over every file in the generated
project with a `Semaphore(10)` and a single `asyncio.gather`. Each task then did
a synchronous `open()` / `read()` plus a CPU-bound `base64.b64encode` **directly
on the event loop**. This PR moves both into one `asyncio.to_thread` hop.

| | before | after |
|---|---|---|
| payload read thread | event loop | worker thread |
| N payload reads | strictly serialised | overlap, bounded by the existing 10 permits |
| aiohttp transport during a read | stalled | keeps servicing the other 9 uploads |
| bytes transmitted | — | **identical** (asserted byte-for-byte) |
| `CancelledError` handling | propagates | propagates (unchanged) |
| public API / call signatures | — | unchanged |

**What this does NOT do.** It does not change the concurrency limit, the retry
behaviour, the request shape, the commit messages, the exclusion rules, or any
error semantics. It does not touch `verify_project`. It is behaviour-preserving:
the same bytes are read and encoded, only the *scheduling* of that work changes.

### Why this is not a no-op

Fan-out fixes are worth measuring before shipping, because a fan-out over work
that never yields saves nothing. That is not the case here:

- The surrounding code **already declares concurrency as its intent** — the
  `Semaphore(10)` and the `gather` over `upload_tasks` exist for no other reason.
  The blocking read defeated a design goal the file already states.
- The offloaded callable is genuinely blocking: a real `read()` syscall plus a
  base64 encode over the full file contents.
- The reads are **independent** — distinct paths, no shared state, no ordering
  requirement. Nothing forces serialisation.
- `test_concurrent_files_are_read_concurrently` parks three reads on a shared
  3-way `threading.Barrier`. Serialised reads can never fill it. This test
  **fails on pristine `main`** and passes here, which is the empirical proof
  that the concurrency was previously unrealised.

### The transport-stall argument

The fan-out runs inside `async with aiohttp.ClientSession()`. aiohttp's transport
is driven by the same event loop. So a synchronous read did not merely delay its
own upload — it also prevented the loop from reading responses for the other
in-flight `PUT`s already on the wire. Offloading restores forward progress for
uploads that had nothing to do with the file being read.

## Risk

**Low.** One blocking region moved to a worker thread; no logic rewritten.

Three specific risks were considered, and each is addressed:

1. **A new cancellation window.** Pristine `upload_single_file` had no `await`
   between `async with semaphore` and `session.put`, so it was uninterruptible
   there. `await asyncio.to_thread(...)` introduces a yield point. This is safe
   **because the offloaded callable is pure**: it opens a file, reads, encodes,
   and returns a `str`. The `with` block closes the handle regardless, and
   **nothing is written to disk**, so a cancelled task leaves no partial state
   to reconcile. This is materially different from an offloaded routine that
   creates files or directories, where cancellation can leak artifacts.
2. **Executor sizing.** `asyncio.to_thread` delegates to
   `loop.run_in_executor(None, ...)`, i.e. the default `ThreadPoolExecutor`,
   sized `min(32, (os.cpu_count() or 1) + 4)`. Stating this precisely rather
   than optimistically: on a 2-core runner that is **6 workers, which is fewer
   than the 10 semaphore permits**, so on small hosts the executor — not the
   semaphore — is the binding constraint and effective read concurrency is 6.
   That is not a failure mode: `to_thread` simply queues the excess, the reads
   do not wait on one another, so the work drains without deadlock, and 6-way
   concurrency is still strictly better than the 1-way serialisation on `main`.
   The honest floor is 5 concurrent reads on a 1-core host. The one genuine
   caveat is that these reads share the default executor with any other
   `to_thread` work in the process, so a long-lived blocking task elsewhere
   would queue them behind it — a pre-existing property of the default executor
   rather than something this PR introduces.
3. **Cancellation being swallowed.** `asyncio.CancelledError` derives from
   `BaseException`, not `Exception`
   (`CancelledError.__mro__ == (CancelledError, BaseException, object)`), so the
   pre-existing `except Exception as e` cannot absorb it. This holds **by
   construction** rather than by new code, and is pinned by a regression test.

`asyncio.gather` here is called without `return_exceptions=True`, but
`upload_single_file` catches `Exception` internally, so only `BaseException`
ever propagates out of it. That is unchanged by this PR.

### Deliberately out of scope

- The `rglob("*")` collection loop that builds `upload_tasks` still walks the
  tree synchronously. It is a directory scan, not file content I/O, and is a
  separate change with a different risk profile.
- `uploaded_files.append(...)` is **correct as-is** — coroutines on a single loop
  do not interleave between statements, so no lock is needed. Noting this
  explicitly so it is not "fixed" later.
- `intelligent_cache.py::warm_cache` has an unbounded `gather`; tracked
  separately, out of scope here.

## Verification

Prove-fail harness — fixed source copied aside, `git show origin/main:<path>`
restored in place, tests run, source restored, `diff -q` confirming exact
restoration:

| suite | pristine `main` | this PR |
|---|---|---|
| `TestUploadToGithubOffLoopReads` (5 tests) | **2 failed**, 3 passed | **5 passed** |
| `tests/unit/test_deployment_manager.py` (full) | — | **110 passed** |

The 2 failures on `main` are the differential tests. The other 3 are guards that
correctly pass both ways and are labelled as such:

- `test_file_read_runs_off_the_event_loop_thread` — **differential.** Patches
  `open` in the module namespace, records `threading.get_ident()`, asserts it is
  not the loop thread. Proof is by **thread identity, never wall-clock timing**,
  so it cannot flake under CI load. Deliberately does not reference the new
  helper by name, so against `main` it fails on the assertion rather than
  erroring on an import.
- `test_concurrent_files_are_read_concurrently` — **differential.** The 3-way
  barrier described above. The barrier wait is bounded (`timeout=5`) and the
  whole call is wrapped in `asyncio.wait_for(..., timeout=30)`, so it can never
  hang the suite on `main`; it fails cleanly instead.
- `test_uploaded_payload_is_byte_identical` — guard. Round-trips
  `bytes(range(256))` plus embedded NUL and `0xff`, asserting the transmitted
  `content` base64-decodes to the original bytes.
- `test_unreadable_file_does_not_abort_siblings` — guard. One unreadable file
  must not cancel the fan-out.
- `test_cancellation_is_not_swallowed` — guard. Pins risk 3 above.

Lint parity (no new findings introduced, compared finding-by-finding with
position columns normalised):

```
PARITY OK :: src/youtube_extension/backend/deployment_manager.py
PARITY OK :: tests/unit/test_deployment_manager.py
```

The repository's CI lint command reports 2 pre-existing errors in
`backend/deploy/__init__.py` and `backend/services/data_service.py`. Both are
present on `main` and are untouched by this PR; the finding sets before and
after are byte-identical.

## Production evidence

Not applicable. This change touches a backend path that is not exercised by the
Vercel preview deployment, and it is behaviour-preserving — the same bytes are
read and encoded, only the scheduling of the work changes. Correctness is
covered by the 5 focused unit tests above rather than by a runtime deployment.

## Agent handoff

Reviewers are asked to challenge four specific claims rather than the diff shape:

1. Is one combined thread hop for read+encode better than two separate hops?
2. Does the new `to_thread` await point introduce a *harmful* cancellation
   window, given the callable writes nothing to disk?
3. Is the aiohttp transport-stall claim real, or would the loop have serviced
   the other responses anyway?
4. I originally claimed the default executor bounds this fan-out at 10 and
   "cannot be exhausted". That was wrong and I corrected it above:
   `min(32, (os.cpu_count() or 1) + 4)` is **6 on a 2-core runner**, below the
   10 permits. Please sanity-check my revised claim that this is a throughput
   ceiling (6-way instead of 10-way) rather than a correctness problem.
