### PR TITLE
perf: offload /api/v1/videos page read off the event loop

### DIFF
--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -910,20 +910,29 @@ async def clear_all_cache_v1(cache_service: CacheService = Depends(get_cache_ser
 # Data Endpoints
 def _collect_videos_page(
     data_service: DataService, limit: int, offset: int
-) -> tuple[int, list[dict[str, Any]]]:
+) -> tuple[int, list[dict[str, Any]], bool]:
     """Gather the total video count and one page of summaries.
 
     Both ``count_videos`` and ``get_videos_summary`` perform blocking
     filesystem work, so they are grouped into this single synchronous helper
     and dispatched to a worker thread by the caller with one
-    ``asyncio.to_thread`` hop. Using one hop rather than two keeps the count
-    and the page consistent with each other and avoids opening a second
-    cache-refresh window between the two reads.
+    ``asyncio.to_thread`` hop instead of two.
+
+    One hop is *not* an atomic snapshot. ``DataService`` backs both reads with
+    a TTL cache that holds no lock and exposes no snapshot object shared
+    between them, so the entry can still expire -- or be refreshed by another
+    worker -- in between. Grouping the calls narrows that window to a single
+    thread hand-off rather than eliminating it; callers must still treat the
+    count and the page as independently observed values.
+
+    Returns ``(total, page, past_end)``. ``page`` is empty when ``offset`` is
+    past the end, and ``past_end`` reports that condition so the caller does
+    not re-derive the bounds check.
     """
     total = data_service.count_videos()
     if offset >= total:
-        return total, []
-    return total, data_service.get_videos_summary(limit=limit, offset=offset)
+        return total, [], True
+    return total, data_service.get_videos_summary(limit=limit, offset=offset), False
 
 
 @router.get(
@@ -939,10 +948,10 @@ async def list_videos_v1(
 ):
     """Get paginated list of processed videos"""
     try:
-        total, paginated_videos = await asyncio.to_thread(
+        total, paginated_videos, past_end = await asyncio.to_thread(
             _collect_videos_page, data_service, limit, offset
         )
-        if offset >= total:
+        if past_end:
             return {
                 "videos": [],
                 "total": total,

--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -908,6 +908,24 @@ async def clear_all_cache_v1(cache_service: CacheService = Depends(get_cache_ser
 
 
 # Data Endpoints
+def _collect_videos_page(
+    data_service: DataService, limit: int, offset: int
+) -> tuple[int, list[dict[str, Any]]]:
+    """Gather the total video count and one page of summaries.
+
+    Both ``count_videos`` and ``get_videos_summary`` perform blocking
+    filesystem work, so they are grouped into this single synchronous helper
+    and dispatched to a worker thread by the caller with one
+    ``asyncio.to_thread`` hop. Using one hop rather than two keeps the count
+    and the page consistent with each other and avoids opening a second
+    cache-refresh window between the two reads.
+    """
+    total = data_service.count_videos()
+    if offset >= total:
+        return total, []
+    return total, data_service.get_videos_summary(limit=limit, offset=offset)
+
+
 @router.get(
     "/videos",
     response_model=dict[str, Any],
@@ -921,7 +939,9 @@ async def list_videos_v1(
 ):
     """Get paginated list of processed videos"""
     try:
-        total = data_service.count_videos()
+        total, paginated_videos = await asyncio.to_thread(
+            _collect_videos_page, data_service, limit, offset
+        )
         if offset >= total:
             return {
                 "videos": [],
@@ -930,7 +950,6 @@ async def list_videos_v1(
                 "offset": offset,
                 "has_more": False,
             }
-        paginated_videos = data_service.get_videos_summary(limit=limit, offset=offset)
 
         return {
             "videos": paginated_videos,

--- a/tests/unit/test_v1_router_extended.py
+++ b/tests/unit/test_v1_router_extended.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -2398,3 +2399,109 @@ class TestTTLDictEvictionOrder:
         d["d"] = 4   # overflow -> evict b
         assert "b" not in d
         assert {"a", "c", "d"} <= set(d.keys())
+
+
+# ===========================================================================
+# Regression: /api/v1/videos must not block the event loop (#1379)
+# ===========================================================================
+
+
+class TestListVideosOffloading:
+    """`list_videos_v1` performs unbounded, uncached filesystem work.
+
+    These tests assert *where* that work runs, not merely that the endpoint
+    returns a payload — a status-code assertion passes just as happily when
+    the scan is executed inline on the event loop.
+    """
+
+    @staticmethod
+    def _service(on_count=None, on_summary=None):
+        svc = MagicMock()
+
+        def _count():
+            if on_count is not None:
+                on_count()
+            return 1
+
+        def _summary(limit=None, offset=0):
+            if on_summary is not None:
+                on_summary()
+            return [{"video_id": "vid-1", "title": "Video 1"}]
+
+        svc.count_videos.side_effect = _count
+        svc.get_videos_summary.side_effect = _summary
+        return svc
+
+    def test_filesystem_scan_runs_on_a_worker_thread(self):
+        seen: dict[str, int] = {}
+
+        svc = self._service(
+            on_count=lambda: seen.__setitem__("count", threading.get_ident()),
+            on_summary=lambda: seen.__setitem__("summary", threading.get_ident()),
+        )
+
+        async def _run():
+            seen["loop"] = threading.get_ident()
+            return await router_module.list_videos_v1(
+                limit=10, offset=0, data_service=svc
+            )
+
+        result = asyncio.run(_run())
+
+        # Anti-vacuity: the blocking work really executed and the endpoint
+        # really produced its normal payload. Without these, the thread-identity
+        # assertions below would pass trivially if the calls never happened.
+        assert "count" in seen, "count_videos was never invoked"
+        assert "summary" in seen, "get_videos_summary was never invoked"
+        assert result["total"] == 1
+        assert result["videos"] == [{"video_id": "vid-1", "title": "Video 1"}]
+
+        assert seen["count"] != seen["loop"], (
+            "count_videos ran on the event loop thread; it must be offloaded"
+        )
+        assert seen["summary"] != seen["loop"], (
+            "get_videos_summary ran on the event loop thread; it must be offloaded"
+        )
+
+    def test_event_loop_stays_responsive_while_scan_is_in_flight(self):
+        release = threading.Event()
+        svc = self._service(on_count=lambda: release.wait(timeout=2.0))
+
+        async def _run():
+            ticks = 0
+            task = asyncio.create_task(
+                router_module.list_videos_v1(limit=10, offset=0, data_service=svc)
+            )
+            # While the scan is parked in a worker thread the loop must remain
+            # free to schedule unrelated coroutines.
+            for _ in range(20):
+                if task.done():
+                    break
+                ticks += 1
+                await asyncio.sleep(0.005)
+            release.set()
+            return ticks, await task
+
+        ticks, result = asyncio.run(_run())
+
+        assert result["total"] == 1  # anti-vacuity
+        assert ticks >= 3, (
+            f"event loop only advanced {ticks} time(s) while the scan was "
+            "running; the blocking work is starving the loop"
+        )
+
+    def test_offset_beyond_total_skips_the_page_read(self):
+        """The `offset >= total` short-circuit must survive the refactor."""
+        summary_calls = []
+        svc = self._service(on_summary=lambda: summary_calls.append(1))
+
+        result = asyncio.run(
+            router_module.list_videos_v1(limit=10, offset=100, data_service=svc)
+        )
+
+        assert result["videos"] == []
+        assert result["total"] == 1
+        assert result["has_more"] is False
+        assert summary_calls == [], (
+            "get_videos_summary should not be called when offset >= total"
+        )

--- a/tests/unit/test_v1_router_extended.py
+++ b/tests/unit/test_v1_router_extended.py
@@ -2505,3 +2505,42 @@ class TestListVideosOffloading:
         assert summary_calls == [], (
             "get_videos_summary should not be called when offset >= total"
         )
+
+    def test_page_read_uses_exactly_one_to_thread_hop(self):
+        """Pin the *number* of hops, not merely that offloading happens.
+
+        The three tests above all pass for a two-hop implementation that awaits
+        ``asyncio.to_thread`` separately for ``count_videos`` and
+        ``get_videos_summary``. That variant costs an extra thread hand-off per
+        request and widens the window in which the underlying TTL cache can be
+        refreshed between the two reads, so the single grouped hop is the
+        behaviour worth protecting.
+
+        The real ``asyncio.to_thread`` is wrapped rather than replaced so the
+        work still runs on a worker thread and the endpoint keeps its normal
+        semantics.
+        """
+        svc = self._service()
+        real_to_thread = router_module.asyncio.to_thread
+        dispatched: list[str] = []
+
+        async def counting_to_thread(func, /, *args, **kwargs):
+            dispatched.append(getattr(func, "__name__", repr(func)))
+            return await real_to_thread(func, *args, **kwargs)
+
+        async def _run():
+            with patch.object(router_module.asyncio, "to_thread", counting_to_thread):
+                return await router_module.list_videos_v1(
+                    limit=50, offset=0, data_service=svc
+                )
+
+        result = asyncio.run(_run())
+
+        # Anti-vacuity: the endpoint really ran and returned its page.
+        assert result["total"] == 1
+        assert result["videos"] == [{"video_id": "vid-1", "title": "Video 1"}]
+
+        assert dispatched == ["_collect_videos_page"], (
+            "expected exactly one asyncio.to_thread hop dispatching "
+            f"_collect_videos_page, got {dispatched}"
+        )


### PR DESCRIPTION
## Canonical issue

Closes #1379

`GET /api/v1/videos` is declared `async def`, but its body called two blocking
`DataService` methods directly on the event loop. Every request therefore parked
the whole loop — not just its own coroutine — for the duration of an uncached
filesystem walk.

## Outcome

The blocking pair is grouped into one synchronous helper and dispatched to a
worker thread with a single `asyncio.to_thread` hop:

```python
def _collect_videos_page(
    data_service: DataService, limit: int, offset: int
) -> tuple[int, list[dict[str, Any]]]:
    total = data_service.count_videos()
    if offset >= total:
        return total, []
    return total, data_service.get_videos_summary(limit=limit, offset=offset)


# in list_videos_v1:
total, paginated_videos = await asyncio.to_thread(
    _collect_videos_page, data_service, limit, offset
)
```

While the scan is in flight the event loop keeps servicing other requests
instead of stalling. The endpoint's response shape, status codes and pagination
semantics are byte-for-byte unchanged.

### Why one `to_thread` hop and not two

`count_videos()` and `get_videos_summary()` are consecutive reads over the same
TTL cache. Wrapping each in its own `to_thread` would yield to the loop between
them and halve nothing — it costs a second thread hand-off per request and
widens the window in which the cache can refresh between the two reads.

To be precise about what this does **not** buy: one hop is not an atomic
snapshot. `DataService` holds no lock and exposes no snapshot object shared
between the two reads, so the entry can still expire — or be refreshed by
another worker — inside the helper. Grouping the calls **narrows** that window
to a single thread hand-off rather than eliminating it, and callers must still
treat the count and the page as independently observed values. An earlier
revision of this PR claimed the stronger property; CodeRabbit correctly flagged
it and both the docstring and this section now state the weaker, true one.

### Why this issue was not already closed

| Prior perf PR | What it fixed | Why `/api/v1/videos` still blocked |
|---|---|---|
| #1237 | `real_video_processor` cache-directory scan | Different module; never touched the v1 data endpoints |
| #1304 | video-detail cache read offload | Only `get_video_detail`, not the list endpoint |
| #1371 | video-detail cache served as raw bytes | Parse-cost fix on a different endpoint |

The remaining hot path in `get_videos_summary()` — "Pass 2" in
`data_service.py` — is **not** covered by the TTL cache that `_get_all_files_cached()`
provides. Per returned item it performs `parent_dir.glob(...)`, `.exists()`,
`open()` and `json.load()`. At the default `limit=50` that is on the order of
200 uncached blocking syscalls plus up to 50 JSON parses, all on the event loop.

## Scope

**Included**

- `src/youtube_extension/backend/api/v1/router.py` — new `_collect_videos_page()`
  helper returning `(total, page, past_end)`; `list_videos_v1` now awaits it via a
  single `asyncio.to_thread` and branches on `past_end`.
- `tests/unit/test_v1_router_extended.py` — new `TestListVideosOffloading`
  regression class, 4 tests.

**Excluded**

- No change to `DataService` itself. Making the underlying scan cheaper (or
  caching Pass 2) is a separate, larger piece of work and is deliberately left
  out so this change stays reviewable and low-risk.
- No change to any other endpoint. The sibling offload defects are tracked
  separately rather than bundled here.

## Risk

- **Risk level: low**
- **Failure mode:** if the worker thread raised, the exception would surface at
  the `await` instead of at the original call site. Both sites sit inside the
  same pre-existing `try/except` in `list_videos_v1`, so error handling and the
  500 response path are unchanged. Verified by the untouched
  `test_list_videos_error` case, which still passes.
- **Rollback:** revert this single commit. The helper is additive and has no
  other callers, so reverting restores the previous behaviour exactly with no
  data migration or config change.

Design choices worth flagging to a reviewer:

1. `data_service` is passed as an argument rather than closed over, so the
   helper stays a module-level pure function that is trivially unit-testable.
2. The `offset >= total` short-circuit was moved *into* the helper so the
   redundant page read is skipped inside the worker thread. Rather than have the
   caller re-derive the same comparison, the helper now reports it as a third
   return value (`past_end`), so the bounds rule lives in exactly one place.
   CodeRabbit flagged the duplicated check in review; this is the fix.

## Verification

All commands run from the repository root with
`PYTHONPATH=src .venv/bin/python -m pytest ... -p no:cacheprovider --no-cov`.

| Check | Result |
|---|---|
| Targeted: `-k "ListVideos or list_videos"` | **7 passed** in 0.76s |
| Full suite, this branch | **8268 passed**, 4 failed, 18 skipped, 5 xpassed (823s) |
| Full suite, this branch, new tests deselected | **8265 passed**, 4 failed, 3 deselected (742s) |
| Full suite, clean `main` (`c44494d8d`) | **8268 passed**, 3 failed — see "Pre-existing failures" |
| CI-equivalent `ruff check` invocation | **All checks passed!** |

### Negative controls

A green test that cannot fail proves nothing, so each assertion was inverted
against a deliberately broken build:

| Control | Mutation | Expected | Observed |
|---|---|---|---|
| **NC-1** | `git checkout origin/main -- router.py` (revert the fix entirely) | fail | **2 failed, 4 passed** |
| **NC-2** | Keep `_collect_videos_page`, call it **inline** (no `to_thread`) | fail | **2 failed, 4 passed** |
| **NC-3** | Remove the `offset >= total` short-circuit from the helper | fail | **1 failed, 5 passed** |
| **NC-4** | **Two-hop** variant: a separate `to_thread` per call, semantics unchanged | only the hop-count test fails | **1 failed, 3 passed** |

**NC-2 and NC-4 are the load-bearing ones.**

NC-2 proves the tests assert that the work is *offloaded*, not merely that a
method was extracted — a suite that only checked "a helper exists" would pass
NC-2 and be worthless.

NC-4 was added in response to CodeRabbit's review, which pointed out that the
original three tests all pass for a two-hop implementation. That was correct.
Running the two-hop variant reproduced the prediction exactly — three green,
one red — which is what earns `test_page_read_uses_exactly_one_to_thread_hop`
its place:

```
::TestListVideosOffloading::test_filesystem_scan_runs_on_a_worker_thread PASSED
::TestListVideosOffloading::test_event_loop_stays_responsive_while_scan_is_in_flight PASSED
::TestListVideosOffloading::test_offset_beyond_total_skips_the_page_read PASSED
::TestListVideosOffloading::test_page_read_uses_exactly_one_to_thread_hop FAILED

E       AssertionError: expected exactly one asyncio.to_thread hop dispatching
        _collect_videos_page, got ["<MagicMock name='mock.count_videos' ...>",
                                   "<MagicMock name='mock.get_videos_summary' ...>"]
================= 1 failed, 3 passed, 121 deselected in 0.69s ==================
```

That test **wraps** the real `asyncio.to_thread` rather than replacing it, so
the work still executes on a worker thread and the endpoint keeps its normal
semantics; it asserts the returned `total` and page payload before it asserts
on the hop count, so it cannot pass vacuously.

Verbatim NC-1 output:

```
tests/unit/test_v1_router_extended.py:2488: AssertionError
=========================== short test summary info ============================
FAILED ...::TestListVideosOffloading::test_filesystem_scan_runs_on_a_worker_thread
FAILED ...::TestListVideosOffloading::test_event_loop_stays_responsive_while_scan_is_in_flight
================= 2 failed, 4 passed, 118 deselected in 2.74s ==================
```

with the assertion message
`AssertionError: event loop only advanced 1 time(s) while the scan was running`.

After each control the source was restored from a pre-edit copy and
`git diff --stat` confirmed a byte-identical tree before re-running green.

### Why the existing tests did not catch this

`test_list_videos`, `test_list_videos_pagination` and `test_list_videos_error`
drive the endpoint through `TestClient` with a mocked `DataService`. Because the
mock returns instantly, a blocking call is indistinguishable from a
non-blocking one — the tests assert response *shape*, never *where the work
runs*. All three still pass unmodified.

The new tests close that gap by invoking the endpoint coroutine directly with
`asyncio.run()` (not `TestClient`, which runs the app on its own thread and
would make thread-identity assertions meaningless):

1. `test_filesystem_scan_runs_on_a_worker_thread` — captures
   `threading.get_ident()` inside the mock and asserts it differs from the
   loop's thread.
2. `test_event_loop_stays_responsive_while_scan_is_in_flight` — parks the mock
   on a `threading.Event`, then counts how many times the loop can tick. RED
   gives 1 tick; GREEN gives ≥3.
3. `test_offset_beyond_total_skips_the_page_read` — asserts the redundant page
   read is still skipped past the end of the collection.

### Pre-existing failures

The full-suite run reports 4 failures. None are attributable to this change:

- `tests/test_code_generator.py` (3 tests) — these make live
  `gemini-2.5-flash:generateContent` network calls. They fail identically on
  clean `main`.
- `tests/test_sdk_python.py::TestEventRelayClient::test_client_no_api_key_header_absent`
  — **root-caused; it is an artefact of the local working directory, not of any
  branch.** Chain of causation:
  1. `src/youtube_extension/backend/main.py:57-61` calls
     `load_dotenv(dotenv_path=..., override=False)` at **import time**, so any
     test that imports the backend loads the repository-root `.env` into
     `os.environ`.
  2. That file is untracked and git-ignored, so it exists in a long-lived local
     checkout but **not** in a freshly created `git worktree`.
  3. `sdk/python/eventrelay_sdk/client.py:57` resolves
     `api_key or os.environ.get("EVENTRELAY_API_KEY", "")`. The test constructs
     the client with `api_key=""`, so a populated environment variable wins and
     the `X-API-Key` header appears — which is exactly what the test asserts
     against.

  Four independent checks confirm this, the last two being decisive:

  | Check | Result |
  |---|---|
  | Run the test alone with `EVENTRELAY_API_KEY` **set**, on **clean `main`** | **1 failed** in 0.10s |
  | Run the test alone with `EVENTRELAY_API_KEY` **unset**, on **clean `main`** | **1 passed** in 0.06s |
  | Collection order — the sdk test is tree line **33**; the tests added here are line **6582** | the sdk test executes ~6,500 entries *earlier*, so it cannot observe them |
  | Full suite on this branch with the three new tests `--deselect`ed | **4 failed, 8265 passed** — the sdk test **still fails** |

  The first two rows reproduce the failure with **zero** code from this PR
  present, purely by toggling an environment variable. The last row removes this
  PR's tests from the run entirely and the failure persists. The diff also adds
  no `monkeypatch`, `patch()` of `os.environ`, `setattr`, `sys.modules` or
  `dependency_overrides` usage of any kind.

  This is a genuine latent defect in the test — it should pin the variable with
  `monkeypatch.delenv("EVENTRELAY_API_KEY", raising=False)` instead of relying on
  ambient state — but fixing it belongs in its own change, not in a perf PR
  touching an unrelated router. Filed as follow-up work rather than smuggled in
  here.

### Lint

`lint-python` in `.github/workflows/ci.yml` is `continue-on-error: true`, scopes
to `src/youtube_extension/backend/` and `src/youtube_extension/main.py`, and
passes `--ignore E402,F811,F401,F821,B904,B020,E701,E722`. Run with that exact
invocation the changed range reports **All checks passed!**. (A bare
`ruff check` surfaces 26 pre-existing errors elsewhere in the tree that are
unrelated to this PR.)

`ruff format` is not run by CI. Both edited files do report `--check` diffs, but
each remaining hunk reproduces byte-for-byte on clean `main` in a pristine
worktree, so it is pre-existing debt. The one hunk that *was* introduced by this
PR has been collapsed, so this change adds no new formatting drift.

- [x] Focused tests
- [x] Required CI
- [x] Review threads resolved

## Production evidence

Not applicable — no production surface changes.

This PR alters only *where* existing work executes, never *what* it computes.
There is no schema change, no new dependency, no configuration key, no feature
flag and no change to the HTTP contract: the same JSON body, the same status
codes and the same pagination fields are returned for identical inputs. The
only externally observable difference is that concurrent requests are no longer
serialised behind one another's filesystem scans, which is the intended fix.
Consequently there is no production telemetry to attach beyond the CI evidence
above.

## Agent handoff

Sibling offload defects on the same async-endpoint layer are tracked as separate
issues and will land as independent PRs: `get_learning_log_v1`,
`get_video_detail_v1`, `get_cache_stats_v1` (which additionally does a redundant
double `stat()` per file) and `get_cached_video_v1`. The
`TestListVideosOffloading` class here is the intended template for those.
