### PR TITLE
perf: bound L1 cache access-history retention

### DIFF
--- a/src/youtube_extension/backend/services/intelligent_cache.py
+++ b/src/youtube_extension/backend/services/intelligent_cache.py
@@ -22,7 +22,7 @@ import logging
 import statistics
 import threading
 import time
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict, defaultdict, deque
 from dataclasses import asdict, dataclass
 
 # pickle removed for security
@@ -55,6 +55,16 @@ def _resolve_tag_write_limit(max_connections: int) -> int:
     its own pool. Always at least 1 so tag writes can still make progress.
     """
     return max(1, min(TAG_WRITE_CONCURRENCY, max_connections - TAG_WRITE_POOL_RESERVE))
+
+
+# Hit timestamps retained per key to drive _calculate_adaptive_ttl(). That
+# consumer reads only the first element, the last element and the length, so the
+# window only has to be long enough for the ratio between them to be a stable
+# frequency estimate rather than a two-sample artefact. Bounding it keeps L1's
+# footprint proportional to the number of resident keys instead of to the total
+# number of reads the process has ever served.
+ACCESS_HISTORY_WINDOW = 64
+
 
 class DateTimeEncoder(json.JSONEncoder):
     """JSON encoder that handles datetime objects"""
@@ -138,7 +148,11 @@ class InMemoryCacheLayer(IntelligentCacheLayer):
         super().__init__(name, max_size)
         self.max_size_bytes = max_size_bytes
         self.cache: OrderedDict[str, CacheEntry] = OrderedDict()
-        self.access_patterns = defaultdict(list)  # Track access patterns for intelligent TTL
+        # Bounded per key: see ACCESS_HISTORY_WINDOW. Entries are released when
+        # the key leaves the cache, via delete() or _evict_if_needed().
+        self.access_patterns = defaultdict(
+            lambda: deque(maxlen=ACCESS_HISTORY_WINDOW)
+        )  # Track access patterns for intelligent TTL
 
     async def get(self, key: str) -> Optional[Any]:
         """Get value from in-memory cache"""
@@ -255,6 +269,11 @@ class InMemoryCacheLayer(IntelligentCacheLayer):
             oldest_key = next(iter(self.cache))
             entry = self.cache[oldest_key]
             del self.cache[oldest_key]
+
+            # Release the hit history too. delete() already does this; without
+            # it here an evicted key's history would be retained forever, with
+            # no cache entry left to ever trigger its cleanup.
+            self.access_patterns.pop(oldest_key, None)
 
             self.stats.total_entries -= 1
             self.stats.total_size_bytes -= entry.size_bytes

--- a/tests/unit/test_intelligent_cache.py
+++ b/tests/unit/test_intelligent_cache.py
@@ -1841,3 +1841,167 @@ class TestRedisCacheLayerUpdateAvgAccessTime:
         layer._update_avg_access_time(20.0)
         # EMA: 0.1 * 20 + 0.9 * 10 = 11.0
         assert layer.stats.avg_access_time_ms == pytest.approx(11.0, rel=0.01)
+
+
+# ---------------------------------------------------------------------------
+# InMemoryCacheLayer — access-history retention is bounded
+# ---------------------------------------------------------------------------
+
+
+class TestAccessHistoryRetentionIsBounded:
+    """A key that is read repeatedly must not accumulate one timestamp per hit
+    forever. Before this was bounded, ``access_patterns[key]`` was a plain list
+    appended to on every cache hit and never trimmed, so a hot key's history
+    grew without limit for the lifetime of the process."""
+
+    async def test_hot_key_history_stays_within_window(self):
+        from youtube_extension.backend.services.intelligent_cache import (
+            ACCESS_HISTORY_WINDOW,
+        )
+
+        layer = InMemoryCacheLayer("hot", max_size=100, max_size_bytes=1024 * 1024)
+        await layer.set("hot", "value")
+
+        hits = ACCESS_HISTORY_WINDOW * 20
+        for _ in range(hits):
+            await layer.get("hot")
+
+        retained = len(layer.access_patterns["hot"])
+        assert retained <= ACCESS_HISTORY_WINDOW, (
+            f"history for a single key grew to {retained} entries after {hits} "
+            f"hits; expected it to stay within ACCESS_HISTORY_WINDOW="
+            f"{ACCESS_HISTORY_WINDOW}"
+        )
+
+    async def test_window_retains_the_most_recent_timestamps(self):
+        """Bounding must drop the oldest samples, not the newest, so the
+        retained window still describes current behaviour."""
+        from youtube_extension.backend.services.intelligent_cache import (
+            ACCESS_HISTORY_WINDOW,
+        )
+
+        layer = InMemoryCacheLayer("recent", max_size=100, max_size_bytes=1024 * 1024)
+        await layer.set("k", "value")
+
+        for _ in range(ACCESS_HISTORY_WINDOW):
+            await layer.get("k")
+        boundary = time.time()
+        for _ in range(ACCESS_HISTORY_WINDOW):
+            await layer.get("k")
+
+        retained = list(layer.access_patterns["k"])
+        assert retained == sorted(retained), "retained timestamps lost their ordering"
+        assert all(ts >= boundary for ts in retained), (
+            "history retained samples recorded before the most recent "
+            f"{ACCESS_HISTORY_WINDOW} hits; the window is dropping the wrong end"
+        )
+
+
+# ---------------------------------------------------------------------------
+# InMemoryCacheLayer — eviction releases access history
+# ---------------------------------------------------------------------------
+
+
+class TestEvictionReleasesAccessHistory:
+    """``delete()`` already drops a key's access history (see
+    ``test_delete_cleans_access_patterns``). ``_evict_if_needed`` must do the
+    same: an evicted key leaves no cache entry behind, so nothing else will ever
+    reclaim its history."""
+
+    async def test_evicted_key_history_is_released(self):
+        layer = InMemoryCacheLayer("evict_one", max_size=1, max_size_bytes=1024 * 1024)
+        await layer.set("first", "value")
+        await layer.get("first")
+        assert "first" in layer.access_patterns
+
+        # Inserting a second key evicts "first" (max_size=1).
+        await layer.set("second", "value")
+
+        assert "first" not in layer.cache
+        assert "first" not in layer.access_patterns, (
+            "history for an evicted key was retained; nothing will ever "
+            "reclaim it because the cache entry is already gone"
+        )
+
+    async def test_eviction_churn_leaves_no_orphaned_histories(self):
+        """The accumulating case: many keys cycle through a small cache. Every
+        key that is evicted must take its history with it, so the number of
+        tracked histories stays proportional to the number of resident keys."""
+        layer = InMemoryCacheLayer("churn", max_size=5, max_size_bytes=1024 * 1024)
+
+        for i in range(200):
+            key = f"k{i}"
+            await layer.set(key, "value")
+            await layer.get(key)
+
+        orphans = set(layer.access_patterns) - set(layer.cache)
+        assert not orphans, (
+            f"{len(orphans)} evicted keys still have access history retained "
+            f"while only {len(layer.cache)} entries are resident; this memory "
+            "is invisible to stats.total_size_bytes so the max_size_bytes "
+            "budget can never reclaim it"
+        )
+
+    async def test_resident_keys_keep_their_history(self):
+        """Releasing evicted histories must not disturb keys still in the
+        cache — the fix must be a narrow cleanup, not a blanket clear."""
+        layer = InMemoryCacheLayer("keep", max_size=3, max_size_bytes=1024 * 1024)
+
+        for i in range(10):
+            await layer.set(f"k{i}", "value")
+            await layer.get(f"k{i}")
+
+        for key in layer.cache:
+            assert layer.access_patterns.get(key), (
+                f"resident key {key!r} lost its access history; adaptive TTL "
+                "would fall back to the base value for a live key"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Adaptive TTL still consumes the bounded history
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptiveTtlOverBoundedHistory:
+    """``_calculate_adaptive_ttl`` reads ``accesses[0]``, ``accesses[-1]`` and
+    ``len(accesses)``. Those must keep working over the bounded container, and
+    a saturated window must still classify a hot key as high-frequency."""
+
+    def _make_system(self, layer):
+        from youtube_extension.backend.services.intelligent_cache import (
+            IntelligentCacheSystem,
+        )
+
+        system = IntelligentCacheSystem.__new__(IntelligentCacheSystem)
+        system.layers = [layer]
+        system.adaptive_ttl_enabled = True
+        system.cache_warming_enabled = False
+        system.auto_invalidation_enabled = False
+        system.performance_history = []
+        system.optimization_suggestions = []
+        return system
+
+    async def test_saturated_window_still_yields_high_frequency_ttl(self):
+        from youtube_extension.backend.services.intelligent_cache import (
+            ACCESS_HISTORY_WINDOW,
+        )
+
+        layer = InMemoryCacheLayer("ttl", max_size=10, max_size_bytes=1024 * 1024)
+        await layer.set("k", "value")
+        # Far more hits than the window holds, all in a tight burst.
+        for _ in range(ACCESS_HISTORY_WINDOW * 5):
+            await layer.get("k")
+
+        system = self._make_system(layer)
+        assert system._calculate_adaptive_ttl("k") == 3600 * 4
+
+    async def test_indexing_and_len_work_over_bounded_history(self):
+        layer = InMemoryCacheLayer("idx", max_size=10, max_size_bytes=1024 * 1024)
+        await layer.set("k", "value")
+        for _ in range(5):
+            await layer.get("k")
+
+        accesses = layer.access_patterns["k"]
+        assert len(accesses) == 5
+        assert accesses[0] <= accesses[-1]


### PR DESCRIPTION
## Canonical issue

Closes #1294.

## Outcome

| Does | Does not |
|---|---|
| Bounds each key's hit-timestamp history to `ACCESS_HISTORY_WINDOW` (64) using a `deque(maxlen=…)` | Change `_calculate_adaptive_ttl()` — it reads only `accesses[0]`, `accesses[-1]` and `len(accesses)`, all O(1) on a deque |
| Releases an evicted key's history in `_evict_if_needed()`, matching what `delete()` already did | Change `get()`, which stays serial by design (L1→L2 short-circuit) |
| Makes L1's history footprint proportional to **resident keys** instead of to **total reads ever served** | Change the cache layer fan-out, the Redis layer, or any public signature |
| Keeps hit rate, `stats.total_size_bytes`, resident entry count and wall time identical | Add a background sweeper, a timer, or any new task |

## Scope

**`src/youtube_extension/backend/services/intelligent_cache.py`** (+21/−2)

- `deque` added to the existing `collections` import.
- New module constant `ACCESS_HISTORY_WINDOW = 64`, placed beside the existing
  `TAG_WRITE_CONCURRENCY` / `TAG_WRITE_POOL_RESERVE` constants introduced by #1262 and
  documented in the same style.
- `InMemoryCacheLayer.__init__` — `defaultdict(list)` → `defaultdict(lambda: deque(maxlen=ACCESS_HISTORY_WINDOW))`.
- `InMemoryCacheLayer._evict_if_needed` — `self.access_patterns.pop(oldest_key, None)`
  immediately after `del self.cache[oldest_key]`.

**`tests/unit/test_intelligent_cache.py`** (+164) — 4 new classes, 7 tests. No existing test modified.

## Risk

**The behaviour change worth arguing about is the frequency semantics.**
`_calculate_adaptive_ttl()` computes `frequency = len(accesses) / (accesses[-1] - accesses[0])`.
Before this change that ratio was an **all-time average** over the key's entire life. Once the
window saturates it becomes a **sliding-window rate over the most recent 64 hits**. For a key
whose access rate is stable the two agree. For a key that was hot an hour ago and is cold now,
the new reading is *lower* — and for a key that is hot now but was cold, *higher*. I claim
recency-weighting is the more appropriate input to an **adaptive** TTL, but this is a genuine
semantic change and not a pure win, so it is called out here rather than buried.

Bounded risks:

- **Window size 64 is a judgement call.** It is large enough that the ratio is a real frequency
  estimate rather than a two-sample artefact, and large enough to keep every existing test
  fixture intact (the largest seeds 20 samples). It is not derived from production telemetry.
- **Existing tests assign plain `list`s** to `access_patterns[k]` directly (4 sites). Those keep
  working because only `[0]`, `[-1]` and `len()` are ever read — confirmed by the full suite.
- `_calculate_adaptive_ttl` guards with `key in l1_layer.access_patterns` *before* subscripting,
  so the new `defaultdict` factory is not accidentally triggered by a read path. Verified.

No public signature, serialization format, or persisted artefact changes.

## Verification

### Non-vacuity

**Retained access-history dropped from 7,461,354 bytes to 587,664 — 12.7× less — while every
control metric held exactly constant.** The headline number is the leak itself, measured
directly via `sys.getsizeof` over the retained structures, not inferred from a proxy.

| metric | before (`origin/main`) | after | reading |
|---|---|---|---|
| **retained history (bytes)** | **7,461,354** | **587,664** | **the fix — 12.7× less retained** |
| cache hit rate *(control)* | 1.0000 | 1.0000 | unchanged — no correctness cost |
| `stats.total_size_bytes` *(control)* | 2,200 | 2,200 | unchanged |
| resident cache entries *(control)* | 200 | 200 | unchanged |
| workload wall time *(control)* | 0.14 s | 0.14 s | unchanged — deque append is not slower |
| tracked history keys | 5,000 | 200 | *(supporting)* orphans gone; now equals resident entries |
| retained timestamp samples | 205,000 | 12,800 | *(supporting)* consistent with 200 × 64 |

The gap between rows 1 and 3 is the point: **the layer's own accounting reports 2,200 bytes
while the process actually holds 7.1 MiB of timestamps.** Because `access_patterns` is never
added to `stats.total_size_bytes`, the `max_size_bytes` budget cannot see this memory and the
LRU can never reclaim it. Eviction — the mechanism that is supposed to bound the layer — was
the very thing creating the orphans.

Workload: 200-entry cache, 5,000 churn keys forcing continuous eviction, 200,000 reads against
a hot working set. Run 3× before and 3× after; results were byte-identical across all runs.
Harness is deterministic (no wall-clock thresholds in the headline row).

### Prove-fail

Each defect was reverted **independently**, with the other fix left in place, so neither test
pair can be passing for the wrong reason.

**A — revert only the deque factory** (`defaultdict(list)`; constant still defined, eviction pop
still present) → **2 failed, 168 passed**:

```
FAILED test_hot_key_history_stays_within_window
  AssertionError: history for a single key grew to 1280 entries after 1280 hits;
  expected it to stay within ACCESS_HISTORY_WINDOW=64
  assert 1280 <= 64
FAILED test_window_retains_the_most_recent_timestamps
  AssertionError: history retained samples recorded before the most recent 64 hits;
  the window is dropping the wrong end
```

**B — revert only the eviction pop** (deque bound still in place) → **2 failed, 168 passed**:

```
FAILED test_evicted_key_history_is_released
  AssertionError: history for an evicted key was retained; nothing will ever reclaim it
  because the cache entry is already gone
FAILED test_eviction_churn_leaves_no_orphaned_histories
  AssertionError: 195 evicted keys still have access history retained while only 5
  entries are resident; this memory is invisible to stats.total_size_bytes so the
  max_size_bytes budget can never reclaim it
```

The other 5 new tests pass in both reverted states, which is expected: they assert the
*surviving* behaviour (bounded-history arithmetic still feeding the correct adaptive-TTL tier,
resident keys keeping their history) rather than the defect under test.

### Tests added

7 tests across 4 classes in `tests/unit/test_intelligent_cache.py`:

- `TestAccessHistoryRetentionIsBounded` — the window holds, and holds the *recent* end
- `TestEvictionReleasesAccessHistory` — evicted keys release; churn leaves zero orphans;
  resident keys are **not** collateral damage
- `TestAdaptiveTtlOverBoundedHistory` — a saturated window still classifies a hot key into the
  `3600 * 4` tier, and `[0]` / `[-1]` / `len()` behave identically over a deque

All import `ACCESS_HISTORY_WINDOW` from the module rather than hardcoding 64, so the tests track
the constant if it is ever retuned.

### Commands

```
.venv/bin/python -m pytest tests/unit/test_intelligent_cache.py \
  --override-ini="addopts=" -p no:cacheprovider -p no:logging -q
170 passed in 0.22s          # 163 baseline + 7 new, zero regressions

.venv/bin/ruff check src/youtube_extension/backend/services/intelligent_cache.py
.venv/bin/ruff check tests/unit/test_intelligent_cache.py
# identical to origin/main at the same paths: src clean/clean, tests 1×I001 / 1×I001
```

Black was checked against the `origin/main` baseline for both files (27 and 21 pre-existing
hunks respectively, unchanged by this PR). No Black hunk covers any line this PR adds; the one
hunk mentioning `access_patterns` is a pre-existing single→double-quote nit at line 732 that is
already present on `main` and is deliberately left alone.

## Production evidence

No production telemetry is attached, and I would rather say so than dress up the bench numbers
as observed traffic. The measurement above is a local harness, and the argument for shipping is
structural rather than statistical:

- Growth is **unbounded in the number of reads the process serves**, so it has no steady state —
  a long-lived worker accumulates until restart regardless of traffic shape.
- The retained memory is **invisible to the layer's own byte accounting**, so no existing
  dashboard, `get_stats()` caller, or `max_size_bytes` tuning can surface or contain it.
- The orphan path is created by **eviction**, which means the leak scales with exactly the
  workload the cache is designed for: a working set larger than `max_size`.

The bench reproduces that shape at small scale; it does not claim a specific production figure.

## Agent handoff

- [x] Canonical issue open and referenced exactly once
- [x] Change implemented using this repo's established idioms (module constant + comment style
      mirroring `TAG_WRITE_CONCURRENCY` from #1262)
- [x] Tests added; full file suite green (170 passed)
- [x] Prove-fail performed **independently per defect**, both quoted verbatim above
- [x] Benchmark run 3× before and after; deterministic
- [x] Lint parity with `origin/main` verified at real paths for ruff and Black
- [x] Behaviour change (sliding-window frequency) disclosed in `## Risk` rather than omitted
