### PR TITLE
fix: remove Stripe placeholder secret defaults; reconcile stale audit docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,9 @@ Baseline pulse identified the following gaps between repo `main` and the live
 
 ### Notes / known follow-ups (not in this change)
 
-- `apps/web/next.config.js` contains duplicate `redirects()` / `headers()`
-  function declarations — only the last in source order is used at runtime.
-  Consolidation is a separate refactor and was intentionally left out of
-  this low-risk change.
+- ~~`apps/web/next.config.js` contains duplicate `redirects()` / `headers()`
+  function declarations~~ — resolved since: the file now contains exactly one
+  `redirects()` and one `headers()` declaration.
 - Live `uvai.io` title `UVAI — Video to Software` is stale vs `main`
   (`UVAI — The Action Layer for Video`). Resolving requires redeploy and is
   out of scope for this PR (no production / Vercel access used).

--- a/docs/NPM_VULNERABILITIES.md
+++ b/docs/NPM_VULNERABILITIES.md
@@ -7,7 +7,9 @@
 > `@ai-sdk/provider-utils`), and `next` is pinned to `^16.2.11` via the root
 > `package.json` `overrides` (resolves 16.2.12), past the vulnerable
 > 15.6.0-canary.0–16.1.4 range. This report is retained for the historical
-> record only.
+> record only. (Separately, `npm audit` as of 2026-08-04 reports 4 new
+> unrelated advisories — 2 high in `ip-address`, 2 moderate in `postcss` —
+> all fixable via `npm audit fix`.)
 
 **Date**: 2026-02-08
 **After Cleanup**: Post repository cleanup

--- a/docs/NPM_VULNERABILITIES.md
+++ b/docs/NPM_VULNERABILITIES.md
@@ -1,5 +1,14 @@
 # NPM Vulnerabilities Report
 
+> **✅ Superseded (2026-08-04):** The vulnerabilities documented below are no
+> longer present. `devalue` and the `@workflow/*` packages that depended on it
+> are gone from `package-lock.json` (only `@workflow/serde@4.1.0`, which does
+> not use `devalue`, remains as a transitive dependency of
+> `@ai-sdk/provider-utils`), and `next` is pinned to `^16.2.11` via the root
+> `package.json` `overrides` (resolves 16.2.12), past the vulnerable
+> 15.6.0-canary.0–16.1.4 range. This report is retained for the historical
+> record only.
+
 **Date**: 2026-02-08
 **After Cleanup**: Post repository cleanup
 

--- a/docs/analysis/EXECUTIVE_SUMMARY.md
+++ b/docs/analysis/EXECUTIVE_SUMMARY.md
@@ -8,6 +8,17 @@
 
 ## 🎯 Overall Assessment: **YELLOW** - Requires Remediation Before Production
 
+> **⚠️ Superseded (2026-08-04):** The security findings in this 2025-12-03
+> analysis have since been resolved and re-verified against the current
+> codebase — pickle deserialization removed (JSON-based
+> `intelligent_cache.py`), the `frontend/` directory (and its
+> `dangerouslySetInnerHTML` usage) replaced by `apps/web`, subprocess calls
+> hardened to list-form args, and the npm vulnerability chain eliminated
+> (`devalue` gone, `next` pinned `^16.2.11`). See the Resolution Status
+> tables in [SECURITY_REPORT.md](./SECURITY_REPORT.md) and
+> [REMEDIATION_PLAN.md](./REMEDIATION_PLAN.md). The assessment below is
+> retained as a historical snapshot.
+
 The EventRelay codebase shows strong architectural vision but requires targeted security fixes and code consolidation before production deployment.
 
 ### Key Metrics

--- a/docs/analysis/PRODUCTION_CHECKLIST.md
+++ b/docs/analysis/PRODUCTION_CHECKLIST.md
@@ -1,19 +1,20 @@
 # EventRelay Production Checklist
 
 **Assessment Date:** 2025-12-03  
+**Last Re-verified:** 2026-08-04 (security/dependency findings re-checked against code)  
 **Target Environment:** Cloud (GCP Cloud Run)
 
 ---
 
 ## 🚦 Go/No-Go Decision Matrix
 
-### Overall Status: **🔴 NO-GO** (Until P0 items resolved)
+### Overall Status: **🟡 CONDITIONAL** (security blockers cleared; operational readiness items remain)
 
 | Category | Status | Blockers |
 |----------|--------|----------|
-| Security | 🔴 NO-GO | 3 critical items |
-| Dependencies | 🔴 NO-GO | 31 npm vulnerabilities |
-| Testing | 🟡 CONDITIONAL | Fragmented but functional |
+| Security | 🟢 GO | SEC-001..005 resolved (see SECURITY_REPORT.md Resolution Status) |
+| Dependencies | 🟢 GO | Vulnerable `devalue` chain removed; `next` pinned `^16.2.11` |
+| Testing | 🟡 CONDITIONAL | Coverage enforced (`fail_under = 88.1833`); E2E/perf gaps remain |
 | CI/CD | 🟢 GO | Pipelines present |
 | Observability | 🟢 GO | Logging configured |
 | Configuration | 🟡 CONDITIONAL | Needs cleanup |
@@ -26,11 +27,11 @@
 
 ### Critical (Must Pass)
 
-- [ ] **SEC-001:** Pickle vulnerability fixed in `intelligent_cache.py`
-- [ ] **SEC-002:** `npm audit --audit-level=high` returns 0 vulnerabilities
-- [ ] **SEC-003:** No `dangerouslySetInnerHTML` with dynamic content
-- [ ] **SEC-004:** Subprocess input audit completed
-- [ ] **SEC-005:** `.env` file gitignored (verified ✅)
+- [x] **SEC-001:** Pickle vulnerability fixed in `intelligent_cache.py`
+- [x] **SEC-002:** `npm audit --audit-level=high` returns 0 vulnerabilities
+- [x] **SEC-003:** No `dangerouslySetInnerHTML` with dynamic content
+- [x] **SEC-004:** Subprocess input audit completed
+- [x] **SEC-005:** `.env` file gitignored (verified ✅)
 
 ### Required (Should Pass)
 
@@ -135,7 +136,7 @@
 ### Unit Tests
 
 - [x] Unit tests present (~60 files)
-- [ ] Coverage meets threshold (>80%)
+- [x] Coverage meets threshold (>80%) — enforced at `fail_under = 88.1833` in `pyproject.toml`
 - [ ] Critical paths covered
 - [ ] Edge cases tested
 
@@ -237,16 +238,21 @@
 
 ## 🎯 Production Readiness Score
 
+*Re-scored 2026-08-04 after verifying the security and dependency findings are
+resolved and coverage is enforced in CI. Operational areas (staging, load
+testing, runbooks, alerting) were not re-assessed and keep their original
+scores.*
+
 | Area | Weight | Score | Weighted |
 |------|--------|-------|----------|
-| Security | 30% | 40/100 | 12 |
-| Testing | 20% | 60/100 | 12 |
+| Security | 30% | 85/100 | 25.5 |
+| Testing | 20% | 70/100 | 14 |
 | CI/CD | 15% | 80/100 | 12 |
 | Observability | 15% | 70/100 | 10.5 |
 | Documentation | 10% | 50/100 | 5 |
 | Infrastructure | 10% | 60/100 | 6 |
 
-**Total Score: 57.5/100** - **NOT READY FOR PRODUCTION**
+**Total Score: 73/100** - **CONDITIONAL** (was 57.5/100 🔴 NO-GO in the 2025-12-03 assessment)
 
 ### Required for Launch: **75/100**
 
@@ -254,12 +260,10 @@
 
 ## 🚀 Path to Production
 
-1. **Week 1:** Fix critical security issues → +20 points
-2. **Week 2:** Resolve npm vulnerabilities → +10 points
-3. **Week 3:** Consolidate tests, add coverage → +5 points
-4. **Week 4:** Documentation and monitoring → +5 points
-
-**Projected Score After Remediation:** 97.5/100 - **READY FOR PRODUCTION**
+1. ~~Fix critical security issues~~ ✅ Done (SEC-001..005 resolved)
+2. ~~Resolve npm vulnerabilities~~ ✅ Done (`devalue` chain removed, `next` ≥16.2.11)
+3. Load testing and baseline performance metrics
+4. Staging validation, runbooks, and alerting → clears the 75-point launch bar
 
 ---
 

--- a/docs/analysis/PRODUCTION_CHECKLIST.md
+++ b/docs/analysis/PRODUCTION_CHECKLIST.md
@@ -13,7 +13,7 @@
 | Category | Status | Blockers |
 |----------|--------|----------|
 | Security | 🟢 GO | SEC-001..005 resolved (see SECURITY_REPORT.md Resolution Status) |
-| Dependencies | 🟢 GO | Vulnerable `devalue` chain removed; `next` pinned `^16.2.11` |
+| Dependencies | 🟡 CONDITIONAL | Original 31-vuln chain removed (`devalue` gone, `next` pinned `^16.2.11`); as of 2026-08-04 `npm audit` reports 4 new unrelated advisories (2 high `ip-address`, 2 moderate `postcss`), all fixable via `npm audit fix` |
 | Testing | 🟡 CONDITIONAL | Coverage enforced (`fail_under = 88.1833`); E2E/perf gaps remain |
 | CI/CD | 🟢 GO | Pipelines present |
 | Observability | 🟢 GO | Logging configured |
@@ -28,7 +28,7 @@
 ### Critical (Must Pass)
 
 - [x] **SEC-001:** Pickle vulnerability fixed in `intelligent_cache.py`
-- [x] **SEC-002:** `npm audit --audit-level=high` returns 0 vulnerabilities
+- [x] **SEC-002:** Original finding (31 vulns: `devalue`/`@workflow/*`/vulnerable `next`) resolved — note new unrelated advisories surface over time; see Dependencies row above
 - [x] **SEC-003:** No `dangerouslySetInnerHTML` with dynamic content
 - [x] **SEC-004:** Subprocess input audit completed
 - [x] **SEC-005:** `.env` file gitignored (verified ✅)

--- a/docs/analysis/REMEDIATION_PLAN.md
+++ b/docs/analysis/REMEDIATION_PLAN.md
@@ -5,6 +5,21 @@
 
 ---
 
+## ✅ Resolution Status (re-verified against code, 2026-08-04)
+
+All P0/P1 security items in this plan are resolved in the current codebase.
+The entries below are retained for the historical record — do not re-remediate.
+
+| Item | Status | Evidence |
+|------|--------|----------|
+| REM-001 (pickle) | ✅ RESOLVED | `intelligent_cache.py` is JSON-based (`# pickle removed for security`) |
+| REM-002 (npm vulns) | ✅ RESOLVED | `devalue` chain gone from `package-lock.json`; `next` pinned `^16.2.11` via root `overrides` |
+| REM-003 (dangerouslySetInnerHTML) | ✅ RESOLVED | Old `frontend/` removed in `apps/web` migration; zero usages remain |
+| REM-004 (subprocess audit) | ✅ RESOLVED | List-form args throughout, with SECURITY comments |
+| REM-005..008 (code quality) | Tracked separately | Non-security hygiene items; see current issue tracker |
+
+---
+
 ## 🚨 P0 - Critical (Fix Immediately)
 
 ### REM-001: Fix Pickle Deserialization Vulnerability

--- a/docs/analysis/SECURITY_REPORT.md
+++ b/docs/analysis/SECURITY_REPORT.md
@@ -6,6 +6,26 @@
 
 ---
 
+## ✅ Resolution Status (re-verified against code, 2026-08-04)
+
+The findings below are preserved as originally written for the historical
+record. Re-verification against the current codebase shows all of them
+resolved:
+
+| Finding | Status | Evidence |
+|---------|--------|----------|
+| SEC-001 (pickle) | ✅ RESOLVED | `src/youtube_extension/backend/services/intelligent_cache.py` uses JSON serialization (`# pickle removed for security`); no `import pickle` remains under `src/youtube_extension/` |
+| SEC-002 (npm vulns) | ✅ RESOLVED | Vulnerable `devalue` chain no longer in `package-lock.json`; `next` pinned `^16.2.11` via root `overrides` (resolves 16.2.12, past the 15.6.0-canary.0–16.1.4 vulnerable range) |
+| SEC-003 (dangerouslySetInnerHTML) | ✅ RESOLVED | The old `frontend/` directory (incl. `LearningFusion.tsx`) was removed in the `apps/web` migration; zero `dangerouslySetInnerHTML` usages in `apps/` or `src/` |
+| SEC-004 (subprocess) | ✅ RESOLVED | Subprocess calls use list-form args (no `shell=True`) with explicit SECURITY comments (e.g. `cli.py`, `enhanced_video_processor.py`) |
+| SEC-005 (os.system in external lib) | ✅ RESOLVED | `video_representations_extractor-1.14.0/` no longer exists in the repository |
+| Stripe placeholder defaults | ✅ RESOLVED 2026-08-04 | `ai_code_generator.py` env generators default to empty strings, never placeholder-looking secrets |
+
+Coverage enforcement is also now real: `[tool.coverage.report] fail_under =
+88.1833` in `pyproject.toml`, enforced by `.github/workflows/coverage.yml`.
+
+---
+
 ## 🔴 CRITICAL Vulnerabilities
 
 ### SEC-001: Insecure Deserialization (Pickle)
@@ -243,11 +263,11 @@ os.system(f'onnxsim {f} {f} && open {f}')
 
 ### Pre-Production Security Gate
 
-- [ ] **SEC-001:** Pickle vulnerability fixed
-- [ ] **SEC-002:** npm audit shows 0 high/critical vulnerabilities
-- [ ] **SEC-003:** dangerouslySetInnerHTML removed or sanitized
-- [ ] **SEC-004:** Subprocess input validation audit complete
-- [ ] **SEC-005:** External library vulnerability isolated
+- [x] **SEC-001:** Pickle vulnerability fixed
+- [x] **SEC-002:** npm audit shows 0 high/critical vulnerabilities
+- [x] **SEC-003:** dangerouslySetInnerHTML removed or sanitized
+- [x] **SEC-004:** Subprocess input validation audit complete
+- [x] **SEC-005:** External library vulnerability isolated
 
 ### Ongoing Security Hygiene
 

--- a/docs/analysis/SECURITY_REPORT.md
+++ b/docs/analysis/SECURITY_REPORT.md
@@ -15,7 +15,7 @@ resolved:
 | Finding | Status | Evidence |
 |---------|--------|----------|
 | SEC-001 (pickle) | ✅ RESOLVED | `src/youtube_extension/backend/services/intelligent_cache.py` uses JSON serialization (`# pickle removed for security`); no `import pickle` remains under `src/youtube_extension/` |
-| SEC-002 (npm vulns) | ✅ RESOLVED | Vulnerable `devalue` chain no longer in `package-lock.json`; `next` pinned `^16.2.11` via root `overrides` (resolves 16.2.12, past the 15.6.0-canary.0–16.1.4 vulnerable range) |
+| SEC-002 (npm vulns) | ✅ RESOLVED (as originally scoped) | Vulnerable `devalue` chain no longer in `package-lock.json`; `next` pinned `^16.2.11` via root `overrides` (resolves 16.2.12, past the 15.6.0-canary.0–16.1.4 vulnerable range). Unrelated new advisories exist as of 2026-08-04 (`ip-address`, `postcss`; fixable via `npm audit fix`) |
 | SEC-003 (dangerouslySetInnerHTML) | ✅ RESOLVED | The old `frontend/` directory (incl. `LearningFusion.tsx`) was removed in the `apps/web` migration; zero `dangerouslySetInnerHTML` usages in `apps/` or `src/` |
 | SEC-004 (subprocess) | ✅ RESOLVED | Subprocess calls use list-form args (no `shell=True`) with explicit SECURITY comments (e.g. `cli.py`, `enhanced_video_processor.py`) |
 | SEC-005 (os.system in external lib) | ✅ RESOLVED | `video_representations_extractor-1.14.0/` no longer exists in the repository |
@@ -264,7 +264,7 @@ os.system(f'onnxsim {f} {f} && open {f}')
 ### Pre-Production Security Gate
 
 - [x] **SEC-001:** Pickle vulnerability fixed
-- [x] **SEC-002:** npm audit shows 0 high/critical vulnerabilities
+- [x] **SEC-002:** Original finding resolved (`devalue` chain and vulnerable `next` gone) — new unrelated advisories surface over time; keep `npm audit` in the release loop
 - [x] **SEC-003:** dangerouslySetInnerHTML removed or sanitized
 - [x] **SEC-004:** Subprocess input validation audit complete
 - [x] **SEC-005:** External library vulnerability isolated

--- a/src/youtube_extension/backend/ai_code_generator.py
+++ b/src/youtube_extension/backend/ai_code_generator.py
@@ -1105,15 +1105,17 @@ MIT
 
         monetization = architecture.get("monetization", {})
         if monetization.get("payment_processor") == "stripe":
-            # Inject real Stripe keys from environment if available
-            stripe_secret = os.environ.get("STRIPE_SECRET_KEY", "sk_test_...")
-            stripe_publishable = os.environ.get("STRIPE_PUBLISHABLE_KEY", "pk_test_...")
+            # Inject real Stripe keys from environment if available; emit
+            # empty values (never placeholder-looking secrets) when absent,
+            # matching _generate_env_local
+            stripe_secret = os.environ.get("STRIPE_SECRET_KEY", "")
+            stripe_publishable = os.environ.get("STRIPE_PUBLISHABLE_KEY", "")
 
             env_vars.extend([
-                "# Stripe (LIVE keys injected from environment)",
+                "# Stripe (keys injected from environment)",
                 f"STRIPE_SECRET_KEY={stripe_secret}",
                 f"NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY={stripe_publishable}",
-                "STRIPE_WEBHOOK_SECRET=whsec_...",
+                "STRIPE_WEBHOOK_SECRET=",
                 ""
             ])
 


### PR DESCRIPTION
## Canonical issue

Closes #1126

## Outcome

The `.env.example` generator no longer emits placeholder-looking secrets (`sk_test_...`, `pk_test_...`, `whsec_...`) when Stripe keys are absent — it emits empty values, matching `_generate_env_local`. The Dec-2025 audit docs no longer misreport resolved findings as open: each carries a dated resolution-status banner with code evidence, and the readiness verdict moves from the stale 57.5/100 🔴 NO-GO to 73/100 🟡 CONDITIONAL (security cleared; operational gaps remain).

## Scope

- Included: Stripe default fix in `ai_code_generator.py`; resolution-status banners in `docs/analysis/{SECURITY_REPORT,REMEDIATION_PLAN,EXECUTIVE_SUMMARY,PRODUCTION_CHECKLIST}.md`; supersession note in `docs/NPM_VULNERABILITIES.md`; stale CHANGELOG follow-up note corrected.
- Explicitly excluded: re-remediating already-fixed findings (pickle, subprocess, XSS, devalue/next chain — all verified fixed in current code); fixing the 4 new unrelated `npm audit` advisories (`ip-address`, `postcss` — noted in docs, fixable via `npm audit fix`); CI coverage config (already enforced via `fail_under = 88.1833` in `pyproject.toml` + `coverage.yml`).

## Risk

- Risk level: low
- Failure mode: generated `.env.example` now has empty Stripe values instead of placeholders when env keys are unset.
- Rollback: revert the two commits.

## Verification

- [x] Focused tests: `pytest tests/unit/test_ai_code_generator.py` — 253 passed
- [x] Every doc claim re-verified against current code (no `pickle` imports in `src/youtube_extension/`, no `frontend/` dir or `dangerouslySetInnerHTML`, list-form subprocess calls, `devalue` absent from lockfile, `next` resolves 16.2.12, `npm audit` re-run to scope SEC-002 accurately)
- [ ] Required CI

## Production evidence

Not applicable — code path only affects generated `.env.example` scaffolding; remaining changes are documentation.

## Agent handoff

- [x] One canonical issue is linked
- [x] No competing PR implements the same issue
- [x] Acceptance criteria are satisfied
- [ ] Required checks pass on the current head
- [x] Human decision is requested only for product, security, irreversible infrastructure, or production approval