### PR TITLE
perf: bound L1 access history, adopt trailing-window TTL

### DIFF
--- a/src/youtube_extension/backend/services/intelligent_cache.py
+++ b/src/youtube_extension/backend/services/intelligent_cache.py
@@ -22,7 +22,7 @@ import logging
 import statistics
 import threading
 import time
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict, defaultdict, deque
 from dataclasses import asdict, dataclass
 
 # pickle removed for security
@@ -55,6 +55,16 @@ def _resolve_tag_write_limit(max_connections: int) -> int:
     its own pool. Always at least 1 so tag writes can still make progress.
     """
     return max(1, min(TAG_WRITE_CONCURRENCY, max_connections - TAG_WRITE_POOL_RESERVE))
+
+
+# Hit timestamps retained per key to drive _calculate_adaptive_ttl(). That
+# consumer reads only the first element, the last element and the length, so the
+# window only has to be long enough for the ratio between them to be a stable
+# frequency estimate rather than a two-sample artefact. Bounding it keeps L1's
+# footprint proportional to the number of resident keys instead of to the total
+# number of reads the process has ever served.
+ACCESS_HISTORY_WINDOW = 64
+
 
 class DateTimeEncoder(json.JSONEncoder):
     """JSON encoder that handles datetime objects"""
@@ -138,7 +148,11 @@ class InMemoryCacheLayer(IntelligentCacheLayer):
         super().__init__(name, max_size)
         self.max_size_bytes = max_size_bytes
         self.cache: OrderedDict[str, CacheEntry] = OrderedDict()
-        self.access_patterns = defaultdict(list)  # Track access patterns for intelligent TTL
+        # Bounded per key: see ACCESS_HISTORY_WINDOW. The whole entry is dropped
+        # when the key leaves the cache, via _release_entry().
+        self.access_patterns = defaultdict(
+            lambda: deque(maxlen=ACCESS_HISTORY_WINDOW)
+        )  # Track access patterns for intelligent TTL
 
     async def get(self, key: str) -> Optional[Any]:
         """Get value from in-memory cache"""

--- a/tests/unit/test_intelligent_cache.py
+++ b/tests/unit/test_intelligent_cache.py
@@ -2123,3 +2123,120 @@ class TestResetOfExpiredKeyStartsCleanHistory:
             "TTL instead of the 3600s base; it inherited its expired "
             "predecessor's access timestamps and was scored as a hot key"
         )
+
+
+# ---------------------------------------------------------------------------
+# InMemoryCacheLayer — access-history retention is bounded
+# ---------------------------------------------------------------------------
+
+
+class TestAccessHistoryRetentionIsBounded:
+    """A key that is read repeatedly must not accumulate one timestamp per hit
+    forever. Before this was bounded, ``access_patterns[key]`` was a plain list
+    appended to on every cache hit and never trimmed, so a hot key's history
+    grew without limit for as long as the key stayed resident."""
+
+    async def test_hot_key_history_stays_within_window(self):
+        from youtube_extension.backend.services.intelligent_cache import (
+            ACCESS_HISTORY_WINDOW,
+        )
+
+        layer = InMemoryCacheLayer("hot", max_size=100, max_size_bytes=1024 * 1024)
+        await layer.set("hot", "value")
+
+        hits = ACCESS_HISTORY_WINDOW * 20
+        for _ in range(hits):
+            await layer.get("hot")
+
+        # Precondition: the key is still resident, so nothing released its
+        # history behind our back and the count below is the retention policy.
+        assert "hot" in layer.cache, "key was evicted; this is not a retention test"
+
+        retained = len(layer.access_patterns["hot"])
+        assert retained <= ACCESS_HISTORY_WINDOW, (
+            f"history for a single resident key grew to {retained} entries "
+            f"after {hits} hits; expected it to stay within "
+            f"ACCESS_HISTORY_WINDOW={ACCESS_HISTORY_WINDOW}"
+        )
+
+    async def test_window_retains_the_most_recent_timestamps(self):
+        """Bounding must drop the oldest samples, not the newest, so the
+        retained window still describes current behaviour."""
+        from youtube_extension.backend.services.intelligent_cache import (
+            ACCESS_HISTORY_WINDOW,
+        )
+
+        layer = InMemoryCacheLayer("recent", max_size=100, max_size_bytes=1024 * 1024)
+        await layer.set("k", "value")
+
+        for _ in range(ACCESS_HISTORY_WINDOW):
+            await layer.get("k")
+        boundary = time.time()
+        for _ in range(ACCESS_HISTORY_WINDOW):
+            await layer.get("k")
+
+        retained = list(layer.access_patterns["k"])
+        assert retained == sorted(retained), "retained timestamps lost their ordering"
+        assert all(ts >= boundary for ts in retained), (
+            "history retained samples recorded before the most recent "
+            f"{ACCESS_HISTORY_WINDOW} hits; the window is dropping the wrong end"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Adaptive TTL still consumes the bounded history
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptiveTtlOverBoundedHistory:
+    """``_calculate_adaptive_ttl`` reads ``accesses[0]``, ``accesses[-1]`` and
+    ``len(accesses)``. Those must keep working over the bounded container, and
+    a saturated window must still classify a hot key as high-frequency."""
+
+    def _make_system(self, layer):
+        from youtube_extension.backend.services.intelligent_cache import (
+            IntelligentCacheSystem,
+        )
+
+        system = IntelligentCacheSystem.__new__(IntelligentCacheSystem)
+        system.layers = [layer]
+        system.adaptive_ttl_enabled = True
+        system.cache_warming_enabled = False
+        system.auto_invalidation_enabled = False
+        system.performance_history = []
+        system.optimization_suggestions = []
+        return system
+
+    async def test_saturated_window_still_yields_high_frequency_ttl(self):
+        """The window holds only the tail of a burst, but that tail is itself a
+        tight burst, so the frequency estimate must still read as hot."""
+        from youtube_extension.backend.services.intelligent_cache import (
+            ACCESS_HISTORY_WINDOW,
+        )
+
+        layer = InMemoryCacheLayer("ttl", max_size=10, max_size_bytes=1024 * 1024)
+        await layer.set("k", "value")
+        # Far more hits than the window holds, all in a tight burst.
+        for _ in range(ACCESS_HISTORY_WINDOW * 5):
+            await layer.get("k")
+
+        system = self._make_system(layer)
+        ttl = system._calculate_adaptive_ttl("k")
+        assert ttl == 3600 * 4, (
+            f"a saturated access window produced a {ttl}s TTL; a key read "
+            f"{ACCESS_HISTORY_WINDOW * 5} times in a burst should still be "
+            "classified as high-frequency"
+        )
+
+    async def test_indexing_and_len_work_over_bounded_history(self):
+        """Guards the three container operations _calculate_adaptive_ttl uses.
+        A container that bounded retention but broke indexing would silently
+        send every key back to the base TTL."""
+        layer = InMemoryCacheLayer("idx", max_size=10, max_size_bytes=1024 * 1024)
+        await layer.set("k", "value")
+        for _ in range(5):
+            await layer.get("k")
+
+        accesses = layer.access_patterns["k"]
+        assert len(accesses) == 5, "len() over the history container is wrong"
+        assert accesses[0] <= accesses[-1], "first/last indexing is not ordered"


### PR DESCRIPTION
## Canonical issue

Closes #1294.

## Outcome

**This change does two coupled things, and the second one is deliberate.** It bounds
each resident key's hit-timestamp history, and — as a direct and inseparable
consequence — moves `_calculate_adaptive_ttl` from a lifetime-average frequency
estimate to a trailing-window one. The second is not scope that crept in: the list
being bounded *is* the list the TTL estimator reads, so there is no version of this
containment that leaves TTL semantics untouched, short of retaining an unbounded
copy purely for the estimator — which forfeits the entire saving. Both effects are
measured below, the TTL one in `## Risk`.

| Does | Does not |
|---|---|
| Bounds each resident key's hit-timestamp history to `ACCESS_HISTORY_WINDOW = 64` | Change when history is *created* — still one append per hit |
| Change the growth basis of L1's access history from **reads served** to **resident keys** | Change any cache-entry payload, key, TTL storage, or serialization |
| **Move `_calculate_adaptive_ttl` to a trailing-window frequency estimate** — deliberate and coupled, measured in `## Risk` | Change the adaptive-TTL thresholds (0.1 → 4x, 0.01 → 2x) or how they are applied |
| Leave entry count, `total_size_bytes`, eviction and expiry behaviour untouched | Add a sweeper, a settings knob, or any background task |
| Keep the hot path O(1) — `deque(maxlen=)` evicts on append | Alter `_release_entry()` / `_is_expired()` from #1298 |

## Scope

```
 src/youtube_extension/backend/services/intelligent_cache.py   (+16/−2)
 tests/unit/test_intelligent_cache.py                          (+117/−0)
```

- `intelligent_cache.py`
  - import `deque` from `collections`
  - new module constant `ACCESS_HISTORY_WINDOW = 64` with a comment explaining
    what the window has to be long enough to do
  - `self.access_patterns = defaultdict(list)` → `defaultdict(lambda: deque(maxlen=ACCESS_HISTORY_WINDOW))`
- `test_intelligent_cache.py` — two new classes, four tests, appended at EOF.

No other call site changed. Every use of `access_patterns` in `src/` (9 references,
all in this file) is `append` / `pop` / `clear` / `in` / `len` / `[0]` / `[-1]` —
no slicing, no `extend`, no `+=`, no list-only method. The structure is a
drop-in.

## Risk

**The real risk is a semantics change, not a memory change: `_calculate_adaptive_ttl`
now estimates frequency over a trailing window instead of the key's whole lifetime.**
`frequency = len(accesses) / (accesses[-1] - accesses[0])`. Truncating the front of
the list changes both the numerator and the denominator, so the estimate can move.

I measured exactly when it moves, with synthetic timestamps across five access
patterns:

| access pattern | before | after | reading |
|---|---|---|---|
| hot burst (500 hits / 1s) | 14400s | 14400s | identical |
| uniform, 1 hit / 20s (300 hits) | 7200s | 7200s | identical |
| cold (2 hits / 1h) | 3600s | 3600s | identical |
| **was hot, then quiet 2.5h** | **7200s** | **3600s** | **diverges** |
| **was quiet, now bursting** | **7200s** | **14400s** | **diverges** |

For any *uniform* rate the two agree exactly — `len / time_span` is scale-free
under uniform sampling, so truncation cancels. They diverge only when the key's
rate **changed**. In both divergent cases the window reports the key's current
behaviour and the unbounded list reports a lifetime average skewed by history the
key has outgrown: a key that was hot two hours ago and is now idle stops being
given a 2x TTL, and a key that has just started bursting gets its 4x TTL
immediately instead of waiting for its dead history to be diluted.

I am claiming this is an improvement, and I want to be explicit that **it is a
behaviour change and it is load-bearing**, not a no-op. The strictly-memory-only
alternative is to keep an unbounded copy purely for the TTL calculation — which
forfeits the entire saving, since that list is the thing being bounded.

**Reviewed and settled.** This was put to review explicitly as "should the TTL
semantics be pulled out into a separate follow-up?", and the answer was no: the
shift is inseparable from the retention change rather than hidden extra scope, the
divergence is measured rather than accidental, and it ships as one change. The
condition attached to that was that the writeup say so plainly instead of selling
this as memory-only — which is what the title and `## Outcome` above now do.

Secondary risks:

- **Window size is a judgement call.** 64 is large enough that
  `len/(last-first)` is a rate rather than a two-sample artefact, and small
  enough that 10k resident keys cost ~2.7 MiB of history. It is a module
  constant, not a setting, per the guidance on #1295 — there is no telemetry
  that would let anyone tune it, so a knob would just be an untestable branch.
- **Not a correctness fix.** Nothing was returning wrong results. This is a
  containment change.
- Entry-lifecycle bookkeeping (eviction / lazy expiry / expired-key replacement)
  is deliberately **not** touched here — that was #1297 / PR #1298, already on
  `main`. This PR is only about the growth of a *resident* key's history, which
  #1298 does not address and cannot address.

## Verification

### Non-vacuity

Probe: 500 resident keys, 2,000 hits each — 1,000,000 reads. Nothing is evicted
or expired, so every key is a live resident key throughout.

**Retained access history: 31,340 KiB → 1,379 KiB (22.7x, 29,961 KiB released).**

Controls, measured in the same run:

| control | before | after |
|---|---|---|
| `total_size_bytes` reported by the cache | 1.5 KiB | 1.5 KiB |
| resident entries | 500 | 500 |
| adaptive TTL for hot key `k0` | 14400s | 14400s |

The headline number is what makes the case, and the first control is what makes
the case *interesting*: **30.6 MiB of history against 1.5 KiB of accounted
payload.** `CacheStats` counts `CacheEntry.size_bytes` only, so neither the byte
budget nor the entry budget can see this memory, let alone reclaim it.

Supporting: retained timestamps per key 2,000 → 64; total 1,000,000 → 32,000.

The framing that matters is not the ratio, which is an artefact of how long I ran
the probe. It is that **before, retention was a function of reads served, and
after, it is a function of resident keys** — a quantity the cache already bounds
by two independent budgets. The 22.7x doubles if I double the read count and the
new number does not move.

### Prove-fail

Reverted **only the bound** — `deque(maxlen=ACCESS_HISTORY_WINDOW)` back to
`list` — while deliberately **keeping `ACCESS_HISTORY_WINDOW` defined**, so the
tests fail on their assertions rather than on `ImportError`:

```
2 failed, 177 passed
assert 1280 <= 64
```

The two failures are the retention tests. **The two adaptive-TTL tests passed
under the revert** — they are supposed to, because they assert that the TTL
calculation is *correct*, which it is with or without the bound. That is the
point of including them: they prove the two failing tests are detecting the
bound specifically, and are not vacuously coupled to the edit.

Restoring the bound: **179 passed**.

### Tests added

| test | asserts |
|---|---|
| `test_hot_key_history_stays_within_window` | after 200 hits on a key that is still resident (precondition asserted), retention ≤ 64 |
| `test_window_retains_the_most_recent_timestamps` | retained samples are ordered and all ≥ a mid-run boundary — i.e. the *newest* are kept, not the oldest |
| `test_saturated_window_still_yields_high_frequency_ttl` | a hot key with a saturated window still gets `base_ttl * 4` |
| `test_indexing_and_len_work_over_bounded_history` | `len`, `[0]`, `[-1]` behave over a deque as `_calculate_adaptive_ttl` requires |

The last two are the fairness controls described above.

### Commands

```
.venv/bin/python -m pytest tests/unit/test_intelligent_cache.py \
  --override-ini="addopts=" -p no:cacheprovider -p no:logging -q
# 179 passed

.venv/bin/ruff check src/youtube_extension/backend/services/intelligent_cache.py \
                     tests/unit/test_intelligent_cache.py
# identical code set to origin/main for both files (parity checked by content swap
# in place, since ruff per-file-ignores are path-scoped)

.venv/bin/black --check --diff <both files>
# every one of the 135 added lines survives Black verbatim
```

## Production evidence

No production telemetry is attached, and I do not want to imply otherwise. This
memory is invisible to the cache's own metrics — that is the substance of the
issue — so there is no existing dashboard that would have shown it and none that
will show it shrink.

The evidence is the probe above, which drives the real `InMemoryCacheLayer` on
the real code path (`await layer.get(...)`), not a model of it, and measures
retention with `sys.getsizeof` over the actual structures. Its controls
(`total_size_bytes`, resident entries, adaptive TTL) are what establish that the
change is confined to what it claims.

## Agent handoff

- [x] Issue #1294 re-scoped to windowing-only before this PR was opened
- [x] All 9 `access_patterns` references audited for deque compatibility
- [x] Prove-fail run with the constant retained, so failures are behavioural
- [x] Fairness controls included and confirmed passing under the revert
- [x] TTL semantics change measured across 5 access patterns, not asserted
- [x] ruff parity + Black verified on added lines

