### PR TITLE
fix(ci): drop stale eventrelay-ci-investigator governance checks

### DIFF
--- a/.github/workflows/gh-aw-validation.yml
+++ b/.github/workflows/gh-aw-validation.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Compile and validate workflows
         run: |
           gh aw compile \
-            eventrelay-ci-investigator \
             canonical-pr-remediator \
             focused-coverage-controller \
             --validate \
@@ -71,7 +70,6 @@ jobs:
       - name: Run actionlint, zizmor, and poutine checks
         run: |
           gh aw compile \
-            eventrelay-ci-investigator \
             canonical-pr-remediator \
             focused-coverage-controller \
             --actionlint \
@@ -82,6 +80,5 @@ jobs:
       - name: Verify compiled lock files are committed
         run: |
           git diff --exit-code -- \
-            .github/workflows/eventrelay-ci-investigator.lock.yml \
             .github/workflows/canonical-pr-remediator.lock.yml \
             .github/workflows/focused-coverage-controller.lock.yml

--- a/tests/unit/test_gh_aw_workflow_governance.py
+++ b/tests/unit/test_gh_aw_workflow_governance.py
@@ -103,43 +103,13 @@ def test_focused_coverage_controller_can_read_authoritative_runs() -> None:
     assert "requires a separate approved GitHub App canary" in source
 
 
-def test_ci_investigator_requires_dedicated_codex_credential() -> None:
-    workflow = _load_frontmatter(
-        ROOT / ".github/workflows/eventrelay-ci-investigator.md"
-    )
-    triggers = workflow.get("on", workflow.get(True))
-    assert triggers is not None
-    credential_gate = next(
-        step
-        for step in triggers["steps"]
-        if step.get("name") == "Require dedicated Codex credential"
-    )
-
-    assert credential_gate["id"] == "require_codex_credential"
-    assert credential_gate["env"]["CODEX_API_KEY"] == "${{ secrets.CODEX_API_KEY }}"
-    assert "Dedicated CODEX_API_KEY is required" in credential_gate["run"]
-    assert "OPENAI_API_KEY" not in credential_gate["run"]
-
-    compiled = _load_yaml(
-        ROOT / ".github/workflows/eventrelay-ci-investigator.lock.yml"
-    )
-    pre_activation_steps = compiled["jobs"]["pre_activation"]["steps"]
-    activation = compiled["jobs"]["activation"]
-    agent_steps = compiled["jobs"]["agent"]["steps"]
-
-    compiled_gate = next(
-        step
-        for step in pre_activation_steps
-        if step.get("id") == "require_codex_credential"
-    )
-    assert compiled_gate["name"] == "Require dedicated Codex credential"
-    assert compiled_gate["env"]["CODEX_API_KEY"] == "${{ secrets.CODEX_API_KEY }}"
-    assert activation["needs"] == "pre_activation"
-    assert any(step.get("id") == "validate-secret" for step in activation["steps"])
-    assert not any(
-        step.get("name") == "Require dedicated Codex credential"
-        for step in agent_steps
-    )
+def test_obsolete_ci_investigator_workflow_removed() -> None:
+    # The EventRelay CI Investigator workflow (source .md and compiled .lock.yml)
+    # was intentionally removed in 07b8a2e ("noise-only output; per repo cleanup").
+    # Guard against reintroduction; canonical-pr-remediator and
+    # focused-coverage-controller remain the authoritative agentic workflows.
+    assert not (ROOT / ".github/workflows/eventrelay-ci-investigator.md").exists()
+    assert not (ROOT / ".github/workflows/eventrelay-ci-investigator.lock.yml").exists()
 
 
 def test_live_smoke_modules_are_excluded_before_import(monkeypatch) -> None:
@@ -202,6 +172,9 @@ def test_gh_aw_validation_pins_runtime_version() -> None:
     step_scripts = [step.get("run", "") for step in workflow["jobs"]["validate-gh-aw"]["steps"]]
     combined = "\n".join(step_scripts)
     assert "gh extension install github/gh-aw --pin v0.82.14" in combined
-    assert "eventrelay-ci-investigator" in combined
+    # eventrelay-ci-investigator was removed (07b8a2e); validation must no longer
+    # compile or diff it, otherwise the gh-aw Validation workflow fails at runtime
+    # against a source/lock file that no longer exists.
+    assert "eventrelay-ci-investigator" not in combined
     assert "canonical-pr-remediator" in combined
     assert "focused-coverage-controller" in combined


### PR DESCRIPTION
## Canonical issue

Closes # <!-- no tracking issue; discovered via PR #1310 CI triage -->

## Outcome

Restores a green `test` job on `main` (and therefore on every open PR branched from it). The unit-test suite was failing `1 failed, 7919 passed` repo-wide because of a governance test that outlived the workflow it guarded.

## Scope

- **Included:**
  - `tests/unit/test_gh_aw_workflow_governance.py` — replaced `test_ci_investigator_requires_dedicated_codex_credential` (which asserted the *removed* `eventrelay-ci-investigator.md` / `.lock.yml` still exist) with `test_obsolete_ci_investigator_workflow_removed`, which codifies the deletion (mirrors the existing `test_obsolete_agentic_verification_loop_removed`). Inverted the stale `assert "eventrelay-ci-investigator" in combined` in `test_gh_aw_validation_pins_runtime_version`.
  - `.github/workflows/gh-aw-validation.yml` — removed `eventrelay-ci-investigator` from both `gh aw compile` steps and from the compiled-lock `git diff` step, so the *gh-aw Validation* workflow no longer compiles/diffs a source and lock file that no longer exist.
- **Explicitly excluded:**
  - `.github/workflows/AUDIT.md` line 27 — a historical audit-ledger row mentioning the file; left intact as a record (non-breaking).
  - No change to `canonical-pr-remediator` / `focused-coverage-controller`, which remain the authoritative agentic workflows.

## Root cause

Commit `07b8a2e` ("ci: remove EventRelay CI Investigator workflow source — noise-only output; per repo cleanup") deleted both `eventrelay-ci-investigator.md` and `.lock.yml` but left two governance hooks pointing at them: a unit test that required their presence, and the gh-aw validation compile/diff steps. The unit test failure is what has been keeping the repo-wide `test` gate red across the open-PR backlog.

## Risk

- Risk level: **low**
- Failure mode: none introduced — this deletes assertions/steps that reference non-existent files. Governance coverage is preserved by asserting the files stay absent.
- Rollback: revert this commit; restores prior (failing) state.

## Verification

Tied to head `6632f75`:

- [x] Focused tests — `pytest tests/unit/test_gh_aw_workflow_governance.py` → **9 passed** (was 1 failed / 8 passed on `main`).
- [x] `gh-aw-validation.yml` re-parsed as valid YAML after edits.
- [x] Repo-wide grep confirms no remaining functional reference to `eventrelay-ci-investigator` (only the AUDIT.md ledger row and the new absence-assertions remain).
- [ ] Required CI — pending on this PR.

## Production evidence

Not applicable — CI-governance/test-only change; no runtime or deploy surface affected.

## Agent handoff

- [ ] One canonical issue is linked — none exists; surfaced during triage of dependabot PR #1310, whose `test` failure was this exact stale test.
- [x] No competing PR implements the same issue
- [x] Acceptance criteria are satisfied (test job green)
- [ ] Required checks pass on the current head — pending
- [x] Human decision is requested only for merge approval to protected `main`

## Agent provenance

Agent-authored. Opened as **draft**; merge to protected `main` left to a human.


---
_Generated by [Claude Code](https://claude.ai/code/session_011GfJq7eGJ3FgkwJHu1YUYi)_