### PR TITLE
docs: record F8 web ownership (EventRelay apps/web → uvai.io)

### DIFF
--- a/docs/F8_WEB_OWNERSHIP.md
+++ b/docs/F8_WEB_OWNERSHIP.md
@@ -1,0 +1,25 @@
+# F8 — uvai.io vs EventRelay web ownership
+
+**Decided:** 2026-08-04  
+**SSOT (full evidence):** `/Users/garvey/BrainVault/UVAI-EventRelay-SSOT/11-F8-WEB-OWNERSHIP.md`
+
+## Decision
+
+| Role | Owner |
+|------|--------|
+| **Canonical product frontend** | **`apps/web`** in this repository |
+| **Production domain `https://uvai.io`** | Vercel project **`v0-uvai`** (rootDirectory `apps/web`) |
+| **GitHub `groupthinking/uvai.io`** (`package.json` name `next-enterprise`) | **Non-canonical** — freeze; no product feature work |
+
+Root `vercel.json` already permanent-redirects `v0-uvai.vercel.app` and `event-relay-web.vercel.app` to `https://uvai.io`. The EventRelay GitHub homepage is `https://uvai.io`.
+
+## Rules for agents
+
+1. Ship UI/API product changes only under `apps/web`.
+2. Do not open product PRs against `groupthinking/uvai.io`.
+3. Local clone under `ALL VID-ANYTHING /uvai.io` is retired for product (see `RETIRED.md` there).
+
+## Optional hygiene (not blocking)
+
+- Rename `apps/web` package from `building-production-ai-infrastructure-platform` to a clearer name.
+- Point `groupthinking/uvai.io` README at EventRelay if that remote is retained for history.


### PR DESCRIPTION
## Canonical issue

Closes #1365

## Outcome

Agents and humans have a written ownership rule: **EventRelay `apps/web`** is the only product frontend; **https://uvai.io** is served by Vercel project **v0-uvai** from that tree. The separate **groupthinking/uvai.io** repo (Blazity `next-enterprise`) is non-canonical for product features.

## Scope

- Included: `docs/F8_WEB_OWNERSHIP.md`
- Explicitly excluded: package rename, deleting uvai.io remote, DNS changes

## Risk

- Risk level: low
- Failure mode: docs-only; no runtime change
- Rollback: revert this PR

## Verification

Head `f469bed8eb5a434579c29be798b0f9fd1273d5e9`.

- [x] Evidence: 26 vs 7 API routes; vercel.json redirects to uvai.io; Vercel project rootDirectory apps/web
- [ ] Required CI green on current head
- [ ] Review threads resolved

## Production evidence

Not applicable — documentation of existing deploy topology only (no code path change).

## Agent handoff

- [x] One canonical issue is linked
- [x] No competing PR implements the same issue
- [x] Acceptance criteria satisfied
- [ ] Required checks pass on the current head
- [x] Human decision only for product/security/production approval

## Agent provenance

Human-authored (Grok Build on Dev canonical tree).
