### PR TITLE
fix(local): full-pipeline auth opt-in and youtube deps (F6/F7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,9 @@ ASSEMBLYAI_API_KEY=
 EVENTRELAY_API_KEY=
 # Local-dev ONLY escape hatch. If EVENTRELAY_API_KEY is unset, the API fails
 # closed (HTTP 503) on protected routes UNLESS this is set to 1. Never set in prod.
+# scripts/dev_backend.sh sets ALLOW_UNAUTHENTICATED=1 when both are unset.
+# When using a shared key, set the same EVENTRELAY_API_KEY in apps/web/.env.local
+# so Next.js can send X-API-Key on BACKEND_URL calls.
 ALLOW_UNAUTHENTICATED=
 
 # --- Frontend (Next.js) login gating & abuse controls ---

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ AI-powered video transcript capture, structured event extraction, and agent exec
 git clone https://github.com/groupthinking/EventRelay.git
 cd EventRelay
 
-# Backend
+# Backend — include the youtube extra for full video path (yt-dlp + youtube-transcript-api)
 python3 -m venv .venv && source .venv/bin/activate
-pip install -e .[dev]
+pip install -e ".[dev,youtube]"
 
 # Frontend
 npm install
@@ -68,17 +68,28 @@ npm install
 # API keys (add to shell profile or .env)
 export GEMINI_API_KEY="your-key"
 export OPENAI_API_KEY="your-key"
+
+# Local full pipeline auth (pick ONE):
+#   A) Dev escape hatch (never in production):
+export ALLOW_UNAUTHENTICATED=1
+#   B) Shared key (frontend Next also needs this for BACKEND_URL calls):
+# export EVENTRELAY_API_KEY="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+# Without either, non-public FastAPI routes return HTTP 503 (fail closed).
 ```
 
 ### Run
 
 ```bash
-# Terminal 1: Backend
-PYTHONPATH=src python3 -m uvicorn youtube_extension.main:app --port 8000
+# Terminal 1: Backend (script sets ALLOW_UNAUTHENTICATED=1 if unset)
+./scripts/dev_backend.sh
+# Or manually:
+# ALLOW_UNAUTHENTICATED=1 PYTHONPATH=src python3 -m uvicorn youtube_extension.main:app --port 8000
 
 # Terminal 2: Frontend
 cd apps/web && BACKEND_URL=http://localhost:8000 npx next dev --port 3000
 ```
+
+Check readiness: `curl -s localhost:8000/health` should show `"auth_mode":"open_dev"` (or `"api_key"`) and `"video_path_ready":true`.
 
 Open http://localhost:3000 — paste a YouTube URL and run the studio workflow. The older dashboard remains available at http://localhost:3000/dashboard.
 

--- a/scripts/dev_backend.sh
+++ b/scripts/dev_backend.sh
@@ -15,6 +15,25 @@ if [[ -f .venv/bin/activate ]]; then
   source .venv/bin/activate
 fi
 
+# The FastAPI app loads a root .env at startup (backend/main.py). Mirror that here
+# for the two auth vars so a key configured only in .env is honored BEFORE the
+# fail-open default below. Without this, EVENTRELAY_API_KEY set only in .env is
+# invisible to the check, we export ALLOW_UNAUTHENTICATED=1, and — because that
+# opt-in takes precedence in the middleware — the backend silently runs OPEN.
+if [[ -f .env ]]; then
+  for _var in EVENTRELAY_API_KEY ALLOW_UNAUTHENTICATED; do
+    [[ -n "${!_var:-}" ]] && continue
+    _line="$(grep -E "^[[:space:]]*(export[[:space:]]+)?${_var}=" .env | tail -n1 || true)"
+    [[ -z "$_line" ]] && continue
+    _val="${_line#*=}"
+    _val="${_val%$'\r'}"           # strip trailing CR from CRLF files
+    _val="${_val#\"}"; _val="${_val%\"}"   # strip surrounding double quotes
+    _val="${_val#\'}"; _val="${_val%\'}"   # strip surrounding single quotes
+    [[ -n "$_val" ]] && export "${_var}=${_val}"
+  done
+  unset _var _line _val
+fi
+
 if [[ -z "${EVENTRELAY_API_KEY:-}" && -z "${ALLOW_UNAUTHENTICATED:-}" ]]; then
   export ALLOW_UNAUTHENTICATED=1
   echo "dev_backend: ALLOW_UNAUTHENTICATED=1 (local fail-open; set EVENTRELAY_API_KEY to require X-API-Key)"

--- a/scripts/dev_backend.sh
+++ b/scripts/dev_backend.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Local FastAPI backend for EventRelay (F6 + F7).
+#
+# - Defaults ALLOW_UNAUTHENTICATED=1 when EVENTRELAY_API_KEY is unset so protected
+#   routes are reachable without 503 fail-closed (never use this in production).
+# - Reminds you to install the youtube extra when yt-dlp / youtube-transcript-api
+#   are missing.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [[ -f .venv/bin/activate ]]; then
+  # shellcheck disable=SC1091
+  source .venv/bin/activate
+fi
+
+if [[ -z "${EVENTRELAY_API_KEY:-}" && -z "${ALLOW_UNAUTHENTICATED:-}" ]]; then
+  export ALLOW_UNAUTHENTICATED=1
+  echo "dev_backend: ALLOW_UNAUTHENTICATED=1 (local fail-open; set EVENTRELAY_API_KEY to require X-API-Key)"
+fi
+
+python - <<'PY' || true
+import importlib.util
+missing = [n for n in ("yt_dlp", "youtube_transcript_api") if importlib.util.find_spec(n) is None]
+if missing:
+    print(
+        "dev_backend: missing video packages "
+        + ", ".join(missing)
+        + ' — install with: pip install -e ".[dev,youtube]"'
+    )
+else:
+    print("dev_backend: yt_dlp + youtube_transcript_api available")
+PY
+
+export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}src"
+exec python -m uvicorn youtube_extension.main:app --host 127.0.0.1 --port "${PORT:-8000}" --reload

--- a/src/youtube_extension/main.py
+++ b/src/youtube_extension/main.py
@@ -196,11 +196,45 @@ except Exception as e:
     logger.error(f"Failed to load API v1 router: {type(e).__name__}: {e}")
 
 
+def _auth_mode() -> str:
+    """Report how APIKeyAuthMiddleware will treat non-public routes (F6)."""
+    if os.getenv("ALLOW_UNAUTHENTICATED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return "open_dev"
+    if (os.getenv("EVENTRELAY_API_KEY") or "").strip():
+        return "api_key"
+    return "fail_closed"
+
+
+def _video_dep_status() -> dict[str, bool]:
+    """Whether optional full-video-path packages import cleanly (F7)."""
+    status: dict[str, bool] = {}
+    for name in ("yt_dlp", "youtube_transcript_api"):
+        try:
+            __import__(name)
+            status[name] = True
+        except ImportError:
+            status[name] = False
+    return status
+
+
 # Health check endpoint
 @app.get("/health")
 async def health_check():
-    """Health check endpoint"""
-    return {"status": "healthy", "service": "uvai-youtube-extension"}
+    """Health check endpoint with local full-pipeline readiness hints."""
+    video_deps = _video_dep_status()
+    return {
+        "status": "healthy",
+        "service": "uvai-youtube-extension",
+        # fail_closed → non-public routes 503 until EVENTRELAY_API_KEY or ALLOW_UNAUTHENTICATED=1
+        "auth_mode": _auth_mode(),
+        "video_deps": video_deps,
+        "video_path_ready": all(video_deps.values()),
+    }
 
 
 async def ensure_api_cost_ready() -> None:

--- a/src/youtube_extension/main.py
+++ b/src/youtube_extension/main.py
@@ -205,7 +205,11 @@ def _auth_mode() -> str:
         "on",
     }:
         return "open_dev"
-    if (os.getenv("EVENTRELAY_API_KEY") or "").strip():
+    # Mirror APIKeyAuthMiddleware, which treats ANY non-empty EVENTRELAY_API_KEY
+    # (whitespace included) as configured. Do not .strip() here: a whitespace-only
+    # key makes the middleware require that key on protected routes, so reporting
+    # "fail_closed" would contradict actual request handling.
+    if os.getenv("EVENTRELAY_API_KEY"):
         return "api_key"
     return "fail_closed"
 

--- a/tests/unit/test_local_pipeline_readiness.py
+++ b/tests/unit/test_local_pipeline_readiness.py
@@ -1,0 +1,29 @@
+"""F6/F7 readiness helpers on the FastAPI /health surface."""
+
+from __future__ import annotations
+
+from youtube_extension import main as app_main
+
+
+def test_auth_mode_fail_closed_by_default(monkeypatch):
+    monkeypatch.delenv("EVENTRELAY_API_KEY", raising=False)
+    monkeypatch.delenv("ALLOW_UNAUTHENTICATED", raising=False)
+    assert app_main._auth_mode() == "fail_closed"
+
+
+def test_auth_mode_open_dev_when_allow_unauthenticated(monkeypatch):
+    monkeypatch.delenv("EVENTRELAY_API_KEY", raising=False)
+    monkeypatch.setenv("ALLOW_UNAUTHENTICATED", "1")
+    assert app_main._auth_mode() == "open_dev"
+
+
+def test_auth_mode_api_key_when_configured(monkeypatch):
+    monkeypatch.setenv("EVENTRELAY_API_KEY", "test-secret")
+    monkeypatch.delenv("ALLOW_UNAUTHENTICATED", raising=False)
+    assert app_main._auth_mode() == "api_key"
+
+
+def test_video_dep_status_keys(monkeypatch):
+    status = app_main._video_dep_status()
+    assert set(status) == {"yt_dlp", "youtube_transcript_api"}
+    assert all(isinstance(v, bool) for v in status.values())

--- a/tests/unit/test_local_pipeline_readiness.py
+++ b/tests/unit/test_local_pipeline_readiness.py
@@ -23,7 +23,55 @@ def test_auth_mode_api_key_when_configured(monkeypatch):
     assert app_main._auth_mode() == "api_key"
 
 
+def test_auth_mode_api_key_when_whitespace_only(monkeypatch):
+    # APIKeyAuthMiddleware treats a whitespace-only value as a configured key
+    # (it requires that key on protected routes); the diagnostic must agree
+    # rather than reporting fail_closed.
+    monkeypatch.setenv("EVENTRELAY_API_KEY", "   ")
+    monkeypatch.delenv("ALLOW_UNAUTHENTICATED", raising=False)
+    assert app_main._auth_mode() == "api_key"
+
+
 def test_video_dep_status_keys(monkeypatch):
     status = app_main._video_dep_status()
     assert set(status) == {"yt_dlp", "youtube_transcript_api"}
     assert all(isinstance(v, bool) for v in status.values())
+
+
+async def test_health_check_contract_when_video_ready(monkeypatch):
+    monkeypatch.setattr(
+        app_main,
+        "_video_dep_status",
+        lambda: {"yt_dlp": True, "youtube_transcript_api": True},
+    )
+    monkeypatch.delenv("EVENTRELAY_API_KEY", raising=False)
+    monkeypatch.setenv("ALLOW_UNAUTHENTICATED", "1")
+
+    payload = await app_main.health_check()
+
+    assert set(payload) == {
+        "status",
+        "service",
+        "auth_mode",
+        "video_deps",
+        "video_path_ready",
+    }
+    assert payload["status"] == "healthy"
+    assert payload["service"] == "uvai-youtube-extension"
+    assert payload["auth_mode"] == "open_dev"
+    assert payload["video_deps"] == {"yt_dlp": True, "youtube_transcript_api": True}
+    assert payload["video_path_ready"] is True
+
+
+async def test_health_check_contract_when_video_not_ready(monkeypatch):
+    monkeypatch.setattr(
+        app_main,
+        "_video_dep_status",
+        lambda: {"yt_dlp": True, "youtube_transcript_api": False},
+    )
+
+    payload = await app_main.health_check()
+
+    # A single missing dependency must flip the aggregate to not-ready.
+    assert payload["video_deps"] == {"yt_dlp": True, "youtube_transcript_api": False}
+    assert payload["video_path_ready"] is False


### PR DESCRIPTION
## Canonical issue

Closes #1347

## Outcome

Local developers can run the full FastAPI + Next pipeline without opaque 503s and without missing yt-dlp / youtube-transcript-api:

1. **F6** — `scripts/dev_backend.sh` defaults `ALLOW_UNAUTHENTICATED=1` when no key is set; README documents key vs escape hatch; `.env.example` notes Next must share `EVENTRELAY_API_KEY` when using a key.
2. **F7** — README install is `pip install -e ".[dev,youtube]"`; dev script warns on missing packages; `/health` exposes `video_deps` + `video_path_ready`.

## Scope

- Included: `main.py` health fields, `scripts/dev_backend.sh`, README, `.env.example`, unit tests
- Explicitly excluded: production auth policy changes, dual ActionImplementer (F4), Vercel deployment protection bypass

## Risk

- Risk level: low
- Failure mode: health payload gains fields only; default production still fail-closed without key/opt-in
- Rollback: revert this PR

## Verification

Head `119dd0e8d76696a55db13622e574e4ddfbb8d23c`.

- [x] Focused tests: `pytest tests/unit/test_local_pipeline_readiness.py tests/unit/test_api_key_auth.py --no-cov` (12 pass)
- [ ] Required CI green on current head
- [ ] Review threads resolved

## Production evidence

Not applicable for production deploy: local DX / health diagnostics only. Production must keep `EVENTRELAY_API_KEY` set and never set `ALLOW_UNAUTHENTICATED=1`.

## Agent handoff

- [x] One canonical issue is linked
- [x] No competing PR implements the same issue
- [x] Acceptance criteria satisfied in code + unit tests
- [ ] Required checks pass on the current head
- [x] Human decision only for product/security/production approval

## Agent provenance

Human-authored (Grok Build on Dev canonical tree).
