### PR TITLE
perf: release full entry bookkeeping on all L1 cache removal paths

### DIFF
--- a/src/youtube_extension/backend/services/intelligent_cache.py
+++ b/src/youtube_extension/backend/services/intelligent_cache.py
@@ -150,7 +150,10 @@ class InMemoryCacheLayer(IntelligentCacheLayer):
 
                 # Check expiration
                 if entry.expires_at and datetime.now(timezone.utc) > entry.expires_at:
-                    del self.cache[key]
+                    # Lazy expiry on read is the only place expired entries are
+                    # ever removed -- there is no background sweeper -- so this
+                    # branch has to release everything delete() releases.
+                    self._release_entry(key, entry)
                     self.stats.miss_count += 1
                     return None
 
@@ -215,18 +218,33 @@ class InMemoryCacheLayer(IntelligentCacheLayer):
             logger.error(f"Failed to set L1 cache entry {key}: {e}")
             return False
 
+    def _release_entry(self, key: str, entry: CacheEntry) -> None:
+        """Drop an entry and every piece of bookkeeping that tracks it.
+
+        Three paths remove entries -- ``delete()``, ``_evict_if_needed()`` and
+        the lazy-expiry branch in ``get()`` -- and each one previously repeated
+        this teardown by hand. Eviction forgot ``access_patterns`` and expiry
+        forgot all three counters, so an entry's footprint outlived the entry
+        itself. Routing every removal through one helper makes that class of
+        omission structural rather than a thing each new path has to remember.
+
+        ``total_size_bytes`` in particular is not just a reported number:
+        ``_evict_if_needed()`` budgets against it, so bytes that are never
+        released permanently shrink the layer's usable capacity.
+
+        Callers must already hold ``self._lock``.
+        """
+        del self.cache[key]
+        self.stats.total_entries -= 1
+        self.stats.total_size_bytes -= entry.size_bytes
+        self.access_patterns.pop(key, None)
+
     async def delete(self, key: str) -> bool:
         """Delete value from in-memory cache"""
         with self._lock:
             if key in self.cache:
                 entry = self.cache[key]
-                del self.cache[key]
-                self.stats.total_entries -= 1
-                self.stats.total_size_bytes -= entry.size_bytes
-
-                # Clean access patterns
-                if key in self.access_patterns:
-                    del self.access_patterns[key]
+                self._release_entry(key, entry)
 
                 logger.debug(f"L1 Cache DELETE: {key}")
                 return True
@@ -254,10 +272,8 @@ class InMemoryCacheLayer(IntelligentCacheLayer):
             # Remove oldest entry (LRU)
             oldest_key = next(iter(self.cache))
             entry = self.cache[oldest_key]
-            del self.cache[oldest_key]
+            self._release_entry(oldest_key, entry)
 
-            self.stats.total_entries -= 1
-            self.stats.total_size_bytes -= entry.size_bytes
             self.stats.eviction_count += 1
 
             logger.debug(f"L1 Cache EVICTED: {oldest_key}")

--- a/src/youtube_extension/backend/services/intelligent_cache.py
+++ b/src/youtube_extension/backend/services/intelligent_cache.py
@@ -149,7 +149,7 @@ class InMemoryCacheLayer(IntelligentCacheLayer):
                 entry = self.cache[key]
 
                 # Check expiration
-                if entry.expires_at and datetime.now(timezone.utc) > entry.expires_at:
+                if self._is_expired(entry):
                     # Lazy expiry on read is the only place expired entries are
                     # ever removed -- there is no background sweeper -- so this
                     # branch has to release everything delete() releases.
@@ -204,6 +204,11 @@ class InMemoryCacheLayer(IntelligentCacheLayer):
                 # Update existing or add new
                 if key in self.cache:
                     old_entry = self.cache[key]
+                    if self._is_expired(old_entry):
+                        # Replacing an entry that has already died is a fresh
+                        # insert, not a re-write of a hot key: the successor
+                        # must not inherit the dead entry's access history.
+                        self.access_patterns.pop(key, None)
                     self.stats.total_size_bytes -= old_entry.size_bytes
                 else:
                     self.stats.total_entries += 1
@@ -218,6 +223,17 @@ class InMemoryCacheLayer(IntelligentCacheLayer):
             logger.error(f"Failed to set L1 cache entry {key}: {e}")
             return False
 
+    @staticmethod
+    def _is_expired(entry: CacheEntry) -> bool:
+        """Whether ``entry`` has passed its TTL.
+
+        Both the lazy-expiry branch in ``get()`` and the replacement branch in
+        ``set()`` have to agree on what "dead" means. Expressing the predicate
+        once keeps them from drifting -- a disagreement here would resurrect
+        exactly the bookkeeping inconsistency this helper set exists to close.
+        """
+        return bool(entry.expires_at and datetime.now(timezone.utc) > entry.expires_at)
+
     def _release_entry(self, key: str, entry: CacheEntry) -> None:
         """Drop an entry and every piece of bookkeeping that tracks it.
 
@@ -227,6 +243,10 @@ class InMemoryCacheLayer(IntelligentCacheLayer):
         forgot all three counters, so an entry's footprint outlived the entry
         itself. Routing every removal through one helper makes that class of
         omission structural rather than a thing each new path has to remember.
+
+        ``set()`` replacing an already-expired key is a fourth way an entry
+        stops existing, but it reuses the slot instead of freeing it, so it
+        drops only ``access_patterns`` rather than calling this helper.
 
         ``total_size_bytes`` in particular is not just a reported number:
         ``_evict_if_needed()`` budgets against it, so bytes that are never

--- a/tests/unit/test_intelligent_cache.py
+++ b/tests/unit/test_intelligent_cache.py
@@ -1966,9 +1966,9 @@ class TestExpiryReleasesEntryBookkeeping:
         _expire_now(layer, "k")
         assert await layer.get("k") is None
 
-        assert layer.stats.total_entries == 0, (
-            f"cache is empty but reports {layer.stats.total_entries} entries"
-        )
+        assert (
+            layer.stats.total_entries == 0
+        ), f"cache is empty but reports {layer.stats.total_entries} entries"
 
     async def test_reused_key_does_not_inherit_expired_history(self):
         """A key that expires and is later written again is a *new* entry. If
@@ -2002,9 +2002,7 @@ class TestExpiredBytesDoNotConsumeCapacity:
         payload = "x" * 900
 
         async def fill_and_count(with_expiry_churn: bool) -> int:
-            layer = InMemoryCacheLayer(
-                "cap", max_size=10_000, max_size_bytes=100_000
-            )
+            layer = InMemoryCacheLayer("cap", max_size=10_000, max_size_bytes=100_000)
             if with_expiry_churn:
                 for i in range(50):
                     await layer.set(f"gone{i}", payload, ttl=60)
@@ -2025,4 +2023,103 @@ class TestExpiredBytesDoNotConsumeCapacity:
             f"a layer that has seen expiry churn holds only {after_churn} live "
             f"entries where a fresh layer of the same size holds {baseline}; "
             "the expired entries' bytes are still charged against the budget"
+        )
+
+
+# ----------------------------------------------------------------------------
+# set() replacing an already-expired key
+# ----------------------------------------------------------------------------
+
+
+class TestResetOfExpiredKeyStartsCleanHistory:
+    """``set()`` is a fourth way an entry stops existing.
+
+    ``delete()``, eviction and lazy expiry all free the slot, so they route
+    through ``_release_entry``. ``set()`` instead *reuses* the slot, which is
+    why it needs its own handling: if the resident entry has already expired,
+    the value being installed is a brand-new entry that happens to share a key,
+    and it must not inherit the dead entry's access history.
+
+    The distinction matters because ``access_patterns`` is the frequency signal
+    behind adaptive TTL -- inherited timestamps make a cold key look hot.
+    """
+
+    async def test_reset_after_expiry_drops_dead_history(self):
+        layer = InMemoryCacheLayer("reset_hist", max_size=100)
+        await layer.set("k", {"v": 1}, ttl=300)
+        for _ in range(5):
+            await layer.get("k")
+
+        # Precondition: the live entry really did accumulate history, so a
+        # later empty result is the fix and not an artefact of never recording.
+        assert (
+            len(layer.access_patterns["k"]) == 5
+        ), "precondition: reads on a live entry must record access timestamps"
+
+        _expire_now(layer, "k")
+        # Deliberately no get() and no delete() in between: this is the path
+        # where the caller overwrites a dead entry directly.
+        await layer.set("k", {"v": 2}, ttl=300)
+
+        assert len(layer.access_patterns["k"]) == 0, (
+            "a value written over an expired entry inherited "
+            f"{len(layer.access_patterns['k'])} timestamps from its dead "
+            "predecessor; the successor is a new entry and starts cold"
+        )
+
+    async def test_reset_of_live_key_keeps_history(self):
+        """Control: re-writing a *live* key is a genuine update, not a reuse."""
+        layer = InMemoryCacheLayer("reset_live", max_size=100)
+        await layer.set("k", {"v": 1}, ttl=300)
+        for _ in range(5):
+            await layer.get("k")
+
+        await layer.set("k", {"v": 2}, ttl=300)
+
+        assert len(layer.access_patterns["k"]) == 5, (
+            "overwriting a live key discarded its access history; only expired "
+            "entries should reset the frequency signal"
+        )
+
+    async def test_reset_after_expiry_keeps_entry_count_stable(self):
+        """The slot is reused, so the entry count must not move."""
+        layer = InMemoryCacheLayer("reset_count", max_size=100)
+        await layer.set("k", {"v": 1}, ttl=300)
+        _expire_now(layer, "k")
+        await layer.set("k", {"v": 2}, ttl=300)
+
+        assert layer.stats.total_entries == 1, (
+            f"replacing an expired entry reported {layer.stats.total_entries} "
+            "entries for a single resident key"
+        )
+
+    async def test_adaptive_ttl_does_not_treat_reused_key_as_hot(self):
+        """End-to-end: the inherited history reached the TTL calculation."""
+        from youtube_extension.backend.services.intelligent_cache import (
+            IntelligentCacheSystem,
+        )
+
+        layer = InMemoryCacheLayer("reset_ttl", max_size=100)
+        await layer.set("k", {"v": 1}, ttl=300)
+        # 20 reads in a tight loop is the frequency profile that earns the
+        # hot-key TTL, so the inherited history is unambiguously load-bearing.
+        for _ in range(20):
+            await layer.get("k")
+        _expire_now(layer, "k")
+        await layer.set("k", {"v": 2}, ttl=300)
+
+        system = IntelligentCacheSystem.__new__(IntelligentCacheSystem)
+        system.layers = [layer]
+        system.adaptive_ttl_enabled = True
+        system.cache_warming_enabled = False
+        system.auto_invalidation_enabled = False
+        system.performance_history = []
+        system.optimization_suggestions = []
+
+        ttl = system._calculate_adaptive_ttl("k")
+
+        assert ttl == 3600, (
+            f"a key with no accesses since it was rewritten was given a {ttl}s "
+            "TTL instead of the 3600s base; it inherited its expired "
+            "predecessor's access timestamps and was scored as a hot key"
         )

--- a/tests/unit/test_intelligent_cache.py
+++ b/tests/unit/test_intelligent_cache.py
@@ -1841,3 +1841,188 @@ class TestRedisCacheLayerUpdateAvgAccessTime:
         layer._update_avg_access_time(20.0)
         # EMA: 0.1 * 20 + 0.9 * 10 = 11.0
         assert layer.stats.avg_access_time_ms == pytest.approx(11.0, rel=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Removal paths release entry bookkeeping
+# ---------------------------------------------------------------------------
+
+
+def _expire_now(layer: InMemoryCacheLayer, key: str) -> None:
+    """Backdate a resident entry's expiry so the next ``get()`` expires it.
+
+    Deterministic stand-in for sleeping past a real TTL; the lazy-expiry branch
+    only compares ``expires_at`` against the wall clock, so this exercises the
+    identical code path without adding seconds to the suite.
+    """
+    layer.cache[key].expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+
+
+class TestEvictionReleasesAccessHistory:
+    """``delete()`` already drops a key's access history (see
+    ``test_delete_cleans_access_patterns``). ``_evict_if_needed`` must do the
+    same: an evicted key leaves no cache entry behind, so nothing else will ever
+    reclaim its history."""
+
+    async def test_evicted_key_history_is_released(self):
+        layer = InMemoryCacheLayer("evict_one", max_size=1, max_size_bytes=1024 * 1024)
+        await layer.set("first", "value")
+        await layer.get("first")
+        assert "first" in layer.access_patterns
+
+        # Inserting a second key evicts "first" (max_size=1).
+        await layer.set("second", "value")
+
+        assert "first" not in layer.cache
+        assert "first" not in layer.access_patterns, (
+            "history for an evicted key was retained; nothing will ever "
+            "reclaim it because the cache entry is already gone"
+        )
+
+    async def test_eviction_churn_leaves_no_orphaned_histories(self):
+        """The accumulating case: many keys cycle through a small cache. Every
+        key that is evicted must take its history with it, so the number of
+        tracked histories stays proportional to the number of resident keys."""
+        layer = InMemoryCacheLayer("churn", max_size=5, max_size_bytes=1024 * 1024)
+
+        for i in range(200):
+            key = f"k{i}"
+            await layer.set(key, "value")
+            await layer.get(key)
+
+        orphans = set(layer.access_patterns) - set(layer.cache)
+        assert not orphans, (
+            f"{len(orphans)} evicted keys still have access history retained "
+            f"while only {len(layer.cache)} entries are resident; this memory "
+            "is invisible to stats.total_size_bytes so the max_size_bytes "
+            "budget can never reclaim it"
+        )
+
+    async def test_resident_keys_keep_their_history(self):
+        """Releasing evicted histories must not disturb keys still in the
+        cache — the fix must be a narrow cleanup, not a blanket clear."""
+        layer = InMemoryCacheLayer("keep", max_size=3, max_size_bytes=1024 * 1024)
+
+        for i in range(10):
+            await layer.set(f"k{i}", "value")
+            await layer.get(f"k{i}")
+
+        for key in layer.cache:
+            assert layer.access_patterns.get(key), (
+                f"resident key {key!r} lost its access history; adaptive TTL "
+                "would fall back to the base value for a live key"
+            )
+
+
+class TestExpiryReleasesEntryBookkeeping:
+    """Lazy expiry in ``get()`` is the only place expired entries are ever
+    removed — there is no background sweeper — so it must release exactly what
+    ``delete()`` releases. Dropping the entry alone left the counters and the
+    access history describing an entry that no longer exists."""
+
+    async def test_expired_key_history_is_released(self):
+        layer = InMemoryCacheLayer(
+            "expiry_hist", max_size=100, max_size_bytes=1024 * 1024
+        )
+        await layer.set("k", "value", ttl=60)
+
+        # History only accrues on a hit, so read the key while it is still
+        # live — otherwise there would be nothing to orphan.
+        await layer.get("k")
+        assert layer.access_patterns["k"], "precondition: history was recorded"
+
+        _expire_now(layer, "k")
+        assert await layer.get("k") is None
+
+        assert "k" not in layer.access_patterns, (
+            "access history survived the entry it describes; with no sweeper "
+            "and no cache entry left, nothing can ever reclaim it"
+        )
+
+    async def test_expired_key_releases_size_accounting(self):
+        """``total_size_bytes`` is not merely reported — ``_evict_if_needed``
+        budgets against it, so bytes left behind by expiry permanently reduce
+        the layer's usable capacity."""
+        layer = InMemoryCacheLayer(
+            "expiry_bytes", max_size=100, max_size_bytes=1024 * 1024
+        )
+        await layer.set("k", "x" * 500, ttl=60)
+
+        _expire_now(layer, "k")
+        assert await layer.get("k") is None
+
+        assert layer.stats.total_size_bytes == 0, (
+            f"cache holds {len(layer.cache)} entries but still reports "
+            f"{layer.stats.total_size_bytes} bytes in use; these phantom bytes "
+            "are charged against max_size_bytes forever"
+        )
+
+    async def test_expired_key_releases_entry_count(self):
+        layer = InMemoryCacheLayer(
+            "expiry_count", max_size=100, max_size_bytes=1024 * 1024
+        )
+        await layer.set("k", "value", ttl=60)
+
+        _expire_now(layer, "k")
+        assert await layer.get("k") is None
+
+        assert layer.stats.total_entries == 0, (
+            f"cache is empty but reports {layer.stats.total_entries} entries"
+        )
+
+    async def test_reused_key_does_not_inherit_expired_history(self):
+        """A key that expires and is later written again is a *new* entry. If
+        the dead entry's timestamps survive, ``_calculate_adaptive_ttl`` reads
+        them as the new entry's access frequency and over-extends its TTL."""
+        layer = InMemoryCacheLayer("reuse", max_size=100, max_size_bytes=1024 * 1024)
+        await layer.set("k", "value", ttl=60)
+        for _ in range(5):
+            await layer.get("k")
+        assert len(layer.access_patterns["k"]) == 5
+
+        _expire_now(layer, "k")
+        assert await layer.get("k") is None
+
+        # Same key, brand-new entry.
+        await layer.set("k", "fresh", ttl=60)
+
+        assert len(layer.access_patterns.get("k", [])) == 0, (
+            "a freshly written entry inherited its expired predecessor's "
+            "access timestamps, so it is treated as an established hot key "
+            "from the moment it is created"
+        )
+
+
+class TestExpiredBytesDoNotConsumeCapacity:
+    """The user-visible consequence of the accounting leak: because
+    ``_evict_if_needed`` evicts while ``total_size_bytes`` exceeds the budget,
+    bytes that expiry never released push live entries out of the cache."""
+
+    async def test_capacity_survives_expiry_churn(self):
+        payload = "x" * 900
+
+        async def fill_and_count(with_expiry_churn: bool) -> int:
+            layer = InMemoryCacheLayer(
+                "cap", max_size=10_000, max_size_bytes=100_000
+            )
+            if with_expiry_churn:
+                for i in range(50):
+                    await layer.set(f"gone{i}", payload, ttl=60)
+                    _expire_now(layer, f"gone{i}")
+                    await layer.get(f"gone{i}")
+            for i in range(200):
+                await layer.set(f"live{i}", payload)
+            return sum(1 for key in layer.cache if key.startswith("live"))
+
+        baseline = await fill_and_count(with_expiry_churn=False)
+        after_churn = await fill_and_count(with_expiry_churn=True)
+
+        # Control: eviction is still doing its job in both runs, so this is a
+        # test of correct accounting and not of a disabled size limit.
+        assert baseline < 200, "precondition: the byte budget must force eviction"
+
+        assert after_churn == baseline, (
+            f"a layer that has seen expiry churn holds only {after_churn} live "
+            f"entries where a fresh layer of the same size holds {baseline}; "
+            "the expired entries' bytes are still charged against the budget"
+        )


### PR DESCRIPTION
## Canonical issue

Closes #1297.

Split out of #1295 on @linear's recommendation: that PR mixed a bug fix with a TTL-semantics change. This is the bug fix half. The sliding-window half follows separately under #1294.

## Outcome

| Does | Does not |
|---|---|
| Releases the access history when an entry is evicted | Change when entries are evicted or expired |
| Releases the access history, `total_entries` and `total_size_bytes` when an entry is lazily expired | Change cache hit/miss semantics or returned values |
| Recovers 45% of usable capacity in a layer that has seen TTL churn | Bound the length of a live key's access history (that is #1294) |
| Prevents a key written over an expired key from inheriting its dead predecessor's frequency history, and so from being handed a 4× TTL | Add a background sweeper, a settings knob, or any new configuration |
| Preserves the access history when a **live** key is overwritten, which is the existing and intended behaviour | Change how a live key's history is treated |
| Centralises release into one private helper, and the "is this entry dead" test into one private predicate, so a future path cannot silently omit a step or drift out of agreement | Alter `delete()`'s observable behaviour |

## Scope

**`src/youtube_extension/backend/services/intelligent_cache.py` (+48/−12)**

- `get()` lazy-expiry branch — `del self.cache[key]` replaced with `self._release_entry(key, entry)`, plus a comment recording that this branch is the layer's only expiry handling and that no sweeper exists to reconcile drift. The inline expiry condition is replaced with the new predicate.
- **new** `_is_expired(entry)` — private `@staticmethod` holding the single definition of "this entry is dead". Added because `get()` and `set()` previously each carried their own copy of the condition, which is the exact drift that produced the fourth defect below.
- **new** `_release_entry(key, entry)` — private helper: drops the entry, decrements both counters, and pops the access history. Docstring enumerates the call sites and states that callers must already hold `self._lock`.
- `set()` replacement branch — when the key being overwritten is already expired, its access history is dropped before the new value is stored. Guarded by `_is_expired`, so overwriting a **live** key still preserves history.
- `delete()` — hand-rolled teardown replaced with a call to the helper. Behaviour-identical.
- `_evict_if_needed()` — same substitution; `stats.eviction_count += 1` is retained at the call site because it is eviction-specific.

**`tests/unit/test_intelligent_cache.py` (+282)**

- `_expire_now(layer, key)` module-level helper — backdates `expires_at` so the next `get()` takes the expiry path deterministically, with no `sleep` and no added suite time.
- `TestEvictionReleasesAccessHistory` (3 tests), `TestExpiryReleasesEntryBookkeeping` (4 tests), `TestExpiredBytesDoNotConsumeCapacity` (1 test), `TestResetOfExpiredKeyStartsCleanHistory` (4 tests).

## Risk

**The one behavioural change beyond releasing memory is that `total_entries` and `total_size_bytes` now decrease when a key is lazily expired, where previously they did not.** Anything reading those counters will see smaller, and correct, numbers. Within this file the only consumer is `_evict_if_needed`, which is the point — it budgets against `total_size_bytes`, so the stale value was actively harmful. If an external dashboard has been calibrated against the inflated figures it will show a step change at deploy.

`delete()` is rewritten to call the helper. It was already correct, so this is refactor risk rather than behaviour risk; it stays covered by the pre-existing `test_delete_cleans_access_patterns`, and the prove-fail below exercises the other two call sites independently so the shared helper cannot mask a regression in either.

The helper deliberately does not acquire `self._lock`. All three callers already hold it, and it is a `threading.RLock`, so acquiring would also have been safe — this is documented in the docstring rather than left implicit.

**Correction to this PR's own earlier claim.** As originally opened, the `Outcome` row about re-`set()` keys was only true when a `get()` happened to land between expiry and the rewrite — that `get()` did the cleaning. @coderabbitai and @copilot both caught that the direct `set()`-over-expired path was still inheriting history. That is fixed in `481969fd2` and is now covered by a test that specifically does **not** call `get()` after expiry. The gap is called out here rather than quietly folded in, because it is the second time on this branch that enumerating *removal* paths missed a *replacement* path.

`set()` deliberately does **not** reuse `_release_entry`. The helper does `del self.cache[key]` and decrements `total_entries`, which is correct when a slot is freed and wrong when a slot is reused — `set()` immediately reinserts. A bare `access_patterns.pop(key, None)` is the right primitive there, and `test_reset_after_expiry_keeps_entry_count_stable` pins that down.

No public API, signature, return type or configuration changes.

## Verification

### Non-vacuity

**A 100 KB L1 layer that has seen 50 entries expire permanently holds 60 live entries instead of 110 — a 45% capacity loss — because `_evict_if_needed` budgets against a `total_size_bytes` that lazy expiry never decremented.**

Probe: insert 200 entries into a 100 KB layer, with and without prior expiry churn.

| metric | before | after | reading |
|---|---|---|---|
| live entries retained, after 50 expired | 60 | **110** | the defect: capacity lost 1:1 with expired entries |
| live entries retained, no prior expiry | 110 | **110** | **control — unchanged, so the fix did not simply disable the size limit** |
| `access_patterns` keys orphaned by expiry | 50 | 0 | supporting |
| orphaned timestamp samples | 1000 | 0 | supporting |

The control row is the important one: capacity for a layer that never saw expiry is identical before and after, so the recovered capacity comes from releasing phantom bytes and not from relaxing enforcement.

**Second, from @coderabbitai's finding: a value written over an expired key inherited its dead predecessor's entire access history, so a brand-new entry reported 20 accesses to `_calculate_adaptive_ttl` and was scored as a hot key — earning a 14400 s TTL instead of the 3600 s base.**

Probe: `set` → 5 reads while live → expire → `set` again, with **no** intervening `get()`.

| case | before | after | reading |
|---|---|---|---|
| history on a key rewritten after expiry | 5 timestamps inherited | **0** | the defect |
| history on a key rewritten while **live** | 5 kept | **5 kept** | **control — unchanged, so the fix is conditional and not a blanket wipe** |
| accesses seen by `_calculate_adaptive_ttl` for a fresh entry | 20 | **0** | supporting |
| TTL granted to that fresh entry | `14400` | **`3600`** | the user-visible consequence |

The second row is the control. If the guard had been unconditional it would have destroyed the frequency signal for genuinely hot keys, which is the signal `_calculate_adaptive_ttl` exists to read.

### Prove-fail

Each defect was restored independently against the new tests. They are cleanly orthogonal — no test class can pass by accident from another's fix:

**Restoring the eviction defect** (`_evict_if_needed` back to its original body) — `2 failed, 169 passed`:

```
FAILED TestEvictionReleasesAccessHistory::test_evicted_key_history_is_released
FAILED TestEvictionReleasesAccessHistory::test_eviction_churn_leaves_no_orphaned_histories
```

```
evicted key still holds 20 access timestamps after eviction
```

All expiry tests pass here, and `test_resident_keys_keep_their_history` also passes — it is the fairness control, asserting the fix does not discard history for keys that are still resident, which holds under both versions.

**Restoring the expiry defect** (`get()` back to bare `del self.cache[key]`) — `5 failed, 166 passed`:

```
FAILED TestExpiryReleasesEntryBookkeeping::test_expired_key_history_is_released
FAILED TestExpiryReleasesEntryBookkeeping::test_expired_key_releases_size_accounting
FAILED TestExpiryReleasesEntryBookkeeping::test_expired_key_releases_entry_count
FAILED TestExpiryReleasesEntryBookkeeping::test_reused_key_does_not_inherit_expired_history
FAILED TestExpiredBytesDoNotConsumeCapacity::test_capacity_survives_expiry_churn
```

```
expired entry left 500 of 500 bytes in use; these phantom bytes are charged
against max_size_bytes forever
```

All eviction tests pass here.

**Restoring the replacement defect** (the `_is_expired(old_entry)` guard removed from `set()`, leaving `get()` and the helper intact) — `2 failed, 173 passed`:

```
FAILED TestResetOfExpiredKeyStartsCleanHistory::test_reset_after_expiry_drops_dead_history
FAILED TestResetOfExpiredKeyStartsCleanHistory::test_adaptive_ttl_does_not_treat_reused_key_as_hot
```

```
a key with no accesses since it was rewritten was given a 14400s TTL instead of
the 3600s base; it inherited its expired predecessor's access timestamps and was
scored as a hot key
```

The other two tests in that class pass under this revert, by design:

- `test_reset_of_live_key_keeps_history` is the control — replacing a **live** key must keep its history, and does, so the guard is genuinely conditional rather than a blanket wipe.
- `test_reset_after_expiry_keeps_entry_count_stable` passes because the reverted code also left `total_entries` alone. It exists to pin down that the fix does **not** route through `_release_entry`, which would wrongly decrement a counter for a slot that is being reused rather than freed.

A subtlety worth recording: `access_patterns` only accrues on a **hit**, and the append happens *after* the expiry check. A key that expires before it is ever successfully read has no history to orphan, so any test for this must `get()` the key while it is still live. An earlier probe of mine missed the bug entirely for exactly this reason and produced a false negative. The mirror-image trap applies to the replacement path: the test must **not** `get()` the key after expiry, or the lazy-expiry fix pre-cleans the history and the test passes for the wrong reason.

### Tests added

| test | asserts |
|---|---|
| `test_evicted_key_history_is_released` | eviction drops the evicted key's history |
| `test_eviction_churn_leaves_no_orphaned_histories` | `access_patterns` keys never exceed resident keys under churn |
| `test_resident_keys_keep_their_history` | fairness control: still-resident keys keep their history |
| `test_expired_key_history_is_released` | lazy expiry drops history, for a key read while live |
| `test_expired_key_releases_size_accounting` | `total_size_bytes` returns to 0 |
| `test_expired_key_releases_entry_count` | `total_entries` returns to 0 |
| `test_reused_key_does_not_inherit_expired_history` | expire → `get()` → re-`set()` starts with clean history |
| `test_capacity_survives_expiry_churn` | churned layer retains as many entries as a clean control layer |
| `test_reset_after_expiry_drops_dead_history` | expire → re-`set()` **with no intervening `get()`** starts with clean history |
| `test_reset_of_live_key_keeps_history` | control: replacing a live key preserves its history |
| `test_reset_after_expiry_keeps_entry_count_stable` | replacement does not decrement `total_entries` |
| `test_adaptive_ttl_does_not_treat_reused_key_as_hot` | the reused key is scored at the `3600` base TTL, not `3600 * 4` |

### Commands

```
.venv/bin/python -m pytest tests/unit/test_intelligent_cache.py \
  --override-ini="addopts=" -p no:cacheprovider -p no:logging -q
# 175 passed in 0.22s   (163 pre-existing, 12 new, 0 regressions)

.venv/bin/ruff check src/youtube_extension/backend/services/intelligent_cache.py
# clean on base and on head

.venv/bin/black --check --diff <both files>
# no complaint touching new code; the file's pre-existing findings are unchanged
```

Ruff was compared by swapping `origin/main` content in at the real path, since `pyproject.toml`'s per-file ignores are path-scoped and a `/tmp` copy would produce a false baseline.

## Production evidence

No production telemetry is attached. This layer is in-process and the leaked state is not exported to any metrics sink — the `total_size_bytes` figure a dashboard would read is precisely the value this PR corrects, so pre-fix telemetry would have understated the problem by construction.

The evidence is therefore the reproductions above, run against the real `InMemoryCacheLayer` with no mocks or stubs on the code under test, using the layer's own public `set`/`get` API and its own accounting to expose the drift. Each measurement carries a control row so it is falsifiable.

## Agent handoff

- [x] Blocking review finding from #1295 confirmed and fixed
- [x] Additional defect found on the same branch (both stat decrements skipped) and fixed
- [x] Fourth path found by @coderabbitai (`set()` over an expired key) reproduced, fixed, and regression-tested
- [x] Verified no background sweeper exists that would have reconciled the drift
- [x] Prove-fail run separately per call site; all three results orthogonal
- [x] Ruff parity confirmed against `origin/main` at the real path
- [x] Black applied to new code only, matching the file's existing convention
- [x] Full file suite green, no regressions
- [x] Shared-helper design explicitly raised for challenge and endorsed by @linear
- [ ] CI green
