### PR TITLE
fix(ci): finish removal of eventrelay-ci-investigator workflow

### DIFF
--- a/.github/workflows/gh-aw-validation.yml
+++ b/.github/workflows/gh-aw-validation.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Compile and validate workflows
         run: |
           gh aw compile \
-            eventrelay-ci-investigator \
             canonical-pr-remediator \
             focused-coverage-controller \
             --validate \
@@ -71,7 +70,6 @@ jobs:
       - name: Run actionlint, zizmor, and poutine checks
         run: |
           gh aw compile \
-            eventrelay-ci-investigator \
             canonical-pr-remediator \
             focused-coverage-controller \
             --actionlint \
@@ -82,6 +80,5 @@ jobs:
       - name: Verify compiled lock files are committed
         run: |
           git diff --exit-code -- \
-            .github/workflows/eventrelay-ci-investigator.lock.yml \
             .github/workflows/canonical-pr-remediator.lock.yml \
             .github/workflows/focused-coverage-controller.lock.yml

--- a/tests/unit/test_gh_aw_workflow_governance.py
+++ b/tests/unit/test_gh_aw_workflow_governance.py
@@ -103,45 +103,6 @@ def test_focused_coverage_controller_can_read_authoritative_runs() -> None:
     assert "requires a separate approved GitHub App canary" in source
 
 
-def test_ci_investigator_requires_dedicated_codex_credential() -> None:
-    workflow = _load_frontmatter(
-        ROOT / ".github/workflows/eventrelay-ci-investigator.md"
-    )
-    triggers = workflow.get("on", workflow.get(True))
-    assert triggers is not None
-    credential_gate = next(
-        step
-        for step in triggers["steps"]
-        if step.get("name") == "Require dedicated Codex credential"
-    )
-
-    assert credential_gate["id"] == "require_codex_credential"
-    assert credential_gate["env"]["CODEX_API_KEY"] == "${{ secrets.CODEX_API_KEY }}"
-    assert "Dedicated CODEX_API_KEY is required" in credential_gate["run"]
-    assert "OPENAI_API_KEY" not in credential_gate["run"]
-
-    compiled = _load_yaml(
-        ROOT / ".github/workflows/eventrelay-ci-investigator.lock.yml"
-    )
-    pre_activation_steps = compiled["jobs"]["pre_activation"]["steps"]
-    activation = compiled["jobs"]["activation"]
-    agent_steps = compiled["jobs"]["agent"]["steps"]
-
-    compiled_gate = next(
-        step
-        for step in pre_activation_steps
-        if step.get("id") == "require_codex_credential"
-    )
-    assert compiled_gate["name"] == "Require dedicated Codex credential"
-    assert compiled_gate["env"]["CODEX_API_KEY"] == "${{ secrets.CODEX_API_KEY }}"
-    assert activation["needs"] == "pre_activation"
-    assert any(step.get("id") == "validate-secret" for step in activation["steps"])
-    assert not any(
-        step.get("name") == "Require dedicated Codex credential"
-        for step in agent_steps
-    )
-
-
 def test_live_smoke_modules_are_excluded_before_import(monkeypatch) -> None:
     monkeypatch.delenv("RUN_LIVE_E2E", raising=False)
     monkeypatch.delenv("RUN_LIVE_DEPLOY", raising=False)
@@ -202,6 +163,5 @@ def test_gh_aw_validation_pins_runtime_version() -> None:
     step_scripts = [step.get("run", "") for step in workflow["jobs"]["validate-gh-aw"]["steps"]]
     combined = "\n".join(step_scripts)
     assert "gh extension install github/gh-aw --pin v0.82.14" in combined
-    assert "eventrelay-ci-investigator" in combined
     assert "canonical-pr-remediator" in combined
     assert "focused-coverage-controller" in combined


### PR DESCRIPTION
## Canonical issue

No separate issue — this completes the deliberate cleanup started by commit
`07b8a2e` (*"ci: remove EventRelay CI Investigator workflow source (noise-only
output; per repo cleanup)"*), which is already merged to `main`.

## Outcome

`07b8a2e` deleted `.github/workflows/eventrelay-ci-investigator.md` but left
dangling references, so the **`test` job is red on `main` and on every open PR**
(surfaced by the `test` check on PR #1319 — `1 failed, 7941 passed`):

- `tests/unit/test_gh_aw_workflow_governance.py::test_ci_investigator_requires_dedicated_codex_credential`
  loaded the deleted `.md` / `.lock.yml` and failed with `FileNotFoundError`.
- `.github/workflows/gh-aw-validation.yml` still ran
  `gh aw compile eventrelay-ci-investigator` and diffed the removed
  `eventrelay-ci-investigator.lock.yml`, which would fail the validation
  workflow at runtime.

This finishes the removal so the repo is internally consistent and the `test`
job goes green.

## Scope

- **Included:**
  - Remove the obsolete `test_ci_investigator_requires_dedicated_codex_credential` test.
  - Remove the stale `eventrelay-ci-investigator` assertion from `test_gh_aw_validation_pins_runtime_version`.
  - Drop the three dangling `eventrelay-ci-investigator` references from `gh-aw-validation.yml` (two compile step lists + the lock-file diff).
- **Explicitly excluded:**
  - `canonical-pr-remediator` and `focused-coverage-controller` — untouched, still validated.
  - The historical `AUDIT.md` row that mentions the workflow — left as a point-in-time audit record; not load-bearing for CI.
  - The Cloud Tasks perf change in #1319 — unrelated; this failure predates and is independent of it.

## Risk

- **Risk level:** low
- **Failure mode:** deletion-only change to a test and a CI workflow; no product/runtime code touched. Worst case is a governance test gap for a workflow that no longer exists.
- **Rollback:** revert this commit.

## Verification

- [x] Focused tests — `pytest tests/unit/test_gh_aw_workflow_governance.py` → **8 passed** (previously-failing test removed).
- [x] `gh-aw-validation.yml` parses as valid YAML; `ruff check` clean on the changed test file.
- [ ] Required CI — will confirm on this PR's head SHA once checks run.
- [ ] Review threads resolved.

## Production evidence

Not applicable — CI/governance-only change. No runtime or deployment surface is affected.

## Agent handoff

- [x] Completes an already-merged cleanup; no competing PR implements this.
- [x] Acceptance: `test` job's single failure is eliminated; validation workflow no longer references a deleted workflow.
- [ ] Required checks pass on the current head (pending CI).
- [x] No human decision required beyond the standard merge approval to a protected branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3EkDi3YzmMyGvHizXKaPf)_