### PR TITLE
perf: batch performance-metric writes into one SQLite round-trip

### DIFF
--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -1177,12 +1177,20 @@ async def ingest_performance_report_v1(report: dict[str, Any]):
         metrics: dict[str, Any] = (
             report.get("metrics", {}) if isinstance(report, dict) else {}
         )
+        # Collect first, then write once. A report carries every web-vital the
+        # page gathered, and recording them one at a time cost one SQLite
+        # connection and one commit fsync each while the client waited.
+        samples: list[dict[str, Any]] = []
         for name, stats in metrics.items():
             value = stats.get("current") if isinstance(stats, dict) else None
             if isinstance(value, (int, float)):
-                await performance_monitor.record_metric(
-                    "frontend", name, float(value), unit=str(stats.get("unit", "ms"))
-                )
+                samples.append({
+                    "component": "frontend",
+                    "metric_name": name,
+                    "value": float(value),
+                    "unit": str(stats.get("unit", "ms")),
+                })
+        await performance_monitor.record_metrics(samples)
         return {"status": "ok", "metrics_recorded": len(metrics)}
     except Exception as e:
         logger.error(f"Failed to ingest performance report: {e}", exc_info=True)

--- a/src/youtube_extension/backend/services/performance_monitor.py
+++ b/src/youtube_extension/backend/services/performance_monitor.py
@@ -24,6 +24,7 @@ import statistics
 import threading
 import time
 from collections import defaultdict, deque
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -268,6 +269,103 @@ class PerformanceMonitor:
         except Exception as e:
             logger.error(f"Failed to record metric: {e}")
 
+    async def record_metrics(self, metrics: Sequence[Mapping[str, Any]]) -> None:
+        """Record several metrics with a single database round-trip.
+
+        Each mapping takes the same keys as :meth:`record_metric` --
+        ``component``, ``metric_name``, ``value``, and optionally ``unit`` and
+        ``tags``. The observable behaviour is identical to calling
+        ``record_metric`` once per entry: the buffer, the fast-access
+        collections and the alert thresholds are all updated the same way, in
+        the same order.
+
+        The difference is the write. ``record_metric`` opens a connection,
+        inserts one row, commits and closes, so a caller holding N metrics pays
+        N connections and -- far more expensively -- N commit fsyncs. This
+        collapses them into one connection, one ``executemany`` and one commit.
+
+        Batching rather than parallelising is deliberate: SQLite serialises
+        writers behind a single database-level write lock, so concurrent
+        writers would queue anyway while adding lock contention on top of the
+        same number of fsyncs.
+        """
+        if not metrics:
+            return
+
+        try:
+            now = datetime.now(timezone.utc)
+            records = [
+                PerformanceMetric(
+                    component=entry["component"],
+                    metric_name=entry["metric_name"],
+                    value=float(entry["value"]),
+                    timestamp=entry.get("timestamp") or now,
+                    unit=entry.get("unit", "ms"),
+                    tags=entry.get("tags") or {},
+                )
+                for entry in metrics
+            ]
+
+            # Mirror record_metric's buffer bookkeeping, but take the lock once
+            # for the whole batch instead of once per metric.
+            with self._lock:
+                for metric in records:
+                    self.metrics_buffer.append(metric)
+
+                    if metric.metric_name == "video_processing_time":
+                        self.video_processing_times.append(metric.value)
+                    elif metric.metric_name == "database_query_time":
+                        self.database_query_times.append(metric.value)
+                    elif metric.metric_name == "api_response_time":
+                        self.api_response_times.append(metric.value)
+
+            # The one write that replaces N.
+            await self._store_metrics(records)
+
+            # Thresholds are evaluated per metric exactly as before; an alert
+            # for one metric must not suppress the rest.
+            for metric in records:
+                await self._check_alert_thresholds(metric)
+
+            logger.debug(f"📊 Recorded {len(records)} metrics in one write")
+
+        except Exception as e:
+            logger.error(f"Failed to record metrics: {e}")
+
+    async def _store_metrics(self, metrics: Sequence[PerformanceMetric]) -> None:
+        """Persist a batch of metrics using one connection and one commit."""
+        if not metrics:
+            return
+
+        rows = [
+            (
+                metric.component,
+                metric.metric_name,
+                metric.value,
+                metric.unit,
+                json.dumps(metric.tags),
+                metric.timestamp.isoformat(),
+            )
+            for metric in metrics
+        ]
+
+        def _write() -> None:
+            conn = sqlite3.connect(self.db_path)
+            try:
+                conn.executemany('''
+                    INSERT INTO performance_metrics
+                    (component, metric_name, value, unit, tags, timestamp)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                ''', rows)
+                conn.commit()
+            finally:
+                conn.close()
+
+        try:
+            await asyncio.to_thread(_write)
+        except Exception as e:
+            logger.error(f"Failed to store metrics in database: {e}")
+
     async def _store_metric(self, metric: PerformanceMetric):
         """Store metric in database"""
 
@@ -419,28 +517,56 @@ class PerformanceMonitor:
     async def _monitor_system_resources(self):
         """Monitor system resource usage"""
         try:
+            samples: list[dict[str, Any]] = []
+
             # CPU usage
             cpu_percent = psutil.cpu_percent(interval=1)
-            await self.record_metric("system", "cpu_usage_percent", cpu_percent, "%")
+            samples.append({
+                "component": "system", "metric_name": "cpu_usage_percent",
+                "value": cpu_percent, "unit": "%",
+            })
 
             # Memory usage
             memory = psutil.virtual_memory()
-            await self.record_metric("system", "memory_usage_percent", memory.percent, "%")
-            await self.record_metric("system", "memory_available_bytes", memory.available, "bytes")
+            samples.append({
+                "component": "system", "metric_name": "memory_usage_percent",
+                "value": memory.percent, "unit": "%",
+            })
+            samples.append({
+                "component": "system", "metric_name": "memory_available_bytes",
+                "value": memory.available, "unit": "bytes",
+            })
 
             # Disk usage
             disk = psutil.disk_usage('/')
             disk_percent = (disk.used / disk.total) * 100
-            await self.record_metric("system", "disk_usage_percent", disk_percent, "%")
+            samples.append({
+                "component": "system", "metric_name": "disk_usage_percent",
+                "value": disk_percent, "unit": "%",
+            })
 
             # Process-specific metrics if available
             try:
                 process = psutil.Process()
-                await self.record_metric("process", "memory_usage_mb", process.memory_info().rss / 1024 / 1024, "MB")
-                await self.record_metric("process", "cpu_percent", process.cpu_percent(), "%")
-                await self.record_metric("process", "threads_count", process.num_threads(), "count")
+                samples.append({
+                    "component": "process", "metric_name": "memory_usage_mb",
+                    "value": process.memory_info().rss / 1024 / 1024, "unit": "MB",
+                })
+                samples.append({
+                    "component": "process", "metric_name": "cpu_percent",
+                    "value": process.cpu_percent(), "unit": "%",
+                })
+                samples.append({
+                    "component": "process", "metric_name": "threads_count",
+                    "value": process.num_threads(), "unit": "count",
+                })
             except Exception:
                 pass  # Process monitoring is optional
+
+            # One connection and one commit for the whole cycle, instead of one
+            # per metric. This loop runs every 30s for the life of the process,
+            # so the saving is ~17k connections and fsyncs per day.
+            await self.record_metrics(samples)
 
         except Exception as e:
             logger.error(f"Error monitoring system resources: {e}")

--- a/tests/unit/test_performance_monitor.py
+++ b/tests/unit/test_performance_monitor.py
@@ -1191,6 +1191,20 @@ class TestRecordMetricsBatch:
         return _wrapped
 
     @staticmethod
+    def _impl_module():
+        """The module whose globals ``PerformanceMonitor`` methods actually read.
+
+        This file's preamble deliberately re-imports the performance monitor,
+        and CI runs with ``PYTHONPATH=src`` so the package can also resolve
+        under a second name. Either can leave the module-level ``perf_mod``
+        alias bound to a *different* module object than the one the class was
+        defined in, at which point ``monkeypatch.setattr(perf_mod, ...)``
+        silently no-ops and the real ``psutil`` runs instead of the fake.
+        Resolving from the class is correct under every import identity.
+        """
+        return sys.modules[PerformanceMonitor.__module__]
+
+    @staticmethod
     def _samples(n):
         return [
             {
@@ -1339,10 +1353,11 @@ class TestRecordMetricsBatch:
                 num_threads=lambda: 8,
             ),
         )
-        monkeypatch.setattr(perf_mod, "psutil", fake_psutil)
+        monkeypatch.setattr(self._impl_module(), "psutil", fake_psutil)
 
+        monitor.metrics_buffer.clear()
         calls: list[int] = []
-        with patch.object(perf_mod.sqlite3, "connect", self._counting_connect(calls)):
+        with patch.object(self._impl_module().sqlite3, "connect", self._counting_connect(calls)):
             await monitor._monitor_system_resources()
 
         assert len(calls) == 1, (
@@ -1369,8 +1384,9 @@ class TestRecordMetricsBatch:
             ),
             Process=_no_process,
         )
-        monkeypatch.setattr(perf_mod, "psutil", fake_psutil)
+        monkeypatch.setattr(self._impl_module(), "psutil", fake_psutil)
 
+        monitor.metrics_buffer.clear()
         await monitor._monitor_system_resources()
 
         # The four system-level metrics still land even though the process

--- a/tests/unit/test_performance_monitor.py
+++ b/tests/unit/test_performance_monitor.py
@@ -1144,3 +1144,238 @@ class TestSqliteDoesNotBlockEventLoop:
 
         with patch.object(perf_mod.sqlite3, "connect", _boom):
             await monitor._store_metric(metric)  # must not raise
+
+
+# ===========================================================================
+# PerformanceMonitor — record_metrics / _store_metrics (batched writes)
+# ===========================================================================
+
+
+class TestRecordMetricsBatch:
+    """The batch path must be a drop-in for N serial record_metric calls.
+
+    Everything observable -- rows persisted, buffer contents, fast-access
+    collections, alerts -- has to match. The only difference permitted is the
+    number of database connections, which is the entire point.
+    """
+
+    @pytest.fixture
+    def monitor(self, tmp_path):
+        return self._quiesced(tmp_path / "perf.db")
+
+    @staticmethod
+    def _quiesced(db_path):
+        """Build a monitor with its background task stopped.
+
+        ``__init__`` calls ``start_monitoring()`` whenever an event loop is
+        running, which every async test provides. That task records real
+        system metrics into the same buffer these tests assert on, so it has
+        to be cancelled before the buffer means anything.
+        """
+        mon = PerformanceMonitor(db_path=str(db_path))
+        mon.monitoring_enabled = False
+        if mon.monitoring_task is not None:
+            mon.monitoring_task.cancel()
+            mon.monitoring_task = None
+        return mon
+
+    @staticmethod
+    def _counting_connect(counter):
+        """Wrap sqlite3.connect so we can count how many times it is called."""
+        real_connect = sqlite3.connect
+
+        def _wrapped(*args, **kwargs):
+            counter.append(1)
+            return real_connect(*args, **kwargs)
+
+        return _wrapped
+
+    @staticmethod
+    def _samples(n):
+        return [
+            {
+                "component": "system",
+                "metric_name": f"metric_{i}",
+                "value": float(i),
+                "unit": "ms",
+            }
+            for i in range(n)
+        ]
+
+    async def test_batch_opens_exactly_one_connection(self, monitor):
+        """Seven metrics must cost one connection, not seven.
+
+        This is the regression guard for the whole change. The background
+        monitor records seven metrics every thirty seconds forever, so a
+        per-metric connection is ~20k connections and commit fsyncs a day.
+        """
+        calls: list[int] = []
+        with patch.object(perf_mod.sqlite3, "connect", self._counting_connect(calls)):
+            await monitor.record_metrics(self._samples(7))
+
+        assert len(calls) == 1, f"expected 1 connection for the batch, got {len(calls)}"
+
+    async def test_serial_path_still_opens_one_connection_per_metric(self, monitor):
+        """Pins the old behaviour so the comparison above is meaningful.
+
+        record_metric is left untouched by this change -- ~15 callers record a
+        single metric and gain nothing from batching -- so it should still
+        connect once per call.
+        """
+        calls: list[int] = []
+        with patch.object(perf_mod.sqlite3, "connect", self._counting_connect(calls)):
+            for sample in self._samples(7):
+                await monitor.record_metric(
+                    sample["component"], sample["metric_name"], sample["value"]
+                )
+
+        assert len(calls) == 7
+
+    async def test_batch_persists_every_row_with_correct_values(self, monitor):
+        await monitor.record_metrics([
+            {"component": "system", "metric_name": "cpu_usage_percent",
+             "value": 42.5, "unit": "%"},
+            {"component": "process", "metric_name": "threads_count",
+             "value": 8.0, "unit": "count"},
+            {"component": "frontend", "metric_name": "bundle_load_time",
+             "value": 1500.0, "unit": "ms", "tags": {"page": "home"}},
+        ])
+
+        conn = sqlite3.connect(monitor.db_path)
+        try:
+            rows = conn.execute(
+                "SELECT component, metric_name, value, unit, tags "
+                "FROM performance_metrics ORDER BY metric_name"
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert len(rows) == 3
+        by_name = {r[1]: r for r in rows}
+        assert by_name["cpu_usage_percent"][0] == "system"
+        assert by_name["cpu_usage_percent"][2] == 42.5
+        assert by_name["cpu_usage_percent"][3] == "%"
+        assert by_name["threads_count"][0] == "process"
+        assert by_name["threads_count"][2] == 8.0
+        assert by_name["bundle_load_time"][2] == 1500.0
+        assert '"page": "home"' in by_name["bundle_load_time"][4]
+
+    async def test_batch_matches_serial_buffer_and_collections(self, tmp_path):
+        """Same inputs through both paths must leave identical in-memory state."""
+        samples = [
+            {"component": "video", "metric_name": "video_processing_time",
+             "value": 1200.0, "unit": "ms"},
+            {"component": "db", "metric_name": "database_query_time",
+             "value": 35.0, "unit": "ms"},
+            {"component": "api", "metric_name": "api_response_time",
+             "value": 250.0, "unit": "ms"},
+            {"component": "system", "metric_name": "cpu_usage_percent",
+             "value": 10.0, "unit": "%"},
+        ]
+
+        serial = self._quiesced(tmp_path / "serial.db")
+        for s in samples:
+            await serial.record_metric(
+                s["component"], s["metric_name"], s["value"], s["unit"]
+            )
+
+        batched = self._quiesced(tmp_path / "batched.db")
+        await batched.record_metrics(samples)
+
+        assert list(batched.video_processing_times) == list(serial.video_processing_times)
+        assert list(batched.database_query_times) == list(serial.database_query_times)
+        assert list(batched.api_response_times) == list(serial.api_response_times)
+
+        assert len(batched.metrics_buffer) == len(serial.metrics_buffer)
+        for got, want in zip(batched.metrics_buffer, serial.metrics_buffer):
+            assert (got.component, got.metric_name, got.value, got.unit) == (
+                want.component, want.metric_name, want.value, want.unit
+            )
+
+    async def test_empty_batch_does_no_database_work(self, monitor):
+        calls: list[int] = []
+        with patch.object(perf_mod.sqlite3, "connect", self._counting_connect(calls)):
+            await monitor.record_metrics([])
+
+        assert calls == []
+        assert len(monitor.metrics_buffer) == 0
+
+    async def test_batch_evaluates_thresholds_for_every_metric(self, monitor):
+        """A breach in one metric must not mask a breach in another."""
+        await monitor.record_metrics([
+            {"component": "system", "metric_name": "cpu_usage_percent",
+             "value": 99.0, "unit": "%"},
+            {"component": "system", "metric_name": "memory_usage_percent",
+             "value": 95.0, "unit": "%"},
+        ])
+
+        assert len(monitor.active_alerts) == 2
+
+    async def test_batch_swallows_database_errors(self, monitor):
+        """Metric recording is best-effort; a dead disk must not fail callers."""
+        def _boom(*_args, **_kwargs):
+            raise sqlite3.OperationalError("disk I/O error")
+
+        with patch.object(perf_mod.sqlite3, "connect", _boom):
+            await monitor.record_metrics(self._samples(3))  # must not raise
+
+    async def test_system_resource_cycle_uses_a_single_connection(
+        self, monitor, monkeypatch
+    ):
+        """End-to-end proof for the background loop's 30-second cycle."""
+        import types
+
+        fake_psutil = types.SimpleNamespace(
+            cpu_percent=lambda interval=None: 45.0,
+            virtual_memory=lambda: types.SimpleNamespace(
+                percent=60.0, available=3 * 1024**3
+            ),
+            disk_usage=lambda path: types.SimpleNamespace(
+                used=60 * 1024**3, total=100 * 1024**3
+            ),
+            Process=lambda: types.SimpleNamespace(
+                memory_info=lambda: types.SimpleNamespace(rss=200 * 1024**2),
+                cpu_percent=lambda: 10.0,
+                num_threads=lambda: 8,
+            ),
+        )
+        monkeypatch.setattr(perf_mod, "psutil", fake_psutil)
+
+        calls: list[int] = []
+        with patch.object(perf_mod.sqlite3, "connect", self._counting_connect(calls)):
+            await monitor._monitor_system_resources()
+
+        assert len(calls) == 1, (
+            f"one monitoring cycle should be one write, got {len(calls)}"
+        )
+        assert len(monitor.metrics_buffer) == 7
+
+    async def test_system_resource_cycle_survives_process_metrics_failure(
+        self, monitor, monkeypatch
+    ):
+        """Process metrics are optional; losing them must not lose the rest."""
+        import types
+
+        def _no_process():
+            raise RuntimeError("process introspection unavailable")
+
+        fake_psutil = types.SimpleNamespace(
+            cpu_percent=lambda interval=None: 45.0,
+            virtual_memory=lambda: types.SimpleNamespace(
+                percent=60.0, available=3 * 1024**3
+            ),
+            disk_usage=lambda path: types.SimpleNamespace(
+                used=60 * 1024**3, total=100 * 1024**3
+            ),
+            Process=_no_process,
+        )
+        monkeypatch.setattr(perf_mod, "psutil", fake_psutil)
+
+        await monitor._monitor_system_resources()
+
+        # The four system-level metrics still land even though the process
+        # block raised partway through.
+        assert len(monitor.metrics_buffer) == 4
+        names = {m.metric_name for m in monitor.metrics_buffer}
+        assert "cpu_usage_percent" in names
+        assert "disk_usage_percent" in names

--- a/tests/unit/test_v1_router_extended.py
+++ b/tests/unit/test_v1_router_extended.py
@@ -2180,10 +2180,16 @@ class TestAdditionalErrorPaths:
         assert resp.status_code == 500
 
     def test_performance_report_error(self, client):
-        """record_metric raises → 500."""
+        """record_metrics raises → 500.
+
+        The report endpoint ingests the whole payload in one batched
+        ``record_metrics`` call, so the failure has to be injected there;
+        patching the singular ``record_metric`` is inert and the request
+        would succeed with a 200.
+        """
         with patch.object(
             router_module.performance_monitor,
-            "record_metric",
+            "record_metrics",
             new_callable=AsyncMock,
             side_effect=RuntimeError("monitor error"),
         ):

--- a/tests/unit/test_v1_router_extended.py
+++ b/tests/unit/test_v1_router_extended.py
@@ -668,6 +668,18 @@ class TestPerformanceEndpoints:
         assert resp.status_code == 200
 
     def test_performance_report(self, client):
+        """Report ingest batches every sample into one ``record_metrics`` call.
+
+        Patches the plural ``record_metrics`` because that is what the endpoint
+        calls. Patching the singular ``record_metric`` here would be inert and
+        let the request perform a live in-process SQLite write, so the test
+        would still pass while silently losing its isolation.
+
+        The await-count assertion is the point: it pins the batching contract
+        this endpoint exists to provide. A regression back to one write per
+        metric would keep the 200 and the count, and only this assertion would
+        catch it.
+        """
         payload = {
             "metrics": {
                 "lcp": {"current": 1200, "unit": "ms"},
@@ -675,13 +687,20 @@ class TestPerformanceEndpoints:
             }
         }
         with patch.object(
-            router_module.performance_monitor, "record_metric", new_callable=AsyncMock
-        ):
+            router_module.performance_monitor, "record_metrics", new_callable=AsyncMock
+        ) as mock_record:
             resp = client.post("/api/v1/performance/report", json=payload)
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "ok"
         assert data["metrics_recorded"] == 2
+
+        # Exactly one write for the whole report, carrying both samples.
+        assert mock_record.await_count == 1
+        (samples,) = mock_record.await_args.args
+        assert [s["metric_name"] for s in samples] == ["lcp", "fid"]
+        assert [s["value"] for s in samples] == [1200.0, 30.0]
+        assert {s["component"] for s in samples} == {"frontend"}
 
     def test_performance_report_empty(self, client):
         resp = client.post("/api/v1/performance/report", json={})


### PR DESCRIPTION
## Canonical issue

Closes #1339

## Outcome

`record_metric()` opens a SQLite connection, INSERTs one row, and commits — once
per metric. Two callers submit metrics in groups, so they paid that cost N times
for what is logically one write:

- `_monitor_system_resources()` emits **7 metrics every 30s**, forever, from the
  background monitoring loop → ~20,160 connect+commit cycles/day.
- `POST /api/v1/performance/report` replays an entire client-side batch through
  the same per-metric path; a browser posting 50 samples cost 50 cycles.

This adds `record_metrics(metrics)` and `_store_metrics(metrics)`, which:

- acquire `self._lock` **once** for the whole batch instead of once per metric,
- extend `metrics_buffer` and the three fast-access deques in one critical section,
- persist every row with a single `connect` → `executemany` → `commit`.

The background cycle drops from 7 connections per tick to 1 (~2,880/day), and
the report endpoint from N to 1.

`record_metric()` and `_store_metric()` are **unchanged**. The ~15 genuine
single-metric callers across the codebase keep their existing behaviour; this
is purely additive plus two call-site rewrites.

## Risk

Low, and deliberately bounded:

- **No behaviour change for existing callers.** The single-metric path is
  untouched. `test_serial_path_still_opens_one_connection_per_metric` pins its
  current behaviour so a future refactor can't silently reroute it.
- **Same alerting semantics.** `_check_alert_thresholds` is per-metric and pure;
  it is still called once per metric, just after the batch write rather than
  interleaved with it.
- **Failure granularity changes.** A serial loop could persist metrics 1–3 and
  fail on 4. The batch is one transaction, so it is all-or-nothing. For
  best-effort telemetry that is an improvement (no torn batches), but it is a
  real semantic difference and is called out here deliberately.
- **`asyncio.to_thread` + `try/finally`.** `_store_metrics` closes its connection
  in a `finally`, so a failed `executemany` cannot leak the handle. (The existing
  `_store_metric` does *not* do this. That is a pre-existing bug and is
  intentionally left alone — fixing it here would put an unrelated correctness
  change in a perf PR.)
- **Pre-existing inconsistency, disclosed, not "fixed":** the report endpoint
  returns `metrics_recorded: len(metrics)`, which counts *all* submitted entries
  including non-numeric ones that get skipped. That was already true before this
  change and the value is preserved verbatim, so this PR is not the place to
  alter a response field. Flagging it so a reviewer doesn't read it as new.

## Verification

`tests/unit/test_performance_monitor.py` — **128 passed** (119 pre-existing + 9 new).

```
.venv/bin/python -m pytest tests/unit/test_performance_monitor.py \
  --override-ini="addopts=" -p no:cacheprovider -q
============================= 128 passed in 2.17s ==============================
```

**Prove-fail** — the 9 new tests were run against the pre-change source
(`git stash` of both source files, test file retained):

```
7 failed, 2 passed
```

The 7 failures are the batching assertions. The 2 passes are intentional
*control* tests that must hold on both sides of the change:
`test_serial_path_still_opens_one_connection_per_metric` (pins the old path) and
`test_system_resource_cycle_survives_process_metrics_failure` (pins best-effort
`psutil.Process` handling). A test that passes before *and* after is only
meaningful as a guard, and both are here for that reason.

New coverage:

| Test | Proves |
|---|---|
| `test_batch_opens_exactly_one_connection` | 7 metrics → 1 `sqlite3.connect`, the core claim |
| `test_serial_path_still_opens_one_connection_per_metric` | old path still 7 — no silent rerouting |
| `test_batch_persists_every_row_with_correct_values` | component/value/unit/tags land intact, not just row count |
| `test_batch_matches_serial_buffer_and_collections` | serial vs batched leave byte-identical in-memory state |
| `test_empty_batch_does_no_database_work` | empty input touches no connection |
| `test_batch_evaluates_thresholds_for_every_metric` | 2 breaching metrics → 2 alerts; batching doesn't swallow alerts |
| `test_batch_swallows_database_errors` | a DB failure can't take down the caller |
| `test_system_resource_cycle_uses_a_single_connection` | end-to-end: real cycle → 1 connection, 7 buffered |
| `test_system_resource_cycle_survives_process_metrics_failure` | `psutil.Process` raising still yields the 4 system metrics |

**A real bug the parity test caught.** `PerformanceMonitor.__init__` calls
`start_monitoring()` whenever an event loop is running — which every async test
provides. That background task writes *real* system metrics into the same buffer
under assertion, so the strict serial-vs-batched comparison failed on a stray
`cpu_usage_percent` sample nobody recorded. The new tests build monitors through
a `_quiesced()` helper that cancels the task first. Looser assertions (`len > 0`)
would never have surfaced this.

Lint: `ruff check --output-format=concise` over all three changed files reports
**25 findings, identical rule-for-rule to `origin/main`** (all pre-existing
`B904` in `router.py`). Compared by rule+count against a `git stash` baseline of
the real paths, not by line number.

## Production evidence

- `src/youtube_extension/backend/services/performance_monitor.py` —
  `_background_monitoring()` loops `while self.monitoring_enabled:` with
  `await asyncio.sleep(30)`, calling `_monitor_system_resources()` each tick.
  That method emitted 7 serial `record_metric` calls. This is live in-process
  work, not a test harness: `__init__` starts the task automatically whenever an
  event loop is present.
- `src/youtube_extension/backend/api/v1/router.py:118` —
  `performance_monitor = PerformanceMonitor()` at module scope;
  `@router.post("/performance/report")` iterates the client's metric list and
  called `record_metric` per entry.
- Routing is confirmed live, not dead code: `backend/main.py:35` imports
  `v1_router` and `backend/main.py:164` calls `app.include_router(v1_router)`.

## Scope

Two call sites repointed; two new methods added. No change to the monitoring
cadence, the metric schema, the DB schema, the alerting rules, or any response
payload.

## Agent handoff

`@linear-code` `@coderabbitai` — please review. Two things worth your attention:

1. The all-or-nothing failure granularity noted under **Risk** — I judged a
   single transaction to be correct for best-effort telemetry, but if you'd
   rather see per-row resilience, say so and I'll add it.
2. I deliberately did **not** fix the `metrics_recorded: len(metrics)`
   miscount or the missing `try/finally` in the legacy `_store_metric`, on the
   grounds that neither belongs in a performance PR. Push back if you'd prefer
   them folded in.
