### PR TITLE
perf: offload /api/v1/videos filesystem scan off the event loop (#1379)

### DIFF
--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -910,20 +910,29 @@ async def clear_all_cache_v1(cache_service: CacheService = Depends(get_cache_ser
 # Data Endpoints
 def _collect_videos_page(
     data_service: DataService, limit: int, offset: int
-) -> tuple[int, list[dict[str, Any]]]:
+) -> tuple[int, list[dict[str, Any]], bool]:
     """Gather the total video count and one page of summaries.
 
     Both ``count_videos`` and ``get_videos_summary`` perform blocking
     filesystem work, so they are grouped into this single synchronous helper
     and dispatched to a worker thread by the caller with one
-    ``asyncio.to_thread`` hop. Using one hop rather than two keeps the count
-    and the page consistent with each other and avoids opening a second
-    cache-refresh window between the two reads.
+    ``asyncio.to_thread`` hop instead of two.
+
+    One hop is *not* an atomic snapshot. ``DataService`` backs both reads with
+    a TTL cache that holds no lock and exposes no snapshot object shared
+    between them, so the entry can still expire -- or be refreshed by another
+    worker -- in between. Grouping the calls narrows that window to a single
+    thread hand-off rather than eliminating it; callers must still treat the
+    count and the page as independently observed values.
+
+    Returns ``(total, page, past_end)``. ``page`` is empty when ``offset`` is
+    past the end, and ``past_end`` reports that condition so the caller does
+    not re-derive the bounds check.
     """
     total = data_service.count_videos()
     if offset >= total:
-        return total, []
-    return total, data_service.get_videos_summary(limit=limit, offset=offset)
+        return total, [], True
+    return total, data_service.get_videos_summary(limit=limit, offset=offset), False
 
 
 @router.get(
@@ -939,10 +948,10 @@ async def list_videos_v1(
 ):
     """Get paginated list of processed videos"""
     try:
-        total, paginated_videos = await asyncio.to_thread(
+        total, paginated_videos, past_end = await asyncio.to_thread(
             _collect_videos_page, data_service, limit, offset
         )
-        if offset >= total:
+        if past_end:
             return {
                 "videos": [],
                 "total": total,

--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -908,6 +908,24 @@ async def clear_all_cache_v1(cache_service: CacheService = Depends(get_cache_ser
 
 
 # Data Endpoints
+def _collect_videos_page(
+    data_service: DataService, limit: int, offset: int
+) -> tuple[int, list[dict[str, Any]]]:
+    """Gather the total video count and one page of summaries.
+
+    Both ``count_videos`` and ``get_videos_summary`` perform blocking
+    filesystem work, so they are grouped into this single synchronous helper
+    and dispatched to a worker thread by the caller with one
+    ``asyncio.to_thread`` hop. Using one hop rather than two keeps the count
+    and the page consistent with each other and avoids opening a second
+    cache-refresh window between the two reads.
+    """
+    total = data_service.count_videos()
+    if offset >= total:
+        return total, []
+    return total, data_service.get_videos_summary(limit=limit, offset=offset)
+
+
 @router.get(
     "/videos",
     response_model=dict[str, Any],
@@ -921,7 +939,9 @@ async def list_videos_v1(
 ):
     """Get paginated list of processed videos"""
     try:
-        total = data_service.count_videos()
+        total, paginated_videos = await asyncio.to_thread(
+            _collect_videos_page, data_service, limit, offset
+        )
         if offset >= total:
             return {
                 "videos": [],
@@ -930,7 +950,6 @@ async def list_videos_v1(
                 "offset": offset,
                 "has_more": False,
             }
-        paginated_videos = data_service.get_videos_summary(limit=limit, offset=offset)
 
         return {
             "videos": paginated_videos,

--- a/tests/unit/test_v1_router_extended.py
+++ b/tests/unit/test_v1_router_extended.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -2398,3 +2399,109 @@ class TestTTLDictEvictionOrder:
         d["d"] = 4   # overflow -> evict b
         assert "b" not in d
         assert {"a", "c", "d"} <= set(d.keys())
+
+
+# ===========================================================================
+# Regression: /api/v1/videos must not block the event loop (#1379)
+# ===========================================================================
+
+
+class TestListVideosOffloading:
+    """`list_videos_v1` performs unbounded, uncached filesystem work.
+
+    These tests assert *where* that work runs, not merely that the endpoint
+    returns a payload — a status-code assertion passes just as happily when
+    the scan is executed inline on the event loop.
+    """
+
+    @staticmethod
+    def _service(on_count=None, on_summary=None):
+        svc = MagicMock()
+
+        def _count():
+            if on_count is not None:
+                on_count()
+            return 1
+
+        def _summary(limit=None, offset=0):
+            if on_summary is not None:
+                on_summary()
+            return [{"video_id": "vid-1", "title": "Video 1"}]
+
+        svc.count_videos.side_effect = _count
+        svc.get_videos_summary.side_effect = _summary
+        return svc
+
+    def test_filesystem_scan_runs_on_a_worker_thread(self):
+        seen: dict[str, int] = {}
+
+        svc = self._service(
+            on_count=lambda: seen.__setitem__("count", threading.get_ident()),
+            on_summary=lambda: seen.__setitem__("summary", threading.get_ident()),
+        )
+
+        async def _run():
+            seen["loop"] = threading.get_ident()
+            return await router_module.list_videos_v1(
+                limit=10, offset=0, data_service=svc
+            )
+
+        result = asyncio.run(_run())
+
+        # Anti-vacuity: the blocking work really executed and the endpoint
+        # really produced its normal payload. Without these, the thread-identity
+        # assertions below would pass trivially if the calls never happened.
+        assert "count" in seen, "count_videos was never invoked"
+        assert "summary" in seen, "get_videos_summary was never invoked"
+        assert result["total"] == 1
+        assert result["videos"] == [{"video_id": "vid-1", "title": "Video 1"}]
+
+        assert seen["count"] != seen["loop"], (
+            "count_videos ran on the event loop thread; it must be offloaded"
+        )
+        assert seen["summary"] != seen["loop"], (
+            "get_videos_summary ran on the event loop thread; it must be offloaded"
+        )
+
+    def test_event_loop_stays_responsive_while_scan_is_in_flight(self):
+        release = threading.Event()
+        svc = self._service(on_count=lambda: release.wait(timeout=2.0))
+
+        async def _run():
+            ticks = 0
+            task = asyncio.create_task(
+                router_module.list_videos_v1(limit=10, offset=0, data_service=svc)
+            )
+            # While the scan is parked in a worker thread the loop must remain
+            # free to schedule unrelated coroutines.
+            for _ in range(20):
+                if task.done():
+                    break
+                ticks += 1
+                await asyncio.sleep(0.005)
+            release.set()
+            return ticks, await task
+
+        ticks, result = asyncio.run(_run())
+
+        assert result["total"] == 1  # anti-vacuity
+        assert ticks >= 3, (
+            f"event loop only advanced {ticks} time(s) while the scan was "
+            "running; the blocking work is starving the loop"
+        )
+
+    def test_offset_beyond_total_skips_the_page_read(self):
+        """The `offset >= total` short-circuit must survive the refactor."""
+        summary_calls = []
+        svc = self._service(on_summary=lambda: summary_calls.append(1))
+
+        result = asyncio.run(
+            router_module.list_videos_v1(limit=10, offset=100, data_service=svc)
+        )
+
+        assert result["videos"] == []
+        assert result["total"] == 1
+        assert result["has_more"] is False
+        assert summary_calls == [], (
+            "get_videos_summary should not be called when offset >= total"
+        )

--- a/tests/unit/test_v1_router_extended.py
+++ b/tests/unit/test_v1_router_extended.py
@@ -2505,3 +2505,42 @@ class TestListVideosOffloading:
         assert summary_calls == [], (
             "get_videos_summary should not be called when offset >= total"
         )
+
+    def test_page_read_uses_exactly_one_to_thread_hop(self):
+        """Pin the *number* of hops, not merely that offloading happens.
+
+        The three tests above all pass for a two-hop implementation that awaits
+        ``asyncio.to_thread`` separately for ``count_videos`` and
+        ``get_videos_summary``. That variant costs an extra thread hand-off per
+        request and widens the window in which the underlying TTL cache can be
+        refreshed between the two reads, so the single grouped hop is the
+        behaviour worth protecting.
+
+        The real ``asyncio.to_thread`` is wrapped rather than replaced so the
+        work still runs on a worker thread and the endpoint keeps its normal
+        semantics.
+        """
+        svc = self._service()
+        real_to_thread = router_module.asyncio.to_thread
+        dispatched: list[str] = []
+
+        async def counting_to_thread(func, /, *args, **kwargs):
+            dispatched.append(getattr(func, "__name__", repr(func)))
+            return await real_to_thread(func, *args, **kwargs)
+
+        async def _run():
+            with patch.object(router_module.asyncio, "to_thread", counting_to_thread):
+                return await router_module.list_videos_v1(
+                    limit=50, offset=0, data_service=svc
+                )
+
+        result = asyncio.run(_run())
+
+        # Anti-vacuity: the endpoint really ran and returned its page.
+        assert result["total"] == 1
+        assert result["videos"] == [{"video_id": "vid-1", "title": "Video 1"}]
+
+        assert dispatched == ["_collect_videos_page"], (
+            "expected exactly one asyncio.to_thread hop dispatching "
+            f"_collect_videos_page, got {dispatched}"
+        )


### PR DESCRIPTION
## Canonical issue

Closes #1379

## Outcome

`GET /api/v1/videos` no longer blocks the FastAPI event loop while it scans the filesystem. `count_videos()` and `get_videos_summary()` are both blocking, uncached I/O; they are now grouped into a single synchronous helper (`_collect_videos_page`) dispatched with exactly **one** `asyncio.to_thread` hop, so the loop stays free to serve other requests while a listing is in flight.

## Scope

- Included:
  - New `_collect_videos_page(data_service, limit, offset)` helper that returns `(total, page, past_end)` and owns the `offset >= total` short-circuit so the caller does not re-derive the bounds check.
  - `list_videos_v1` now awaits the helper via a single `asyncio.to_thread` hop instead of two inline blocking calls.
  - Regression tests in `TestListVideosOffloading` (4 cases) asserting *where* the work runs and that exactly one thread hop is used.
- Explicitly excluded:
  - The count/page pair is still not an atomic snapshot (the underlying TTL cache holds no lock); grouping narrows but does not eliminate the refresh window. This is documented in the helper docstring and left as-is.

## Risk

- Risk level: low
- Failure mode: if `DataService` reads were somehow not thread-safe, moving them to a worker thread could surface a latent race. They are already invoked concurrently under load, so this does not introduce new sharing.
- Rollback: revert the two commits on this branch; the endpoint returns to inline blocking calls.

## Verification

Tied to head `e9b738c`:

- [x] Focused tests — `pytest tests/unit/test_v1_router_extended.py::TestListVideosOffloading` → 4 passed
- [ ] Required CI — pending on this PR
- [x] Review threads resolved — none open yet

The tests are written to be non-vacuous: each asserts the normal payload is produced *and* that the blocking calls execute on a non-loop thread, so a status-code-only implementation cannot pass them.

## Production evidence

Not applicable — internal event-loop scheduling change with no user-visible API contract change. Payload shape (`videos`, `total`, `limit`, `offset`, `has_more`) is unchanged and asserted by the tests.

## Agent handoff

- [x] One canonical issue is linked
- [x] No competing PR implements the same issue
- [x] Acceptance criteria are satisfied
- [ ] Required checks pass on the current head — pending CI
- [x] Human decision is requested only for product, security, irreversible infrastructure, or production approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx2RqjB8e98Ke2uWbbqAUJ)_