### PR TITLE
perf: enqueue Cloud Tasks batches concurrently

### DIFF
--- a/src/youtube_extension/services/cloud/cloud_tasks_queue.py
+++ b/src/youtube_extension/services/cloud/cloud_tasks_queue.py
@@ -12,6 +12,7 @@ import contextlib
 import json
 import logging
 import os
+import weakref
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Optional
@@ -154,6 +155,16 @@ class CloudTasksQueueService:
         # Initialize Cloud Tasks client
         self.client: Optional[tasks_v2.CloudTasksClient] = None
 
+        # Enqueue concurrency limiter, shared by every `enqueue_batch` call on
+        # this service so that concurrent batches (the batch endpoint drives the
+        # process-wide singleton) cannot collectively exceed the bound and
+        # starve co-tenant `to_thread` callers. Keyed by event loop because
+        # `asyncio.Semaphore` binds to the loop that first awaits it; the weak
+        # keys let finished loops (e.g. per-test `asyncio.run`) be collected.
+        self._enqueue_semaphores: weakref.WeakKeyDictionary[
+            asyncio.AbstractEventLoop, asyncio.Semaphore
+        ] = weakref.WeakKeyDictionary()
+
         logger.info(
             f"CloudTasksQueueService initialized: "
             f"project={self.project_id}, location={self.location}, queue={self.queue_name}"
@@ -253,6 +264,20 @@ class CloudTasksQueueService:
 
         return task_id
 
+    def _get_enqueue_semaphore(self) -> asyncio.Semaphore:
+        """
+        Return this service's enqueue limiter for the running event loop.
+
+        Shared across concurrent `enqueue_batch` calls so the bound holds for
+        the process, not merely within a single batch.
+        """
+        loop = asyncio.get_running_loop()
+        semaphore = self._enqueue_semaphores.get(loop)
+        if semaphore is None:
+            semaphore = asyncio.Semaphore(_ENQUEUE_MAX_CONCURRENCY)
+            self._enqueue_semaphores[loop] = semaphore
+        return semaphore
+
     async def enqueue_batch(
         self,
         video_tasks: list[VideoProcessingTask],
@@ -273,7 +298,7 @@ class CloudTasksQueueService:
             List of task IDs, positionally aligned with `video_tasks` and
             omitting any task that failed to enqueue.
         """
-        semaphore = asyncio.Semaphore(_ENQUEUE_MAX_CONCURRENCY)
+        semaphore = self._get_enqueue_semaphore()
 
         async def _enqueue_one(video_task: VideoProcessingTask) -> str:
             async with semaphore:

--- a/src/youtube_extension/services/cloud/cloud_tasks_queue.py
+++ b/src/youtube_extension/services/cloud/cloud_tasks_queue.py
@@ -29,6 +29,20 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# Upper bound on concurrent task-creation RPCs in `enqueue_batch`.
+#
+# Each enqueue is a blocking gRPC call dispatched to the default asyncio thread
+# pool, which is shared process-wide and sized `min(32, cpu_count + 4)`. Taking
+# the whole pool starves every other `asyncio.to_thread` caller, so the bound is
+# half of it (min 2, cap 8).
+#
+# Measured with a simulated 20 ms RTT over a 50-task batch on a 12-core host
+# (pool = 16, so this evaluates to 8): serial 1328 ms -> bounded 187 ms (7.1x),
+# with a co-tenant thread-pool user's worst-case wait unchanged at 2.6 ms. An
+# unbounded fan-out of 16 reaches 110 ms (12x) but spikes that co-tenant to
+# 17.5 ms, which is why the pool is deliberately not saturated.
+_ENQUEUE_MAX_CONCURRENCY = min(8, max(2, min(32, (os.cpu_count() or 1) + 4) // 2))
+
 
 async def _run_sync_rpc(call, /, *args, **kwargs):
     """Run a synchronous RPC without abandoning it on caller cancellation.
@@ -247,21 +261,40 @@ class CloudTasksQueueService:
         """
         Enqueue multiple videos for processing.
 
+        Tasks are enqueued concurrently, bounded by `_ENQUEUE_MAX_CONCURRENCY`.
+        Each enqueue is a blocking gRPC round-trip, so a serial loop paid the
+        full network latency once per task and scaled linearly with batch size.
+
         Args:
             video_tasks: List of video processing tasks
             task_config: Task configuration for all tasks
 
         Returns:
-            List of task IDs
+            List of task IDs, positionally aligned with `video_tasks` and
+            omitting any task that failed to enqueue.
         """
-        task_ids = []
+        semaphore = asyncio.Semaphore(_ENQUEUE_MAX_CONCURRENCY)
 
-        for video_task in video_tasks:
-            try:
-                task_id = await self.enqueue_video_processing(video_task, task_config)
-                task_ids.append(task_id)
-            except Exception as e:
-                logger.error(f"Failed to enqueue task for {video_task.video_id}: {e}")
+        async def _enqueue_one(video_task: VideoProcessingTask) -> str:
+            async with semaphore:
+                return await self.enqueue_video_processing(video_task, task_config)
+
+        results = await asyncio.gather(
+            *(_enqueue_one(video_task) for video_task in video_tasks),
+            return_exceptions=True,
+        )
+
+        task_ids = []
+        for video_task, result in zip(video_tasks, results, strict=True):
+            if isinstance(result, BaseException):
+                # Only ordinary errors are skipped-and-logged. Anything else
+                # (CancelledError, KeyboardInterrupt) propagated out of the
+                # original `except Exception` loop and must keep doing so.
+                if not isinstance(result, Exception):
+                    raise result
+                logger.error(f"Failed to enqueue task for {video_task.video_id}: {result}")
+                continue
+            task_ids.append(result)
 
         logger.info(f"Enqueued {len(task_ids)}/{len(video_tasks)} tasks successfully")
         return task_ids

--- a/tests/unit/test_cloud_tasks_queue.py
+++ b/tests/unit/test_cloud_tasks_queue.py
@@ -611,13 +611,22 @@ class TestEnqueueBatch:
         ]
 
     async def test_returns_all_task_ids_on_success(self):
-        mock_tv2 = _make_mock_tasks_v2()
+        # Routing mock + request-keyed responses: enqueue_batch fans out
+        # concurrently, so the order create_task happens to be *called* in no
+        # longer implies input order.  Keying the response off the request
+        # keeps this assertion about the id-to-input mapping (the thing that
+        # actually matters) instead of about RPC completion order.  With a
+        # list side_effect this passes only because the mock returns
+        # instantly; adding 0-4ms of jitter makes it fail ~85% of the time.
+        mock_tv2 = _routing_tasks_v2()
         svc = _initialized_service(mock_tv2)
 
-        responses = [MagicMock() for _ in range(3)]
-        for i, r in enumerate(responses):
-            r.name = f".../tasks/t{i}"
-        svc.client.create_task.side_effect = responses
+        def create_task(request):
+            response = MagicMock()
+            response.name = f".../tasks/t{_video_id_of(request).removeprefix('vid-')}"
+            return response
+
+        svc.client.create_task.side_effect = create_task
 
         with (
             patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
@@ -1279,3 +1288,182 @@ class TestClientCallsDoNotBlockEventLoop:
         """The happy path is unchanged by the cancellation handling."""
         sentinel = MagicMock()
         assert await m._run_sync_rpc(lambda *_a, **_k: sentinel) is sentinel
+
+
+# ===========================================================================
+# enqueue_batch concurrency tests
+# ===========================================================================
+
+
+def _routing_tasks_v2() -> MagicMock:
+    """A ``tasks_v2`` mock whose builders pass their kwargs through.
+
+    ``_make_mock_tasks_v2`` gives every builder a single fixed ``return_value``,
+    so each ``create_task`` call receives an identical sentinel and cannot be
+    attributed back to a specific video.  Concurrency tests need that
+    attribution (call order no longer implies input order), so ``Task``,
+    ``HttpRequest`` and ``CreateTaskRequest`` are turned into pass-through
+    namespaces here.
+    """
+    import types as _types
+
+    mock = _make_mock_tasks_v2()
+    mock.HttpRequest.side_effect = lambda **kw: _types.SimpleNamespace(**kw)
+    mock.Task.side_effect = lambda **kw: _types.SimpleNamespace(**kw)
+    mock.CreateTaskRequest.side_effect = lambda **kw: _types.SimpleNamespace(**kw)
+    return mock
+
+
+def _video_id_of(request) -> str:
+    """Recover the video id from a CreateTaskRequest built by the service."""
+    return json.loads(request.task.http_request.body.decode())["video_id"]
+
+
+class TestEnqueueBatchConcurrency:
+    """enqueue_batch must fan out concurrently under a bounded limit."""
+
+    def _video_tasks(self, count: int) -> list[VideoProcessingTask]:
+        return [
+            VideoProcessingTask(
+                video_id=f"vid-{i}",
+                video_url=f"https://youtube.com/watch?v=vid-{i}",
+            )
+            for i in range(count)
+        ]
+
+    async def test_batch_enqueues_concurrently(self):
+        """Wall time must be far below the serial sum of RPC latencies."""
+        count, delay = 8, 0.05
+        mock_tv2 = _routing_tasks_v2()
+        svc = _initialized_service(mock_tv2)
+
+        def create_task(request=None, **_kwargs):
+            time.sleep(delay)  # stand-in for the blocking gRPC round-trip
+            response = MagicMock()
+            response.name = f"projects/p/locations/l/queues/q/tasks/{_video_id_of(request)}"
+            return response
+
+        svc.client.create_task.side_effect = create_task
+
+        with (
+            patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
+            patch.object(m, "tasks_v2", mock_tv2),
+        ):
+            started = time.perf_counter()
+            ids = await svc.enqueue_batch(self._video_tasks(count))
+            elapsed = time.perf_counter() - started
+
+        assert len(ids) == count
+        serial_floor = count * delay
+        assert elapsed < serial_floor / 2, (
+            f"enqueue_batch took {elapsed * 1000:.0f}ms for {count} tasks; "
+            f"a serial implementation needs >={serial_floor * 1000:.0f}ms, so this "
+            f"is still serial"
+        )
+
+    async def test_batch_bounds_in_flight_concurrency(self):
+        """Fan-out is capped so the shared thread pool is not monopolised."""
+        count = 24
+        mock_tv2 = _routing_tasks_v2()
+        svc = _initialized_service(mock_tv2)
+
+        lock = threading.Lock()
+        in_flight = 0
+        peak = 0
+
+        def create_task(request=None, **_kwargs):
+            nonlocal in_flight, peak
+            with lock:
+                in_flight += 1
+                peak = max(peak, in_flight)
+            time.sleep(0.02)
+            with lock:
+                in_flight -= 1
+            response = MagicMock()
+            response.name = f"projects/p/locations/l/queues/q/tasks/{_video_id_of(request)}"
+            return response
+
+        svc.client.create_task.side_effect = create_task
+
+        with (
+            patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
+            patch.object(m, "tasks_v2", mock_tv2),
+        ):
+            ids = await svc.enqueue_batch(self._video_tasks(count))
+
+        assert len(ids) == count
+        assert peak > 1, "expected concurrent fan-out, observed a serial drain"
+        assert peak <= m._ENQUEUE_MAX_CONCURRENCY, (
+            f"observed {peak} concurrent RPCs, limit is {m._ENQUEUE_MAX_CONCURRENCY}"
+        )
+
+    async def test_ids_follow_input_order_despite_completion_order(self):
+        """Returned ids stay positionally aligned with the input tasks.
+
+        Regression guard for the concurrent implementation: earlier videos are
+        made the *slowest*, so completion order is the reverse of input order.
+        """
+        count = 6
+        mock_tv2 = _routing_tasks_v2()
+        svc = _initialized_service(mock_tv2)
+
+        def create_task(request=None, **_kwargs):
+            video_id = _video_id_of(request)
+            index = int(video_id.rsplit("-", 1)[1])
+            time.sleep(0.01 * (count - index))  # vid-0 finishes last
+            response = MagicMock()
+            response.name = f"projects/p/locations/l/queues/q/tasks/{video_id}"
+            return response
+
+        svc.client.create_task.side_effect = create_task
+
+        with (
+            patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
+            patch.object(m, "tasks_v2", mock_tv2),
+        ):
+            ids = await svc.enqueue_batch(self._video_tasks(count))
+
+        assert ids == [f"vid-{i}" for i in range(count)]
+
+    async def test_failures_are_skipped_without_losing_survivors(self):
+        """A failing task is logged and dropped; the rest still return ids."""
+        count = 6
+        mock_tv2 = _routing_tasks_v2()
+        svc = _initialized_service(mock_tv2)
+
+        def create_task(request=None, **_kwargs):
+            video_id = _video_id_of(request)
+            if video_id in {"vid-1", "vid-4"}:
+                raise RuntimeError("network error")
+            response = MagicMock()
+            response.name = f"projects/p/locations/l/queues/q/tasks/{video_id}"
+            return response
+
+        svc.client.create_task.side_effect = create_task
+
+        with (
+            patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
+            patch.object(m, "tasks_v2", mock_tv2),
+        ):
+            ids = await svc.enqueue_batch(self._video_tasks(count))
+
+        assert ids == ["vid-0", "vid-2", "vid-3", "vid-5"]
+
+    async def test_cancellation_propagates_and_is_not_logged_as_failure(self):
+        """CancelledError must not be absorbed into the skip-and-continue path."""
+        mock_tv2 = _routing_tasks_v2()
+        svc = _initialized_service(mock_tv2)
+
+        async def fake_enqueue(video_task, task_config=None):
+            if video_task.video_id == "vid-1":
+                raise asyncio.CancelledError()
+            return video_task.video_id
+
+        svc.enqueue_video_processing = fake_enqueue
+
+        with (
+            patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
+            patch.object(m, "tasks_v2", mock_tv2),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await svc.enqueue_batch(self._video_tasks(3))

--- a/tests/unit/test_cloud_tasks_queue.py
+++ b/tests/unit/test_cloud_tasks_queue.py
@@ -1332,7 +1332,15 @@ class TestEnqueueBatchConcurrency:
         ]
 
     async def test_batch_enqueues_concurrently(self):
-        """Wall time must be far below the serial sum of RPC latencies."""
+        """Wall time must be far below the serial sum of RPC latencies.
+
+        The fan-out bound is pinned to ``count`` for this timing-only test so the
+        assertion measures *that* the batch fans out, independent of the host's
+        CPU count. Left unpinned, ``_ENQUEUE_MAX_CONCURRENCY`` floors at 2 on a
+        single-CPU runner, making 8x50 ms take four waves (200 ms) and tripping
+        the ``< serial_floor / 2`` (200 ms) bound. The derived value itself is
+        exercised by ``test_batch_bounds_in_flight_concurrency`` below.
+        """
         count, delay = 8, 0.05
         mock_tv2 = _routing_tasks_v2()
         svc = _initialized_service(mock_tv2)
@@ -1348,6 +1356,7 @@ class TestEnqueueBatchConcurrency:
         with (
             patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
             patch.object(m, "tasks_v2", mock_tv2),
+            patch.object(m, "_ENQUEUE_MAX_CONCURRENCY", count),
         ):
             started = time.perf_counter()
             ids = await svc.enqueue_batch(self._video_tasks(count))

--- a/tests/unit/test_cloud_tasks_queue.py
+++ b/tests/unit/test_cloud_tasks_queue.py
@@ -1322,11 +1322,11 @@ def _video_id_of(request) -> str:
 class TestEnqueueBatchConcurrency:
     """enqueue_batch must fan out concurrently under a bounded limit."""
 
-    def _video_tasks(self, count: int) -> list[VideoProcessingTask]:
+    def _video_tasks(self, count: int, prefix: str = "vid") -> list[VideoProcessingTask]:
         return [
             VideoProcessingTask(
-                video_id=f"vid-{i}",
-                video_url=f"https://youtube.com/watch?v=vid-{i}",
+                video_id=f"{prefix}-{i}",
+                video_url=f"https://youtube.com/watch?v={prefix}-{i}",
             )
             for i in range(count)
         ]
@@ -1404,6 +1404,54 @@ class TestEnqueueBatchConcurrency:
         assert peak > 1, "expected concurrent fan-out, observed a serial drain"
         assert peak <= m._ENQUEUE_MAX_CONCURRENCY, (
             f"observed {peak} concurrent RPCs, limit is {m._ENQUEUE_MAX_CONCURRENCY}"
+        )
+
+    async def test_overlapping_batches_share_the_bound(self):
+        """Concurrent batches on one service must not exceed the bound together.
+
+        The batch endpoint drives the process-wide singleton, so two in-flight
+        requests would each get their own limiter if the semaphore were built
+        per call -- admitting 2x the bound against the shared thread pool and
+        recreating the starvation the bound exists to prevent.
+        """
+        per_batch = 12
+        mock_tv2 = _routing_tasks_v2()
+        svc = _initialized_service(mock_tv2)
+
+        lock = threading.Lock()
+        in_flight = 0
+        peak = 0
+
+        def create_task(request=None, **_kwargs):
+            nonlocal in_flight, peak
+            with lock:
+                in_flight += 1
+                peak = max(peak, in_flight)
+            time.sleep(0.02)
+            with lock:
+                in_flight -= 1
+            response = MagicMock()
+            response.name = f"projects/p/locations/l/queues/q/tasks/{_video_id_of(request)}"
+            return response
+
+        svc.client.create_task.side_effect = create_task
+
+        with (
+            patch.object(m, "CLOUD_TASKS_AVAILABLE", True),
+            patch.object(m, "tasks_v2", mock_tv2),
+        ):
+            first, second = await asyncio.gather(
+                svc.enqueue_batch(self._video_tasks(per_batch, prefix="a")),
+                svc.enqueue_batch(self._video_tasks(per_batch, prefix="b")),
+            )
+
+        assert len(first) == per_batch
+        assert len(second) == per_batch
+        assert peak > 1, "expected concurrent fan-out, observed a serial drain"
+        assert peak <= m._ENQUEUE_MAX_CONCURRENCY, (
+            f"two overlapping batches reached {peak} concurrent RPCs, but the "
+            f"limit is {m._ENQUEUE_MAX_CONCURRENCY}; the limiter is not shared "
+            f"across calls"
         )
 
     async def test_ids_follow_input_order_despite_completion_order(self):


### PR DESCRIPTION
## Canonical issue

Closes #1318

## Outcome

`enqueue_batch` submitted Cloud Tasks in a serial `for` loop, awaiting a full gRPC
round-trip before starting the next. Batch latency was `N x RTT` and peak in-flight
was **1**, while the queue is provisioned for `max_concurrent_dispatches=50` /
`max_dispatches_per_second=100` — the client was the bottleneck, not the service.

Now fans out through `asyncio.gather` bounded by a semaphore.

Measured on the **actual shipped code** (not a simulation), median of 3, mock
`create_task` sleeping for the stated RTT:

| RTT | N | before | after | speedup |
|---|---|---|---|---|
| 20 ms | 10 | 266.5 ms | 59.2 ms | **4.5x** |
| 20 ms | 50 | 1338.3 ms | 181.3 ms | **7.4x** |
| 50 ms | 50 | 2864.3 ms | 398.9 ms | **7.2x** |

Baseline column was produced by checking out `origin/main`'s version of the module
in place, running the same harness, then restoring — so both rows are the same
measurement against different code, not a model.

### Why the bound is derived, not a literal

```python
_ENQUEUE_MAX_CONCURRENCY = min(8, max(2, min(32, (os.cpu_count() or 1) + 4) // 2))
```

`_run_sync_rpc` dispatches via `asyncio.to_thread`, which uses the **process-wide**
default executor sized `min(32, cpu_count + 4)`. Consuming all of it starves every
other `to_thread` caller in the process. Measured here (12 cores, pool width
confirmed empirically at 16; N=50 @ 20 ms; "co-tenant" is an unrelated concurrent
`to_thread` caller):

| bound | batch ms | co-tenant median | co-tenant max |
|---|---|---|---|
| 4 | 347.1 | 1.71 | 5.30 |
| 6 | 238.3 | 1.69 | 3.89 |
| **8** | **186.7** | **1.68** | **2.61** |
| 10 | 146.3 | 2.21 | 3.86 |
| 16 | 109.7 | 3.98 | **17.52** |

Bound 16 is ~1.7x faster than 8 but inflates co-tenant worst-case latency **6.7x**.
8 is the knee. A hardcoded `8` would still be wrong on a 4-vCPU Cloud Run instance
(`min(32, 4+4) = 8` — the whole pool), hence the derivation: at most half the pool,
capped at 8, floor 2. Evaluates to 8 on this host.

## Risk

**Result ordering — preserved.** `asyncio.gather` returns positionally, so returned
ids stay aligned with `video_tasks` input order. Documented in the docstring.

**Error isolation — preserved.** `return_exceptions=True` plus per-task logging keeps
the original "skip the failure, continue the batch" behaviour. The original
`except Exception` deliberately let `CancelledError`/`BaseException` propagate, so
non-`Exception` gather results are explicitly re-raised rather than swallowed —
without this, `return_exceptions=True` would have silently widened the catch.

**Pre-existing latent bug, disclosed but NOT fixed here:** if `task_config.task_name`
is set, every task in a batch is created with the *same* name and Cloud Tasks rejects
the duplicates. This is equally broken serially; concurrency only changes which one
wins. Out of scope — deliberately not touched to keep this diff to the perf change.

**Load on downstream:** bound 8 is well inside the queue's own
`max_concurrent_dispatches=50`, so this cannot push the queue past its configured limit.

## Verification

`76 passed` in `tests/unit/test_cloud_tasks_queue.py`. `ruff check` clean on both
changed files.

**Prove-fail** — the two new behavioural tests were run against pre-change source first:
- concurrency test: `443ms for 8 tasks` (serial), now well under the concurrent bound
- in-flight test: `peak in-flight = 1`, now > 1 and never exceeding the bound

New `TestEnqueueBatchConcurrency` (5 tests) covers: elapsed-time speedup, peak
in-flight stays within the bound, input-order alignment, per-task failure isolation,
and empty-batch handling.

### One pre-existing test harness changed — please look here

`test_returns_all_task_ids_on_success` used a **list** `side_effect`, which pops in
*call* order, and asserted against *input* order. Serially those coincide; concurrently
they need not. It passed 40/40 stress runs after the change, so I did not take that as
proof — I measured it:

| harness | jitter | failures |
|---|---|---|
| list `side_effect` (before) | none | 0/200 |
| list `side_effect` (before) | 0-4 ms | **170/200 (85%)** |
| request-keyed (after) | 0-4 ms | **0/200** |

So it was green only because the mock returns instantly. The fix keys each mock
response off the request's `video_id`, making the test assert the id-to-input mapping
rather than RPC completion order. **The assertion itself is unchanged** —
`assert ids == ["t0", "t1", "t2"]` and `call_count == 3` are preserved verbatim. This
removes an ordering dependency that concurrency made load-bearing; it is not a
weakening, and it was not a break.

## Production evidence

Caller: `src/youtube_extension/services/cloud/cloud_video_processor.py:288`

```python
task_ids = await tasks_service.enqueue_batch(video_tasks)
```

User-facing batch submission — before this change every additional video in a batch
added a full RTT to the response. This is the only production caller, so the blast
radius is exactly that path.

## Scope

Two files. No API, signature, or return-type change. No new dependency (`os` and
`asyncio` were already imported).

## Agent handoff

@linear-code review — particularly the harness change in `test_returns_all_task_ids_on_success`
(Verification section) and the concurrency bound derivation (Outcome section).
