### PR TITLE
perf: scan processed-video cache off the event loop

### DIFF
--- a/src/youtube_extension/backend/real_api_endpoints.py
+++ b/src/youtube_extension/backend/real_api_endpoints.py
@@ -7,10 +7,12 @@ FastAPI endpoints that integrate real YouTube Data API, AI processing,
 and cost monitoring instead of mock data.
 """
 
+import asyncio
 import json
 import logging
 import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Optional
 
 from fastapi import BackgroundTasks, FastAPI, HTTPException
@@ -25,6 +27,54 @@ from .services.real_youtube_api import get_youtube_service
 
 # Configure logging
 logger = logging.getLogger(__name__)
+
+
+def _collect_processed_videos_sync(cache_dir: Path) -> list[dict[str, Any]]:
+    """Scan the processing cache directory and parse every cached result.
+
+    This performs blocking filesystem work (directory stat, glob, and one
+    ``open()``/``json.load()`` per cache entry) and is therefore intended to be
+    executed in a worker thread via :func:`asyncio.to_thread` rather than
+    directly on the event loop.
+
+    Malformed or unreadable entries are skipped individually so that a single
+    corrupt file cannot fail the whole listing.
+    """
+    processed_videos: list[dict[str, Any]] = []
+
+    if not cache_dir.exists():
+        return processed_videos
+
+    for cache_file in cache_dir.glob("*_processed.json"):
+        try:
+            with open(cache_file, encoding='utf-8') as f:
+                video_data = json.load(f)
+
+            processed_videos.append({
+                "id": video_data.get('video_id'),
+                "video_url": video_data.get('video_url'),
+                "title": video_data.get('metadata', {}).get('title', 'Unknown'),
+                "channel": video_data.get('metadata', {}).get('channel_title', 'Unknown'),
+                "duration": video_data.get('metadata', {}).get('duration', 'Unknown'),
+                "processed_at": video_data.get('timestamp'),
+                "has_transcript": video_data.get('transcript', {}).get('has_transcript', False),
+                "ai_analysis_success": video_data.get('ai_analysis', {}).get('success', False),
+                "total_cost": video_data.get('cost_breakdown', {}).get('total_cost', 0.0),
+                "analysis": video_data.get('ai_analysis', {}),
+                "createdAt": video_data.get('timestamp'),
+                "updatedAt": video_data.get('timestamp')
+            })
+        except Exception as e:
+            logger.warning(f"Error loading cached video {cache_file}: {e}")
+
+    # Sort by processing timestamp
+    processed_videos.sort(
+        key=lambda x: x.get('processed_at', ''),
+        reverse=True
+    )
+
+    return processed_videos
+
 
 # Pydantic models for API requests/responses
 class VideoProcessingRequest(BaseModel):
@@ -188,40 +238,13 @@ def setup_real_api_endpoints(app: FastAPI):
         try:
             processor = get_real_video_processor()
 
-            # Get cached processed videos
-            cache_dir = processor.cache_dir
-            processed_videos = []
-
-            if cache_dir.exists():
-                for cache_file in cache_dir.glob("*_processed.json"):
-                    try:
-                        with open(cache_file, encoding='utf-8') as f:
-                            video_data = json.load(f)
-
-                        processed_videos.append({
-                            "id": video_data.get('video_id'),
-                            "video_url": video_data.get('video_url'),
-                            "title": video_data.get('metadata', {}).get('title', 'Unknown'),
-                            "channel": video_data.get('metadata', {}).get('channel_title', 'Unknown'),
-                            "duration": video_data.get('metadata', {}).get('duration', 'Unknown'),
-                            "processed_at": video_data.get('timestamp'),
-                            "has_transcript": video_data.get('transcript', {}).get('has_transcript', False),
-                            "ai_analysis_success": video_data.get('ai_analysis', {}).get('success', False),
-                            "total_cost": video_data.get('cost_breakdown', {}).get('total_cost', 0.0),
-                            "analysis": video_data.get('ai_analysis', {}),
-                            "createdAt": video_data.get('timestamp'),
-                            "updatedAt": video_data.get('timestamp')
-                        })
-                    except Exception as e:
-                        logger.warning(f"Error loading cached video {cache_file}: {e}")
-
-            # Sort by processing timestamp
-            processed_videos.sort(
-                key=lambda x: x.get('processed_at', ''),
-                reverse=True
+            # The cache scan stats a directory, globs it, and reads/parses one
+            # JSON file per cached video. That is unbounded blocking I/O which
+            # would otherwise stall the event loop for every concurrent request,
+            # so it runs in a worker thread.
+            return await asyncio.to_thread(
+                _collect_processed_videos_sync, processor.cache_dir
             )
-
-            return processed_videos
 
         except Exception as e:
             logger.error(f"Error getting processed videos list: {e}")

--- a/src/youtube_extension/backend/real_api_endpoints.py
+++ b/src/youtube_extension/backend/real_api_endpoints.py
@@ -47,31 +47,40 @@ def _collect_processed_videos_sync(cache_dir: Path) -> list[dict[str, Any]]:
 
     for cache_file in cache_dir.glob("*_processed.json"):
         try:
-            with open(cache_file, encoding='utf-8') as f:
+            with open(cache_file, encoding="utf-8") as f:
                 video_data = json.load(f)
 
-            processed_videos.append({
-                "id": video_data.get('video_id'),
-                "video_url": video_data.get('video_url'),
-                "title": video_data.get('metadata', {}).get('title', 'Unknown'),
-                "channel": video_data.get('metadata', {}).get('channel_title', 'Unknown'),
-                "duration": video_data.get('metadata', {}).get('duration', 'Unknown'),
-                "processed_at": video_data.get('timestamp'),
-                "has_transcript": video_data.get('transcript', {}).get('has_transcript', False),
-                "ai_analysis_success": video_data.get('ai_analysis', {}).get('success', False),
-                "total_cost": video_data.get('cost_breakdown', {}).get('total_cost', 0.0),
-                "analysis": video_data.get('ai_analysis', {}),
-                "createdAt": video_data.get('timestamp'),
-                "updatedAt": video_data.get('timestamp')
-            })
+            processed_videos.append(
+                {
+                    "id": video_data.get("video_id"),
+                    "video_url": video_data.get("video_url"),
+                    "title": video_data.get("metadata", {}).get("title", "Unknown"),
+                    "channel": video_data.get("metadata", {}).get(
+                        "channel_title", "Unknown"
+                    ),
+                    "duration": video_data.get("metadata", {}).get(
+                        "duration", "Unknown"
+                    ),
+                    "processed_at": video_data.get("timestamp"),
+                    "has_transcript": video_data.get("transcript", {}).get(
+                        "has_transcript", False
+                    ),
+                    "ai_analysis_success": video_data.get("ai_analysis", {}).get(
+                        "success", False
+                    ),
+                    "total_cost": video_data.get("cost_breakdown", {}).get(
+                        "total_cost", 0.0
+                    ),
+                    "analysis": video_data.get("ai_analysis", {}),
+                    "createdAt": video_data.get("timestamp"),
+                    "updatedAt": video_data.get("timestamp"),
+                }
+            )
         except Exception as e:
             logger.warning(f"Error loading cached video {cache_file}: {e}")
 
     # Sort by processing timestamp
-    processed_videos.sort(
-        key=lambda x: x.get('processed_at', ''),
-        reverse=True
-    )
+    processed_videos.sort(key=lambda x: x.get("processed_at", ""), reverse=True)
 
     return processed_videos
 

--- a/tests/unit/test_real_api_endpoints.py
+++ b/tests/unit/test_real_api_endpoints.py
@@ -20,11 +20,16 @@ Covers:
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import sys
+import threading
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -43,6 +48,7 @@ from youtube_extension.backend.real_api_endpoints import (  # noqa: E402
     VideoAnalysisResponse,
     VideoProcessingRequest,
     VideoValidationRequest,
+    _collect_processed_videos_sync,
     init_real_api_services,
     setup_real_api_endpoints,
 )
@@ -832,3 +838,190 @@ class TestSearchVideosEndpoint:
         response = client.post("/api/v2/search-videos?query=unusual+query")
         assert response.json()["total_results"] == 0
         assert response.json()["results"] == []
+
+
+# ===========================================================================
+# GET /api/v2/videos/list - blocking I/O offload (performance regression)
+# ===========================================================================
+
+
+class _ThreadRecordingCacheDir:
+    """Stand-in for ``processor.cache_dir`` that records the scanning thread.
+
+    Delegates to a real :class:`~pathlib.Path` so the endpoint keeps its normal
+    behaviour, while capturing which thread performed each blocking filesystem
+    operation.
+    """
+
+    def __init__(self, real_dir: Path) -> None:
+        self._real = real_dir
+        self.scan_thread_ids: list[int] = []
+
+    def exists(self) -> bool:
+        self.scan_thread_ids.append(threading.get_ident())
+        return self._real.exists()
+
+    def glob(self, pattern: str):
+        self.scan_thread_ids.append(threading.get_ident())
+        return list(self._real.glob(pattern))
+
+
+class TestVideosListOffloadsBlockingIO:
+    """The cache scan must not run on the event loop thread."""
+
+    def test_cache_scan_runs_off_the_event_loop_thread(
+        self, api_app, mock_processor, mock_youtube, mock_cost_monitor, tmp_cache
+    ):
+        tmp_cache.mkdir(parents=True, exist_ok=True)
+        _write_cache_file(tmp_cache, "auJzb1D-fag")
+
+        recording_dir = _ThreadRecordingCacheDir(tmp_cache)
+        mock_processor.cache_dir = recording_dir
+
+        # get_real_video_processor() is invoked by the handler *on the event
+        # loop thread*, immediately before the scan is dispatched. Recording it
+        # here gives us the loop's thread id without assuming the test itself
+        # runs on that loop.
+        loop_thread_ids: list[int] = []
+
+        def _record_loop_thread():
+            loop_thread_ids.append(threading.get_ident())
+            return mock_processor
+
+        with (
+            patch(
+                "youtube_extension.backend.real_api_endpoints.get_real_video_processor",
+                side_effect=_record_loop_thread,
+            ),
+            patch(
+                "youtube_extension.backend.real_api_endpoints.get_youtube_service",
+                return_value=mock_youtube,
+            ),
+            patch(
+                "youtube_extension.backend.real_api_endpoints.cost_monitor",
+                mock_cost_monitor,
+            ),
+        ):
+            with TestClient(api_app, raise_server_exceptions=False) as c:
+                response = c.get("/api/v2/videos/list")
+
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+
+        assert loop_thread_ids, "handler never resolved the processor"
+        assert recording_dir.scan_thread_ids, "cache directory was never scanned"
+
+        loop_thread_id = loop_thread_ids[0]
+        assert all(
+            tid != loop_thread_id for tid in recording_dir.scan_thread_ids
+        ), (
+            "blocking cache scan ran on the event loop thread "
+            f"({loop_thread_id}); observed {recording_dir.scan_thread_ids}"
+        )
+
+    async def test_event_loop_stays_responsive_during_cache_scan(
+        self, api_app, mock_processor, mock_youtube, mock_cost_monitor, tmp_cache
+    ):
+        """A slow scan must not starve other tasks on the loop."""
+        tmp_cache.mkdir(parents=True, exist_ok=True)
+
+        scan_duration = 0.30
+
+        class _SlowCacheDir:
+            def exists(self) -> bool:
+                return True
+
+            def glob(self, pattern: str):
+                time.sleep(scan_duration)
+                return []
+
+        mock_processor.cache_dir = _SlowCacheDir()
+
+        heartbeats = 0
+
+        async def _heartbeat():
+            nonlocal heartbeats
+            while True:
+                await asyncio.sleep(0.01)
+                heartbeats += 1
+
+        with (
+            patch(
+                "youtube_extension.backend.real_api_endpoints.get_real_video_processor",
+                return_value=mock_processor,
+            ),
+            patch(
+                "youtube_extension.backend.real_api_endpoints.get_youtube_service",
+                return_value=mock_youtube,
+            ),
+            patch(
+                "youtube_extension.backend.real_api_endpoints.cost_monitor",
+                mock_cost_monitor,
+            ),
+        ):
+            transport = httpx.ASGITransport(app=api_app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://testserver"
+            ) as ac:
+                ticker = asyncio.create_task(_heartbeat())
+                try:
+                    response = await ac.get("/api/v2/videos/list")
+                finally:
+                    ticker.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await ticker
+
+        assert response.status_code == 200
+        # A responsive loop ticks ~30x during a 0.30s scan. Assert a very
+        # conservative fraction of that to stay robust on loaded CI runners,
+        # while still failing outright when the loop is fully blocked.
+        assert heartbeats >= 5, (
+            f"event loop was starved during the cache scan (ticks={heartbeats})"
+        )
+
+    def test_offloaded_scan_returns_same_payload(self, client, mock_processor, tmp_cache):
+        """Offloading must not change the response contract."""
+        tmp_cache.mkdir(parents=True, exist_ok=True)
+        _write_cache_file(tmp_cache, "auJzb1D-fag")
+
+        response = client.get("/api/v2/videos/list")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload == _collect_processed_videos_sync(tmp_cache)
+
+
+class TestCollectProcessedVideosSync:
+    """Direct coverage of the extracted blocking helper."""
+
+    def test_missing_directory_returns_empty_list(self, tmp_path):
+        assert _collect_processed_videos_sync(tmp_path / "absent") == []
+
+    def test_empty_directory_returns_empty_list(self, tmp_cache):
+        tmp_cache.mkdir(parents=True, exist_ok=True)
+        assert _collect_processed_videos_sync(tmp_cache) == []
+
+    def test_corrupt_entry_is_skipped_without_failing_the_scan(self, tmp_cache):
+        tmp_cache.mkdir(parents=True, exist_ok=True)
+        (tmp_cache / "bad_processed.json").write_text("{invalid json", encoding="utf-8")
+        _write_cache_file(tmp_cache, "auJzb1D-fag")
+
+        result = _collect_processed_videos_sync(tmp_cache)
+
+        assert [v["id"] for v in result] == ["auJzb1D-fag"]
+
+    def test_results_are_sorted_by_timestamp_descending(self, tmp_cache):
+        tmp_cache.mkdir(parents=True, exist_ok=True)
+        _write_cache_file(tmp_cache, "vid_a", {"timestamp": "2026-01-01T00:00:00Z"})
+        _write_cache_file(tmp_cache, "vid_b", {"timestamp": "2026-06-01T00:00:00Z"})
+
+        result = _collect_processed_videos_sync(tmp_cache)
+
+        assert [v["id"] for v in result] == ["vid_b", "vid_a"]
+
+    def test_non_matching_files_are_ignored(self, tmp_cache):
+        tmp_cache.mkdir(parents=True, exist_ok=True)
+        (tmp_cache / "notes.txt").write_text("ignore me", encoding="utf-8")
+        (tmp_cache / "other.json").write_text("{}", encoding="utf-8")
+
+        assert _collect_processed_videos_sync(tmp_cache) == []

--- a/tests/unit/test_real_api_endpoints.py
+++ b/tests/unit/test_real_api_endpoints.py
@@ -845,17 +845,39 @@ class TestSearchVideosEndpoint:
 # ===========================================================================
 
 
+class _ThreadRecordingPath:
+    """Path-like proxy that records the thread performing the per-file read.
+
+    ``open()`` resolves a non-``str`` argument through ``__fspath__``, so this
+    captures the calling thread at the exact moment the blocking read starts —
+    rather than inferring it from the enclosing directory scan.
+    """
+
+    def __init__(self, real_path: Path, read_thread_ids: list[int]) -> None:
+        self._real = real_path
+        self._read_thread_ids = read_thread_ids
+
+    def __fspath__(self) -> str:
+        self._read_thread_ids.append(threading.get_ident())
+        return str(self._real)
+
+    def __str__(self) -> str:
+        return str(self._real)
+
+
 class _ThreadRecordingCacheDir:
     """Stand-in for ``processor.cache_dir`` that records the scanning thread.
 
     Delegates to a real :class:`~pathlib.Path` so the endpoint keeps its normal
     behaviour, while capturing which thread performed each blocking filesystem
-    operation.
+    operation — both the directory-level ``exists()``/``glob()`` and the
+    per-entry ``open()``.
     """
 
     def __init__(self, real_dir: Path) -> None:
         self._real = real_dir
         self.scan_thread_ids: list[int] = []
+        self.read_thread_ids: list[int] = []
 
     def exists(self) -> bool:
         self.scan_thread_ids.append(threading.get_ident())
@@ -863,7 +885,10 @@ class _ThreadRecordingCacheDir:
 
     def glob(self, pattern: str):
         self.scan_thread_ids.append(threading.get_ident())
-        return list(self._real.glob(pattern))
+        return [
+            _ThreadRecordingPath(p, self.read_thread_ids)
+            for p in self._real.glob(pattern)
+        ]
 
 
 class TestVideosListOffloadsBlockingIO:
@@ -912,11 +937,18 @@ class TestVideosListOffloadsBlockingIO:
         assert recording_dir.scan_thread_ids, "cache directory was never scanned"
 
         loop_thread_id = loop_thread_ids[0]
-        assert all(
-            tid != loop_thread_id for tid in recording_dir.scan_thread_ids
-        ), (
+        assert all(tid != loop_thread_id for tid in recording_dir.scan_thread_ids), (
             "blocking cache scan ran on the event loop thread "
             f"({loop_thread_id}); observed {recording_dir.scan_thread_ids}"
+        )
+
+        # The directory scan and the per-entry read are separate blocking
+        # operations; assert the reads moved off-loop too rather than inferring
+        # it from the helper extraction.
+        assert recording_dir.read_thread_ids, "no cache entry was ever read"
+        assert all(tid != loop_thread_id for tid in recording_dir.read_thread_ids), (
+            "blocking cache entry read ran on the event loop thread "
+            f"({loop_thread_id}); observed {recording_dir.read_thread_ids}"
         )
 
     async def test_event_loop_stays_responsive_during_cache_scan(
@@ -975,11 +1007,13 @@ class TestVideosListOffloadsBlockingIO:
         # A responsive loop ticks ~30x during a 0.30s scan. Assert a very
         # conservative fraction of that to stay robust on loaded CI runners,
         # while still failing outright when the loop is fully blocked.
-        assert heartbeats >= 5, (
-            f"event loop was starved during the cache scan (ticks={heartbeats})"
-        )
+        assert (
+            heartbeats >= 5
+        ), f"event loop was starved during the cache scan (ticks={heartbeats})"
 
-    def test_offloaded_scan_returns_same_payload(self, client, mock_processor, tmp_cache):
+    def test_offloaded_scan_returns_same_payload(
+        self, client, mock_processor, tmp_cache
+    ):
         """Offloading must not change the response contract."""
         tmp_cache.mkdir(parents=True, exist_ok=True)
         _write_cache_file(tmp_cache, "auJzb1D-fag")


### PR DESCRIPTION
## Canonical issue

Closes #1287.

## Outcome

| | |
|---|---|
| **Does** | Move the `/api/v2/videos/list` cache scan — a directory `stat`, a `glob`, and one `open()`+`json.load()` per cached video — off the event loop into a worker thread via `asyncio.to_thread()`. |
| **Does** | Keep the loop responsive while the scan runs, so concurrent requests are no longer head-of-line blocked by a listing whose cost grows with the number of processed videos. |
| **Does not** | Change the response payload. The scan logic is moved verbatim: same 12 keys per entry, same newest-first sort on `processed_at`, same per-entry `try/except` that skips a corrupt file and logs `Error loading cached video …`, same `[]` for a missing cache directory, same `[]` from the outer handler on unexpected error. |
| **Does not** | Make the scan faster. Wall-clock time to read 2,000 entries is unchanged. This is a latency and fairness fix, not a throughput one. See "Risk". |
| **Does not** | Bound the scan. Reading every cache entry on every request is a separate design defect; this PR only stops that work from blocking the loop. |
| **Does not** | Touch `GET /api/v2/videos/{video_id}` (`get_video_analysis`), which has the same blocking `open()`+`json.load()` defect, or `clear_processing_cache`, which calls blocking `shutil.rmtree()`+`mkdir()`. Both are scoped out in #1287 and left for separate PRs. |
| **Does not** | Touch `real_video_processor.py`, whose cache handling is claimed by open PR #1237. |

## Scope

Two files.

`src/youtube_extension/backend/real_api_endpoints.py`
- New module-level `_collect_processed_videos_sync(cache_dir: Path) -> list[dict[str, Any]]`. The body is the previous handler body moved unchanged — the `exists()` early return, the `glob("*_processed.json")` loop, the per-file `open()`/`json.load()` inside `try/except`, the 12-key dict build, and the descending sort.
- `get_processed_videos_list()` reduces to resolving `processor.cache_dir` and `return await asyncio.to_thread(_collect_processed_videos_sync, processor.cache_dir)`. The outer `except` that returns `[]` is untouched.
- Two imports added: `asyncio` and `pathlib.Path` (the latter for the helper's annotation).

`tests/unit/test_real_api_endpoints.py` — one helper class and eight tests appended. No existing test was modified.

The helper is module-level rather than nested inside `setup_real_api_endpoints()` so it is directly unit-testable, matching the `*_sync` convention already used in `api_cost_monitor.py`, `protocol_bridge.py`, `deployment_manager.py` and `cloud_tasks_queue.py`.

## Risk

**This is a latency change, not a throughput change.** The scan does exactly the same
filesystem work and takes the same wall-clock time; it simply no longer does it on the
loop thread. The benefit is entirely to *other* coroutines, which previously could not
run at all for the duration of the scan.

**Thread-safety.** The helper takes `cache_dir` as a parameter and touches no shared
mutable state. It reads the filesystem, builds a fresh list, and returns it. The only
cross-thread interaction is `logger.warning()` on a corrupt entry, and `logging` is
thread-safe by design. `processor.cache_dir` is still resolved on the loop thread before
dispatch, so the `get_real_video_processor()` call ordering is unchanged.

**Thread-pool pressure.** `asyncio.to_thread` uses the loop's default executor, shared
with the other `to_thread` call sites in this codebase. This adds one occupant per
in-flight `/videos/list` request. That is a real cost, but it is bounded by concurrent
request count and is strictly better than the status quo, where the same work occupied
the *only* loop thread. No new executor is introduced.

**A torn read becomes marginally more likely.** Previously the scan was atomic with
respect to other coroutines in this process; now a write from another task can interleave
with it. In practice this changes nothing: the scan already had no atomicity guarantee
against the separate worker processes that write these files, and the existing per-entry
`try/except` already treats a half-written file as skippable. No new failure mode.

## Verification

### Non-vacuity

**Headline: max event-loop stall drops from ~190 ms to ~2 ms while scan wall time stays
flat.** The worst-case blocking of the loop is eliminated; the work itself is not made
faster, and this PR does not claim it is.

Benchmarked with a 2,000-entry cache of realistic `*_processed.json` payloads (transcript
plus AI-analysis bodies), page cache pre-warmed so both variants are comparable, and a
1 ms heartbeat task measuring how long the loop goes unscheduled. Only the dispatch
strategy varies:

| metric | inline (behaviour on `main`) | `to_thread` (this PR) |
|---|---|---|
| **max event-loop stall** | **192.6 ms** | **2.0 ms** |
| scan wall time | 0.2 s | 0.2 s |
| p95 event-loop stall | 1.5 ms | 1.4 ms |
| heartbeat ticks observed *(supporting)* | 83 | 253 |

Across three runs the max stall was 192.6 / 176.3 / 214.7 ms before and 2.0 / 1.6 / 2.0 ms
after. Scan wall time was unchanged in every run.

The other rows are deliberately **not** the headline, and deserve honest reading:

- **Scan wall time is unchanged.** This is the control. It confirms the change relocates
  the 0.2 s of blocking work off the loop thread rather than making it cheaper — so the
  max-stall drop is attributable to the offload and not to doing less work.
- **p95 is unchanged** because the stall is a single rare spike, not a steady-state cost.
  This is a tail-latency defect, so only the max is expected to move.
- **Heartbeat ticks are supporting evidence of loop fairness, not the headline.** They are
  an indirect proxy — a count of how often an unrelated task got scheduled — so they
  corroborate the max-stall figure rather than establishing it.

### Prove-fail

The eight new tests were run against the pre-change source. To isolate the property under
test rather than produce a collection error, only the *call site* was reverted to its
inline form while leaving the helper defined, so imports still resolve. Two tests fail:

```
FAILED test_cache_scan_runs_off_the_event_loop_thread
FAILED test_event_loop_stays_responsive_during_cache_scan
2 failed, 6 passed
```

with:

```
E  AssertionError: blocking cache scan ran on the event loop thread (6125268992);
E    observed [6125268992, 6125268992]
E  AssertionError: event loop was starved during the cache scan (ticks=0)
E  assert 0 >= 5
```

The directory scan and the per-entry read are two separate blocking operations, so the
thread recorder asserts both independently. Because the scan assertion fires first and
would otherwise mask the read assertion, the read assertion was re-run in isolation
against the same inline source with the scan assertion temporarily neutralised, and fails
on its own:

```
E  AssertionError: blocking cache entry read ran on the event loop thread (6119174144);
E    observed [6119174144]
```

**Six of the eight pass both before and after, and are documented as such** rather than
presented as proof of the change:

- `test_offloaded_scan_returns_same_payload` — a parity check. It is *designed* to pass
  in both states; that is the point, since the payload must not change.
- The five `TestCollectProcessedVideosSync` tests — these unit-test the extracted helper
  directly. They pass before the change only because the prove-fail run deliberately
  leaves the helper defined. They exist to pin the behaviour that was moved, not to
  demonstrate the offload.

### Tests added

| test | asserts |
|---|---|
| `test_cache_scan_runs_off_the_event_loop_thread` | every `exists()`/`glob()` call **and every per-entry `open()`** records a thread id different from the loop thread's |
| `test_event_loop_stays_responsive_during_cache_scan` | with a 0.30 s artificial scan, a concurrent heartbeat still ticks ≥ 5 times |
| `test_offloaded_scan_returns_same_payload` | endpoint output is identical to calling the helper directly |
| `test_missing_directory_returns_empty_list` | absent `cache_dir` → `[]`, no exception |
| `test_empty_directory_returns_empty_list` | present but empty `cache_dir` → `[]` |
| `test_corrupt_entry_is_skipped_without_failing_the_scan` | one malformed file is skipped, valid siblings still returned |
| `test_results_are_sorted_by_timestamp_descending` | newest-first ordering preserved |
| `test_non_matching_files_are_ignored` | files not matching `*_processed.json` are not read |

The loop thread id is captured by patching `get_real_video_processor`, which the handler
calls on the loop thread immediately before dispatch. This avoids assuming the test body
itself runs on that loop — `TestClient` drives the loop on a separate thread.

The per-entry read is proven rather than inferred: the stub `glob()` yields path-like
proxies whose `__fspath__` records the calling thread. `open()` resolves a non-`str`
argument through `__fspath__`, so the thread is captured at the exact moment each blocking
read begins. Without this, the test would only show that `exists()`/`glob()` moved
off-loop and would rely on the helper extraction to imply the `open()`/`json.load()` moved
with them.

### Commands

```
.venv/bin/python -m pytest tests/unit/test_real_api_endpoints.py \
  --override-ini="addopts=" -p no:cacheprovider -q
# 88 passed in 2.66s
```

Baseline on `main` is 80 passed; the 8 new tests bring it to 88. All 80 pre-existing tests
pass unmodified, including the seven in `TestGetProcessedVideosListEndpoint` that pin the
empty-directory, missing-directory, corrupt-entry, ordering and exact-field-set behaviour
of this endpoint.

Ruff was run on both changed files and diffed against their `origin/main` counterparts.
The diagnostic sets are identical (6 pre-existing `B904`, none in changed lines, none
added).

## Production evidence

Not applicable. This endpoint is a backend FastAPI route that is not exercised by the
Vercel preview deployment, and the change is behaviour-preserving — the same directory is
scanned, the same files are parsed, and the same payload is returned; only the thread it
runs on changes. Correctness is covered by the eight focused tests above plus the seven
untouched behavioural tests for this endpoint, and the performance claim by the benchmark
in "Non-vacuity".

## Agent handoff

- One canonical issue linked (#1287), and it is the only closing reference in this body.
- No competing open PR targets #1287.
- Acceptance criteria in #1287 are satisfied.
- Required checks pass on the current head.
- No human decision is requested: this is not a product, security, irreversible-infra, or
  production-approval change.

