### PR TITLE
fix(cloud): authenticate task requests before payload validation

### DIFF
--- a/src/youtube_extension/backend/cloud_api_endpoints.py
+++ b/src/youtube_extension/backend/cloud_api_endpoints.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from fastapi import APIRouter, BackgroundTasks, FastAPI, Header, HTTPException, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 # Import cloud services
 from ..services.cloud import (
@@ -143,9 +143,24 @@ async def process_video_cloud(
         # detail is a static string; error_msg (with the exception) is logged above only
         raise HTTPException(status_code=500, detail="Internal server error")
 
-@router.post("/api/v3/process-video-task")
+@router.post(
+    "/api/v3/process-video-task",
+    # The body is parsed manually after the Cloud Tasks header check, so the
+    # schema is declared here to keep it documented in OpenAPI.
+    openapi_extra={
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "schema": CloudTaskPayload.model_json_schema(
+                        ref_template="#/components/schemas/{model}"
+                    )
+                }
+            },
+        }
+    },
+)
 async def process_video_task_handler(
-    payload: CloudTaskPayload,
     request: Request,
     x_cloudtasks_taskname: Optional[str] = Header(None),
 ):
@@ -162,6 +177,13 @@ async def process_video_task_handler(
             status_code=403,
             detail="Only Cloud Tasks can call this endpoint"
         )
+
+    try:
+        payload = CloudTaskPayload.model_validate_json(await request.body())
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=422, detail=exc.errors(include_input=False)
+        ) from exc
 
     logger.info(
         f"📝 Processing Cloud Task: {x_cloudtasks_taskname} "

--- a/tests/unit/test_cloud_routes.py
+++ b/tests/unit/test_cloud_routes.py
@@ -604,6 +604,13 @@ class TestCloudApiEndpoints:
         })
         assert response.status_code == 403
 
+    def test_process_video_task_no_header_malformed_payload_still_403(self):
+        client = self._build_app()
+        response = client.post("/api/v3/process-video-task", json={
+            "video_id": "auJzb1D-fag",
+        })
+        assert response.status_code == 403
+
     def test_process_video_task_with_header_success(self):
         state = self._make_state()
 
@@ -625,6 +632,33 @@ class TestCloudApiEndpoints:
         data = response.json()
         assert data["success"] is True
         assert data["video_id"] == "auJzb1D-fag"
+
+    def test_process_video_task_with_header_malformed_payload_returns_422(self):
+        client = self._build_app()
+        response = client.post(
+            "/api/v3/process-video-task",
+            json={"video_id": "auJzb1D-fag"},
+            headers={"X-CloudTasks-TaskName": "task-abc-123"},
+        )
+        assert response.status_code == 422
+
+    def test_process_video_task_with_header_invalid_utf8_returns_422(self):
+        client = self._build_app()
+        response = client.post(
+            "/api/v3/process-video-task",
+            content=b"\xff",
+            headers={"X-CloudTasks-TaskName": "task-abc-123"},
+        )
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["type"] == "json_invalid"
+
+    def test_process_video_task_documents_request_body_schema(self):
+        client = self._build_app()
+        spec = client.app.openapi()
+        operation = spec["paths"]["/api/v3/process-video-task"]["post"]
+        schema = operation["requestBody"]["content"]["application/json"]["schema"]
+        assert operation["requestBody"]["required"] is True
+        assert set(schema["required"]) == {"video_id", "video_url"}
 
     def test_process_video_task_exception(self):
         mock_processor = AsyncMock()


### PR DESCRIPTION
## Canonical issue

Closes #1134

## Outcome

`/api/v3/process-video-task` now checks the Cloud Tasks `X-CloudTasks-TaskName` gate before parsing the request body. Unauthorized malformed calls return `403`; authorized malformed calls (including invalid UTF-8 bodies) keep strict `422` validation; authorized valid calls behave exactly as before.

## Scope

- Included: `src/youtube_extension/backend/cloud_api_endpoints.py`, `tests/unit/test_cloud_routes.py` — an exact port of the canonical two-file artifact from #1132 (head `42939e0012ed2d3bab18de445655c98da0ad6980`) onto current `main`, since that branch is now in a conflicting (dirty) merge state.
- Explicitly excluded: Cloud Tasks queue construction, payload format changes, auth expansion, production configuration, unrelated refactors.

## Risk

- Risk level: low
- Failure mode: body parsing regression on the task handler; the OpenAPI request-body schema is preserved via `openapi_extra` and covered by a test.
- Rollback: revert the single two-file commit.

## Verification

- [x] Focused tests: `pytest tests/unit/test_cloud_routes.py -k process_video_task --no-cov` — 7 passed (403-before-422 ordering, malformed authorized 422, invalid UTF-8 422, OpenAPI schema)
- [x] Full `tests/unit/test_cloud_routes.py` — 93 passed
- [x] `ruff check` on both files — only pre-existing B904 findings in untouched code
- [ ] Required CI on this head
- [ ] Review threads resolved

## Production evidence

No production mutation is authorized by the linked issue; not applicable.

## Agent handoff

- [x] One canonical issue is linked
- [ ] No competing PR implements the same issue — #1132 contains the same artifact but is stale/conflicting against `main`; one of the two should be closed once this head verifies
- [x] Acceptance criteria are satisfied
- [ ] Required checks pass on the current head
- [x] Human decision is requested only for product, security, irreversible infrastructure, or production approval

## Agent provenance

<!-- agent-lock-manifest
{"issue_number": 1134, "agent_login": "linear-code[bot]", "run_id": "agent-session-95a9c398"}
-->

<!-- agent-lock-event-example
{"kind": "artifact_ready", "run_id": "provider-run-id", "head_sha": "0000000000000000000000000000000000000000"}
-->
