### PR TITLE
fix(perf): keep failure isolation and drain in-flight writes in fix_build_errors (review follow-up to #1336)

### DIFF
--- a/src/youtube_extension/backend/ai_code_generator.py
+++ b/src/youtube_extension/backend/ai_code_generator.py
@@ -9,6 +9,7 @@ based on video analysis. Produces monetizable products, not templates.
 
 import ast
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -1330,7 +1331,11 @@ jobs:
 
             try:
                 current_content = await asyncio.to_thread(_read_source)
-            except OSError as e:
+            except (OSError, UnicodeError) as e:
+                # read_text() raises UnicodeDecodeError (a UnicodeError, *not* an
+                # OSError) for a file that is not valid in the default encoding.
+                # Treat it as a per-file read failure so it cannot escape
+                # _fix_one and cancel the sibling fixes via gather().
                 logger.warning(f"⚠️ Failed to read {rel_path}: {e}")
                 return None
 
@@ -1380,8 +1385,20 @@ Return ONLY the fixed code, no explanations. Ensure:
                                 fixed_code = block
                             break
 
-                # Write fixed content
-                await asyncio.to_thread(file_path.write_text, fixed_code)
+                # Write fixed content. asyncio.to_thread runs write_text in a
+                # worker thread that a cancellation cannot interrupt once it has
+                # begun. Shield the write and, if we are cancelled mid-write,
+                # drain it before propagating CancelledError so a caller's
+                # cleanup or retry cannot race a still-running write.
+                write_task = asyncio.ensure_future(
+                    asyncio.to_thread(file_path.write_text, fixed_code)
+                )
+                try:
+                    await asyncio.shield(write_task)
+                except asyncio.CancelledError:
+                    with contextlib.suppress(Exception):
+                        await write_task
+                    raise
                 logger.info(f"✅ Fixed: {rel_path}")
                 return rel_path
 

--- a/tests/unit/test_ai_code_generator.py
+++ b/tests/unit/test_ai_code_generator.py
@@ -1232,6 +1232,77 @@ class TestFixBuildErrorsConcurrency:
 
         assert result["fixed_files"] == sorted(rel_paths)
 
+    async def test_undecodable_file_does_not_abort_siblings(
+        self, tmp_path, monkeypatch
+    ):
+        """A non-UTF-8 source raises UnicodeDecodeError (a UnicodeError, not an
+        OSError) on read. It must be caught as a per-file read failure, not
+        allowed to escape _fix_one and cancel the siblings via
+        gather(return_exceptions=False)."""
+        gen = _make_gen_with_mock_client(tmp_path)
+        rel_paths = self._make_files(tmp_path, 3)
+        gen.router.generate = AsyncMock(return_value="const fixed = true;")
+
+        real_read = Path.read_text
+
+        def _maybe_undecodable(self, *args, **kwargs):
+            if self.as_posix().endswith("src/app/page1.tsx"):
+                raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+            return real_read(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", _maybe_undecodable)
+
+        result = await gen.fix_build_errors(tmp_path, self._errors_for(rel_paths), [])
+
+        # The undecodable file is skipped; the other two are still fixed.
+        assert result["fixed_files"] == ["src/app/page0.tsx", "src/app/page2.tsx"]
+        assert result["success"] is True
+
+    async def test_cancellation_drains_inflight_write(self, tmp_path, monkeypatch):
+        """A write already running in a worker thread cannot be interrupted, so
+        cancellation must drain it before propagating — otherwise fix_build_errors
+        returns CancelledError while a write is still live and a caller's cleanup
+        or retry races it."""
+        gen = _make_gen_with_mock_client(tmp_path)
+        rel = self._make_files(tmp_path, 1)[0]
+        gen.router.generate = AsyncMock(return_value="const fixed = true;")
+
+        write_started = threading.Event()
+        may_finish = threading.Event()
+        real_write = Path.write_text
+
+        def _blocking_write(self, data, *args, **kwargs):
+            write_started.set()
+            may_finish.wait(5)
+            return real_write(self, data, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", _blocking_write)
+
+        task = asyncio.ensure_future(
+            gen.fix_build_errors(tmp_path, self._errors_for([rel]), [])
+        )
+
+        # Wait until the write is actually in progress inside the worker thread.
+        for _ in range(100):
+            if write_started.is_set():
+                break
+            await asyncio.sleep(0.05)
+        assert write_started.is_set()
+
+        task.cancel()
+        await asyncio.sleep(0.1)
+
+        # The in-flight write is still blocked, so the drain must keep the task
+        # pending. Buggy code abandons the write and finishes immediately.
+        assert not task.done(), "cancellation abandoned an in-flight write"
+
+        may_finish.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # The drained write landed rather than being orphaned mid-flight.
+        assert (tmp_path / rel).read_text() == "const fixed = true;"
+
 
 # ===========================================================================
 # AICodeGenerator._generate_turborepo_monorepo


### PR DESCRIPTION
## Canonical issue

Follow-up to groupthinking/EventRelay#1336 (which closes groupthinking/EventRelay#1335). This PR targets the `perf/ai-fix-parallel` branch so its diff is *only* the two correctness fixes below — merging it updates groupthinking/EventRelay#1336 in place rather than opening a competing PR against `main`. No new canonical issue: it remediates review findings on groupthinking/EventRelay#1336 raised **independently by both** `copilot-pull-request-reviewer` **and** `@coderabbitai`.

## Outcome

Two production-correctness gaps in `AICodeGenerator.fix_build_errors` are closed, restoring the failure-isolation and cancellation-safety guarantees groupthinking/EventRelay#1336 claims:

1. **UnicodeDecodeError no longer breaks failure isolation.** `_read_source()` caught only `OSError`. A non-UTF-8 source file raises `UnicodeDecodeError` (a `UnicodeError`, **not** an `OSError`), which escaped `_fix_one`, made `asyncio.gather(return_exceptions=False)` re-raise, and cancelled the sibling fixes. The read `except` is broadened to `(OSError, UnicodeError)`, so an undecodable file is skipped like any other per-file read failure.
2. **Cancellation no longer abandons a live write.** `await asyncio.to_thread(file_path.write_text, …)` starts a write in a worker thread that a cancellation cannot interrupt. Cancelling mid-write previously returned `CancelledError` while the write was still running, racing a caller's cleanup/retry. The write is now wrapped in a task, `asyncio.shield`-ed, and drained on cancellation before `CancelledError` propagates.

## Scope

- **Included:** `src/youtube_extension/backend/ai_code_generator.py` (`fix_build_errors` read `except` + write path; new `import contextlib`); `tests/unit/test_ai_code_generator.py` (two regression tests).
- **Explicitly excluded:** CodeRabbit's third note — the per-invocation `asyncio.Semaphore` does not bound *process-wide* provider traffic, since each `AICodeGenerator` instance gets its own 4-permit semaphore. That is an architectural change to shared router/provider infrastructure and is out of scope for this perf PR. It does **not** affect groupthinking/EventRelay#1336's actual guarantee (exactly one `generate` call per readable error file — billed LLM spend unchanged); only the "rate-limit protection" framing is broader than the per-call bound delivers. Left for a follow-up that owns shared-infra rate limiting.

## Risk

- **Risk level:** low
- **Failure mode:** none identified. Both changes are strictly more defensive: fix (1) converts a crash-and-cancel into the existing skip-and-continue path; fix (2) adds a drain that only changes behaviour under cancellation, and re-raises `CancelledError` unchanged. The public return shape (`success`, `fixed_files`, `total_errors`) and the one-call-per-file contract are untouched.
- **Rollback:** revert this commit; `fix_build_errors` returns to prior behaviour. No schema or data migration.

## Verification

Against head `d4a510b`:

```
# Both new tests prove-failed against the pre-change source (git stash of the fix):
FAILED test_undecodable_file_does_not_abort_siblings
FAILED test_cancellation_drains_inflight_write
# 2 failed  ← confirms the tests catch the bugs

# With the fix restored:
tests/unit/test_ai_code_generator.py tests/unit/test_deployment_manager.py
363 passed
```

- `test_undecodable_file_does_not_abort_siblings` — one file's `read_text` raises `UnicodeDecodeError`; asserts the other two files are still fixed and no exception escapes.
- `test_cancellation_drains_inflight_write` — blocks a write in a worker thread, cancels the task, asserts the task stays pending until the write drains (buggy code finishes immediately), then that `CancelledError` propagates and the drained write landed.
- `ruff` / `black` / `mypy`: added lines clean; pre-existing whole-file `F841`/format/`[index]` findings (lines 668–711, 2057) are not touched, matching groupthinking/EventRelay#1336's tight-diff posture.
- [X] Focused tests (2 new, both prove-failed)
- [X] Required CI (pending on this PR's head)
- [X] Review threads resolved — addresses the two blocking findings; the semaphore note is answered in Scope as a deliberate deferral

## Production evidence

Not applicable — backend change to an internal code-repair path with no HTTP surface. `DeploymentManager.verify_and_fix_project` is the caller; its suite (`test_deployment_manager.py`) is green in the run above.

## Agent handoff

- [X] One canonical issue is linked (via groupthinking/EventRelay#1336 → groupthinking/EventRelay#1335)
- [X] No competing PR implements the same issue — stacked onto groupthinking/EventRelay#1336's branch, not a parallel main PR
- [X] Acceptance criteria are satisfied
- [ ] Required checks pass on the current head — CI pending
- [X] Human decision is requested only for product, security, irreversible infrastructure, or production approval — merge of this and groupthinking/EventRelay#1336 into `main` is left to a human

---

*Generated by [Claude Code](<https://claude.ai/code/session_015F7qZu4PsmYyLtt6QbCUtQ>)*