### PR TITLE
fix(perf): correct metrics_recorded count and close SQLite handle on error in _store_metric

### DIFF
--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -1191,7 +1191,7 @@ async def ingest_performance_report_v1(report: dict[str, Any]):
                     "unit": str(stats.get("unit", "ms")),
                 })
         await performance_monitor.record_metrics(samples)
-        return {"status": "ok", "metrics_recorded": len(metrics)}
+        return {"status": "ok", "metrics_recorded": len(samples)}
     except Exception as e:
         logger.error(f"Failed to ingest performance report: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/src/youtube_extension/backend/services/performance_monitor.py
+++ b/src/youtube_extension/backend/services/performance_monitor.py
@@ -368,31 +368,7 @@ class PerformanceMonitor:
 
     async def _store_metric(self, metric: PerformanceMetric):
         """Store metric in database"""
-
-        def _write() -> None:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
-
-            cursor.execute('''
-                INSERT INTO performance_metrics
-                (component, metric_name, value, unit, tags, timestamp)
-                VALUES (?, ?, ?, ?, ?, ?)
-            ''', (
-                metric.component,
-                metric.metric_name,
-                metric.value,
-                metric.unit,
-                json.dumps(metric.tags),
-                metric.timestamp.isoformat()
-            ))
-
-            conn.commit()
-            conn.close()
-
-        try:
-            await asyncio.to_thread(_write)
-        except Exception as e:
-            logger.error(f"Failed to store metric in database: {e}")
+        await self._store_metrics([metric])
 
     async def _check_alert_thresholds(self, metric: PerformanceMetric):
         """Check if metric exceeds alert thresholds"""

--- a/tests/unit/test_v1_router_extended.py
+++ b/tests/unit/test_v1_router_extended.py
@@ -702,6 +702,30 @@ class TestPerformanceEndpoints:
         assert [s["value"] for s in samples] == [1200.0, 30.0]
         assert {s["component"] for s in samples} == {"frontend"}
 
+    def test_performance_report_counts_only_persisted_samples(self, client):
+        """``metrics_recorded`` reports samples written, not keys submitted.
+
+        Non-numeric ``current`` values are skipped by the ingest loop, so a
+        mixed report must count only the numeric samples that were actually
+        handed to ``record_metrics``.
+        """
+        payload = {
+            "metrics": {
+                "lcp": {"current": 1200, "unit": "ms"},
+                "note": {"current": "n/a"},
+            }
+        }
+        with patch.object(
+            router_module.performance_monitor, "record_metrics", new_callable=AsyncMock
+        ) as mock_record:
+            resp = client.post("/api/v1/performance/report", json=payload)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["metrics_recorded"] == 1
+
+        (samples,) = mock_record.await_args.args
+        assert [s["metric_name"] for s in samples] == ["lcp"]
+
     def test_performance_report_empty(self, client):
         resp = client.post("/api/v1/performance/report", json={})
         assert resp.status_code == 200


### PR DESCRIPTION
## Canonical issue

Closes #1352

## Outcome

`POST /api/v1/performance/report` now returns the number of samples actually persisted (`len(samples)`) instead of the number of metric keys submitted, so reports mixing numeric and non-numeric values no longer overcount. The legacy `_store_metric` now delegates to the batched `_store_metrics` with a one-element list, inheriting its `try/finally` so an exception mid-write no longer leaks the SQLite connection.

## Scope

- Included: the two defects tracked in the linked issue, plus a regression test for the mixed-report count.
- Explicitly excluded: any behavior changes to the batched write path from #1341.

## Risk

- Risk level: low
- Failure mode: clients relying on the old (incorrect) submitted-key count would see a lower `metrics_recorded` value for mixed reports.
- Rollback: revert the single commit.

## Verification

At head `cbb020f1ef3555a8e842d572651b4c00e347ee68`:

- [x] Focused tests — `pytest tests/unit/test_v1_router_extended.py -k performance`: 7 passed, including the new `test_performance_report_counts_only_persisted_samples`.
- [x] Smoke test — `_store_metric` exercised against a temp SQLite DB; the row is written through the batched path.
- [ ] Required CI
- [ ] Review threads resolved

## Production evidence

Not applicable — backend-only bug fix, covered by unit tests.

## Agent handoff

- [x] One canonical issue is linked
- [x] No competing PR implements the same issue
- [x] Acceptance criteria are satisfied
- [ ] Required checks pass on the current head
- [x] Human decision is requested only for product, security, irreversible infrastructure, or production approval

## Agent provenance

<!-- agent-lock-manifest
{"issue_number": 1352, "agent_login": "linear-code[bot]", "run_id": "6d3cc388"}
-->
