### PR TITLE
fix(agents): resolve dual ActionImplementer (F4)

### DIFF
--- a/scripts/continuous_runner.py
+++ b/scripts/continuous_runner.py
@@ -15,7 +15,8 @@ except ImportError:
     from agents.process_video_with_mcp import RealVideoProcessor
 from datetime import datetime
 
-# Reuse existing implementer to turn actions into plans
+# Offline plan builder only (not ActionImplementerAgent — F4).
+# Product orchestrator path uses adapters.action_implementer_agent.
 try:
     from ..agents.action_implementer import ActionImplementer
 except ImportError:

--- a/src/agents/action_implementer.py
+++ b/src/agents/action_implementer.py
@@ -1,13 +1,32 @@
 #!/usr/bin/env python3
 """
-ACTION IMPLEMENTER
-Helps users implement generated actions from video processing
+Offline action implementation plan builder (F4 — non-agent path)
+================================================================
+
+This module is **not** the FastAPI/orchestrator agent.
+
+Canonical product agent (registered as ``action_implementer``)::
+
+    from youtube_extension.services.agents.adapters.action_implementer_agent import (
+        ActionImplementerAgent,
+    )
+
+This file keeps the file-oriented batch helper used by continuous runners and
+``video_to_action_workflow`` (load processed JSON → write implementation plans
+under ``action_implementations/``). It intentionally does not register with
+the agent registry.
+
+``ActionImplementerAgent`` is re-exported below so callers that historically
+imported from ``agents.action_implementer`` can migrate without hunting paths.
 """
+
+from __future__ import annotations
 
 import asyncio
 import json
 import logging
 import sys
+import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -22,10 +41,42 @@ logging.basicConfig(
 )
 logger = logging.getLogger("action_implementer")
 
+# Product agent re-export (canonical orchestrator path). Optional import so this
+# offline helper still loads when youtube_extension is not on PYTHONPATH.
+try:
+    from youtube_extension.services.agents.adapters.action_implementer_agent import (  # noqa: E402
+        ActionImplementerAgent,
+        ActionPlan,
+    )
+except ImportError:  # pragma: no cover - standalone script path
+    try:
+        from src.youtube_extension.services.agents.adapters.action_implementer_agent import (
+            ActionImplementerAgent,
+            ActionPlan,
+        )
+    except ImportError:
+        ActionImplementerAgent = None  # type: ignore[misc, assignment]
+        ActionPlan = None  # type: ignore[misc, assignment]
+
+
 class ActionImplementer:
-    """Helps implement generated actions from video processing"""
+    """Offline batch builder for implementation plans from processed video JSON.
+
+    Not a BaseAgent. Prefer :class:`ActionImplementerAgent` for orchestrator /
+    registry workflows.
+    """
+
+    #: Marker so call sites and tests can distinguish offline vs agent path.
+    role = "offline_plan_builder"
 
     def __init__(self):
+        warnings.warn(
+            "ActionImplementer is the offline plan builder. For orchestrator/"
+            "agent registration use ActionImplementerAgent "
+            "(youtube_extension.services.agents.adapters.action_implementer_agent).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.output_dir = Path('action_implementations')
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -408,7 +459,7 @@ class ActionImplementer:
                     print(f"        • ... and {len(implementation['next_steps']) - 3} more steps")
 
 async def main():
-    """Main execution function"""
+    """Main execution function (offline CLI; not the orchestrator agent)."""
 
     if len(sys.argv) < 2:
         print("Usage: python action_implementer.py <video_id>")
@@ -416,7 +467,9 @@ async def main():
         sys.exit(1)
 
     video_id = sys.argv[1]
-    implementer = ActionImplementer()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        implementer = ActionImplementer()
 
     try:
         # Load processed video data

--- a/src/youtube_extension/services/agents/action_implementer_agent.py
+++ b/src/youtube_extension/services/agents/action_implementer_agent.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 """
-Compatibility shim for the Action Implementer agent.
+Compatibility shim for the Action Implementer agent (F4).
 
-The refactored implementation resides in
-``src.youtube_extension.services.agents.adapters.action_implementer_agent``.
-This module simply re-exports the public class so older imports remain valid.
+Canonical implementation:
+``youtube_extension.services.agents.adapters.action_implementer_agent``.
+
+There is only one registered agent class. Do not import
+``src.agents.action_implementer.ActionImplementer`` for orchestrator work —
+that module is the offline plan builder only.
 """
 
-from src.youtube_extension.services.agents.adapters.action_implementer_agent import (
+from .adapters.action_implementer_agent import (
     ActionImplementerAgent,
     ActionPlan,
 )

--- a/src/youtube_extension/services/agents/adapters/action_implementer_agent.py
+++ b/src/youtube_extension/services/agents/adapters/action_implementer_agent.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
 """
-Action Implementer Agent Service
-=================================
+Action Implementer Agent Service (canonical product path — F4)
+==============================================================
 
-Extracted and refactored from development/agents/action_implementer.py
-Provides actionable task generation and implementation planning with clean service interfaces.
+Registered name: ``action_implementer`` (BaseAgent for the FastAPI orchestrator).
+
+This is the **only** agent implementation used by the service container and
+agent registry. The offline batch plan builder at
+``src/agents/action_implementer.py`` (class ``ActionImplementer``) is a
+separate, non-registered helper for continuous-runner style workflows; it is
+not a second agent.
+
+Shim re-export: ``youtube_extension.services.agents.action_implementer_agent``.
 """
 
 import asyncio

--- a/tests/unit/test_action_implementer_f4_dual.py
+++ b/tests/unit/test_action_implementer_f4_dual.py
@@ -1,0 +1,60 @@
+"""F4 — dual ActionImplementer resolution.
+
+Canonical product agent: adapters.ActionImplementerAgent (registered name).
+Offline batch helper: agents.action_implementer.ActionImplementer (not registered).
+Shim re-exports the adapter class only.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+
+def test_shim_exports_same_class_as_adapter():
+    from youtube_extension.services.agents import action_implementer_agent as shim
+    from youtube_extension.services.agents.adapters import (
+        action_implementer_agent as adapter,
+    )
+
+    assert shim.ActionImplementerAgent is adapter.ActionImplementerAgent
+    assert shim.ActionImplementerAgent.name == "action_implementer"
+
+
+def test_offline_builder_is_not_the_agent():
+    from agents.action_implementer import ActionImplementer
+    from youtube_extension.services.agents.adapters.action_implementer_agent import (
+        ActionImplementerAgent,
+    )
+
+    assert ActionImplementer is not ActionImplementerAgent
+    assert getattr(ActionImplementer, "role", None) == "offline_plan_builder"
+    assert ActionImplementerAgent.name == "action_implementer"
+
+
+def test_offline_builder_warns_and_reexports_agent():
+    from agents import action_implementer as offline_mod
+    from youtube_extension.services.agents.adapters.action_implementer_agent import (
+        ActionImplementerAgent as Canonical,
+    )
+
+    assert offline_mod.ActionImplementerAgent is Canonical
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        offline_mod.ActionImplementer()
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_registry_registers_adapter_once():
+    # Importing the adapter module runs @register.
+    from youtube_extension.services.agents.adapters.action_implementer_agent import (
+        ActionImplementerAgent,
+    )
+    from youtube_extension.services.agents import registry as reg_mod
+
+    registry = reg_mod._REG
+    assert "action_implementer" in registry
+    assert registry["action_implementer"] is ActionImplementerAgent
+    # Single name → single class (no dual registration under aliases).
+    aliases = [k for k, v in registry.items() if v is ActionImplementerAgent]
+    assert aliases == ["action_implementer"]


### PR DESCRIPTION
## Canonical issue

Closes #1353

## Outcome

EventRelay has a single registered **ActionImplementerAgent** for orchestrator/registry work. The offline **ActionImplementer** batch plan builder remains for continuous-runner/CLI only, with an explicit roleprecation warning and migration re-export of the agent class. Shim import is relative so class identity is singular.

## Scope

- Included:
  - adapters + shim docs
  - `src/agents/action_implementer.py` offline role + re-export + warning
  - continuous_runner comment
  - `tests/unit/test_action_implementer_f4_dual.py`
- Explicitly excluded:
  - Rewriting offline plan templates into the agent
  - Deleting continuous-runner offline path
  - F8+ ownership / archive work

## Risk

- Risk level: low
- Failure mode: DeprecationWarning on offline constructor may surface in strict warning filters; continuous_runner still works
- Rollback: revert this PR

## Verification

Head `e4bf1bcffbb618d7c15b410dc6b90a5eab312f03`.

- [x] Focused tests: `pytest tests/unit/test_action_implementer_f4_dual.py -k action_implementer --no-cov` (4 pass) + shim coverage (4 pass)
- [ ] Required CI green on current head
- [ ] Review threads resolved

## Production evidence

Not applicable — agent graph clarification / import hygiene only; no deploy surface change.

## Agent handoff

- [x] One canonical issue is linked
- [x] No competing PR implements the same issue
- [x] Acceptance criteria satisfied in code + unit tests
- [ ] Required checks pass on the current head
- [x] Human decision only for product/security/production approval

## Agent provenance

Human-authored (Grok Build on Dev canonical tree).
