### PR TITLE
perf: offload the learning-log filesystem walk off the event loop

### DIFF
--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -1006,7 +1006,10 @@ async def get_video_detail_v1(
 async def get_learning_log_v1(data_service: DataService = Depends(get_data_service)):
     """Get learning log from enhanced analysis files"""
     try:
-        learning_log = data_service.get_learning_log()
+        # ``get_learning_log`` walks the enhanced-analysis tree and opens a
+        # metadata file per entry. That is unbounded blocking I/O, so it is
+        # dispatched to a worker thread rather than run on the event loop.
+        learning_log = await asyncio.to_thread(data_service.get_learning_log)
         return learning_log
     except Exception as e:
         logger.error(f"Error getting learning log: {e}", exc_info=True)

--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -10,8 +10,10 @@ Provides versioned API endpoints with proper OpenAPI documentation.
 import asyncio
 import logging
 import os
+import threading
 import time
 import uuid as _uuid
+import weakref
 from dataclasses import asdict
 from datetime import datetime, timezone
 from typing import Any, Optional
@@ -997,6 +999,30 @@ async def get_video_detail_v1(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+# Concurrency gate for the learning-log walk.
+#
+# ``asyncio.Semaphore`` binds itself to the first event loop that awaits it and
+# refuses to be reused from another one, so a single module-level instance would
+# break any process that runs more than one loop over its lifetime (every
+# ``asyncio.run`` in the test suite, for one). The gate is therefore created
+# per running loop and held weakly, so it disappears with the loop it belongs to.
+_LEARNING_LOG_MAX_CONCURRENCY = 4
+# Maps a running event loop -> the ``asyncio.Semaphore`` bound to that loop.
+_learning_log_gates: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+_learning_log_gates_lock = threading.Lock()
+
+
+def _get_learning_log_gate() -> asyncio.Semaphore:
+    """Return the learning-log concurrency gate bound to the running loop."""
+    loop = asyncio.get_running_loop()
+    with _learning_log_gates_lock:
+        gate = _learning_log_gates.get(loop)
+        if gate is None:
+            gate = asyncio.Semaphore(_LEARNING_LOG_MAX_CONCURRENCY)
+            _learning_log_gates[loop] = gate
+        return gate
+
+
 @router.get(
     "/learning-log",
     response_model=list[dict[str, Any]],
@@ -1009,7 +1035,14 @@ async def get_learning_log_v1(data_service: DataService = Depends(get_data_servi
         # ``get_learning_log`` walks the enhanced-analysis tree and opens a
         # metadata file per entry. That is unbounded blocking I/O, so it is
         # dispatched to a worker thread rather than run on the event loop.
-        learning_log = await asyncio.to_thread(data_service.get_learning_log)
+        #
+        # The walk is also uncached, so every concurrent request starts its own.
+        # Without a bound those walks would be free to occupy every worker in
+        # the shared default executor and starve unrelated ``to_thread``
+        # callers. The gate caps how many walks may be in flight; requests over
+        # the cap wait here on the event loop, holding no worker thread.
+        async with _get_learning_log_gate():
+            learning_log = await asyncio.to_thread(data_service.get_learning_log)
         return learning_log
     except Exception as e:
         logger.error(f"Error getting learning log: {e}", exc_info=True)

--- a/src/youtube_extension/backend/api/v1/router.py
+++ b/src/youtube_extension/backend/api/v1/router.py
@@ -1001,11 +1001,18 @@ async def get_video_detail_v1(
 
 # Concurrency gate for the learning-log walk.
 #
-# ``asyncio.Semaphore`` binds itself to the first event loop that awaits it and
-# refuses to be reused from another one, so a single module-level instance would
-# break any process that runs more than one loop over its lifetime (every
-# ``asyncio.run`` in the test suite, for one). The gate is therefore created
-# per running loop and held weakly, so it disappears with the loop it belongs to.
+# A single module-level ``asyncio.Semaphore`` would be a latent landmine rather
+# than an obvious bug. ``Semaphore.acquire`` only reaches ``_get_loop()`` when it
+# has to wait -- the uncontended path decrements the counter and returns before
+# any loop is touched. So the semaphore stays unbound, and works fine across any
+# number of event loops, right up until the first time it is genuinely contended.
+# That acquisition pins it, and every later use from a different loop raises
+# ``RuntimeError: ... is bound to a different event loop``.
+#
+# The failure therefore cannot show up in low-concurrency tests; it waits for the
+# exact burst this gate exists to absorb. Building the gate per running loop and
+# holding it weakly removes the trap outright -- each loop gets its own semaphore,
+# which is collected along with the loop it belongs to.
 _LEARNING_LOG_MAX_CONCURRENCY = 4
 # Maps a running event loop -> the ``asyncio.Semaphore`` bound to that loop.
 _learning_log_gates: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()

--- a/tests/unit/test_v1_router_extended.py
+++ b/tests/unit/test_v1_router_extended.py
@@ -2544,3 +2544,137 @@ class TestListVideosOffloading:
             "expected exactly one asyncio.to_thread hop dispatching "
             f"_collect_videos_page, got {dispatched}"
         )
+
+
+class TestLearningLogOffloading:
+    """`get_learning_log_v1` performs an unbounded, uncached filesystem walk.
+
+    `DataService.get_learning_log` issues its own `rglob` on every call — it does
+    not go through `_get_all_files_cached` — and then opens a metadata file per
+    entry. These tests assert *where* that work runs. A status-code assertion
+    passes just as happily when the walk is executed inline on the event loop,
+    which is exactly why the pre-existing tests for this endpoint stayed green
+    while production stalled.
+    """
+
+    @staticmethod
+    def _service(on_call=None):
+        svc = MagicMock()
+
+        def _log():
+            if on_call is not None:
+                on_call()
+            return [{"video_id": "vid-1", "title": "Video 1"}]
+
+        svc.get_learning_log.side_effect = _log
+        return svc
+
+    def test_walk_runs_on_a_worker_thread(self):
+        seen: dict[str, int] = {}
+
+        svc = self._service(
+            on_call=lambda: seen.__setitem__("walk", threading.get_ident())
+        )
+
+        async def _run():
+            seen["loop"] = threading.get_ident()
+            return await router_module.get_learning_log_v1(data_service=svc)
+
+        result = asyncio.run(_run())
+
+        # Anti-vacuity: the blocking work really executed and the endpoint really
+        # produced its normal payload. Without these, the thread-identity
+        # assertion below would pass trivially if the call never happened.
+        assert "walk" in seen, "get_learning_log was never invoked"
+        assert result == [{"video_id": "vid-1", "title": "Video 1"}]
+
+        assert seen["walk"] != seen["loop"], (
+            "get_learning_log ran on the event loop thread; it must be offloaded"
+        )
+
+    def test_event_loop_stays_responsive_while_walk_is_in_flight(self):
+        """Ticks must complete *while* the walk is still running.
+
+        Counting ticks alone is not enough: a blocking call with a timeout
+        eventually returns, after which the loop is free and the ticks run
+        anyway. So each tick is timestamped and compared against the moment the
+        walk actually finished. If the walk runs inline it pins the loop, and
+        every tick necessarily lands *after* it -- giving zero qualifying ticks.
+        """
+        import time
+
+        release = threading.Event()
+        finished_at: dict[str, float] = {}
+
+        def _block():
+            release.wait(timeout=5.0)
+            finished_at["walk"] = time.monotonic()
+
+        svc = self._service(on_call=_block)
+
+        async def _run():
+            task = asyncio.create_task(
+                router_module.get_learning_log_v1(data_service=svc)
+            )
+            tick_times: list[float] = []
+            for _ in range(20):
+                await asyncio.sleep(0.005)
+                tick_times.append(time.monotonic())
+                if len(tick_times) >= 3:
+                    break
+            release.set()
+            return tick_times, await task
+
+        tick_times, result = asyncio.run(_run())
+
+        # Anti-vacuity: the endpoint still returned its real payload, and the
+        # blocking work really ran to completion.
+        assert result == [{"video_id": "vid-1", "title": "Video 1"}]
+        assert "walk" in finished_at, "get_learning_log never completed"
+
+        walk_end = finished_at["walk"]
+        concurrent = [t for t in tick_times if t < walk_end]
+        assert len(concurrent) >= 3, (
+            "event loop was blocked during the walk: only "
+            f"{len(concurrent)} of {len(tick_times)} tick(s) completed before "
+            "the walk finished"
+        )
+
+    def test_walk_uses_exactly_one_to_thread_hop(self):
+        svc = self._service()
+        real_to_thread = router_module.asyncio.to_thread
+        dispatched: list[str] = []
+
+        async def counting_to_thread(func, /, *args, **kwargs):
+            dispatched.append(getattr(func, "__name__", repr(func)))
+            return await real_to_thread(func, *args, **kwargs)
+
+        async def _run():
+            with patch.object(router_module.asyncio, "to_thread", counting_to_thread):
+                return await router_module.get_learning_log_v1(data_service=svc)
+
+        result = asyncio.run(_run())
+
+        # Anti-vacuity: the endpoint really ran and returned its payload.
+        assert result == [{"video_id": "vid-1", "title": "Video 1"}]
+
+        assert len(dispatched) == 1, (
+            "expected exactly one asyncio.to_thread hop for the learning-log "
+            f"walk, got {len(dispatched)}: {dispatched}"
+        )
+
+    def test_error_contract_is_unchanged(self):
+        """A failure inside the worker thread must still surface as a 500."""
+        from fastapi import HTTPException as FastAPIHTTPException
+
+        svc = MagicMock()
+        svc.get_learning_log.side_effect = RuntimeError("scan exploded")
+
+        async def _run():
+            return await router_module.get_learning_log_v1(data_service=svc)
+
+        with pytest.raises(FastAPIHTTPException) as exc:
+            asyncio.run(_run())
+
+        assert exc.value.status_code == 500
+        assert exc.value.detail == "Internal server error"

--- a/tests/unit/test_v1_router_extended.py
+++ b/tests/unit/test_v1_router_extended.py
@@ -2678,3 +2678,115 @@ class TestLearningLogOffloading:
 
         assert exc.value.status_code == 500
         assert exc.value.detail == "Internal server error"
+
+    def test_concurrent_walks_are_capped_by_the_gate(self):
+        """The walk is uncached, so concurrency must be bounded.
+
+        Offloading alone moves the stall off the event loop but lets any burst
+        of requests occupy every worker in the shared default executor, which
+        starves unrelated `to_thread` callers. This asserts the cap is real:
+        more callers than the limit must never produce more simultaneous walks
+        than the limit.
+        """
+        import time
+
+        limit = router_module._LEARNING_LOG_MAX_CONCURRENCY
+        callers = limit + 3
+
+        state = {"in_flight": 0, "peak": 0}
+        counter_lock = threading.Lock()
+        release = threading.Event()
+
+        def _occupy():
+            with counter_lock:
+                state["in_flight"] += 1
+                state["peak"] = max(state["peak"], state["in_flight"])
+            release.wait(timeout=5.0)
+            with counter_lock:
+                state["in_flight"] -= 1
+
+        svc = self._service(on_call=_occupy)
+
+        async def _run():
+            tasks = [
+                asyncio.create_task(router_module.get_learning_log_v1(data_service=svc))
+                for _ in range(callers)
+            ]
+
+            # Wait for the first wave to reach the worker threads.
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                with counter_lock:
+                    if state["in_flight"] >= limit:
+                        break
+                await asyncio.sleep(0.01)
+
+            # Give any unbounded overflow a chance to appear before releasing;
+            # without the gate all `callers` walks would be in flight by now.
+            await asyncio.sleep(0.25)
+            with counter_lock:
+                observed_peak = state["peak"]
+
+            release.set()
+            return observed_peak, await asyncio.gather(*tasks)
+
+        peak, results = asyncio.run(_run())
+
+        # Anti-vacuity: every caller really ran and got the payload back.
+        assert len(results) == callers
+        assert all(r == [{"video_id": "vid-1", "title": "Video 1"}] for r in results)
+        assert svc.get_learning_log.call_count == callers
+
+        # The gate held: never more than `limit` walks at once...
+        assert peak <= limit, (
+            f"{peak} concurrent walks observed with a cap of {limit}; the "
+            "concurrency gate is not bounding the shared executor"
+        )
+        # ...and it did not over-restrict into effective serialisation.
+        assert peak == limit, (
+            f"expected the cap of {limit} to be reached with {callers} "
+            f"concurrent callers, only saw {peak}"
+        )
+
+    def test_gate_is_rebuilt_for_each_event_loop(self):
+        """A loop-bound `Semaphore` must not leak across event loops.
+
+        `asyncio.Semaphore` pins itself to the first loop that awaits it and
+        raises `RuntimeError` if reused elsewhere, so a single module-level
+        instance would break the second `asyncio.run` in any process.
+        """
+        svc = self._service()
+
+        async def _run():
+            gate = router_module._get_learning_log_gate()
+            result = await router_module.get_learning_log_v1(data_service=svc)
+            return gate, result
+
+        first_gate, first_result = asyncio.run(_run())
+        second_gate, second_result = asyncio.run(_run())
+
+        # Anti-vacuity: both calls actually completed through the gate.
+        assert first_result == [{"video_id": "vid-1", "title": "Video 1"}]
+        assert second_result == [{"video_id": "vid-1", "title": "Video 1"}]
+
+        assert first_gate is not second_gate, (
+            "the same Semaphore was reused across two event loops; it would "
+            "raise RuntimeError once the first loop is closed"
+        )
+
+    def test_gate_is_shared_within_one_event_loop(self):
+        """Within a single loop every request must contend for the same gate."""
+        svc = self._service()
+
+        async def _run():
+            a = router_module._get_learning_log_gate()
+            await router_module.get_learning_log_v1(data_service=svc)
+            b = router_module._get_learning_log_gate()
+            return a, b
+
+        first, second = asyncio.run(_run())
+
+        assert first is second, (
+            "a fresh Semaphore per call would impose no bound at all"
+        )
+        assert svc.get_learning_log.call_count == 1

--- a/tests/unit/test_v1_router_extended.py
+++ b/tests/unit/test_v1_router_extended.py
@@ -2751,9 +2751,12 @@ class TestLearningLogOffloading:
     def test_gate_is_rebuilt_for_each_event_loop(self):
         """A loop-bound `Semaphore` must not leak across event loops.
 
-        `asyncio.Semaphore` pins itself to the first loop that awaits it and
-        raises `RuntimeError` if reused elsewhere, so a single module-level
-        instance would break the second `asyncio.run` in any process.
+        `asyncio.Semaphore` does not bind on first use. `acquire` only calls
+        `_get_loop()` on the path where it must wait, so an uncontended
+        semaphore stays unbound and crosses loops happily. The first genuinely
+        contended acquisition pins it, and every later use from another loop
+        raises `RuntimeError`. A module-level instance would therefore pass
+        quiet tests and fail only under the burst this gate exists to absorb.
         """
         svc = self._service()
 
@@ -2790,3 +2793,70 @@ class TestLearningLogOffloading:
             "a fresh Semaphore per call would impose no bound at all"
         )
         assert svc.get_learning_log.call_count == 1
+
+    def test_gate_survives_a_contended_loop_then_a_fresh_loop(self):
+        """The real failure mode: contention binds a semaphore to its loop.
+
+        `test_gate_is_rebuilt_for_each_event_loop` asserts gate *identity*,
+        which is a proxy. This asserts the consequence. It saturates the gate
+        hard enough to force at least one waiter — the only path that reaches
+        `_LoopBoundMixin._get_loop()` and pins the semaphore — and then drives
+        the endpoint again on a brand-new loop. A module-level singleton raises
+        `RuntimeError: ... is bound to a different event loop` here.
+        """
+        import time
+
+        limit = router_module._LEARNING_LOG_MAX_CONCURRENCY
+        release = threading.Event()
+        in_flight = 0
+        peaked = threading.Event()
+        counter_lock = threading.Lock()
+
+        def _occupy():
+            nonlocal in_flight
+            with counter_lock:
+                in_flight += 1
+                if in_flight >= limit:
+                    peaked.set()
+            release.wait(timeout=5.0)
+            with counter_lock:
+                in_flight -= 1
+
+        async def _saturate():
+            svc = self._service(on_call=_occupy)
+            # limit + 2 callers guarantees at least one must *wait* on the gate.
+            tasks = [
+                asyncio.create_task(router_module.get_learning_log_v1(data_service=svc))
+                for _ in range(limit + 2)
+            ]
+            deadline = time.monotonic() + 5.0
+            while not peaked.is_set() and time.monotonic() < deadline:
+                await asyncio.sleep(0.01)
+            # Let the surplus callers actually queue on the semaphore.
+            await asyncio.sleep(0.25)
+            release.set()
+            return await asyncio.gather(*tasks)
+
+        saturated = asyncio.run(_saturate())
+
+        # Anti-vacuity: the contended loop really did serve every caller.
+        assert peaked.is_set(), "the gate was never saturated; no waiter existed"
+        assert len(saturated) == limit + 2
+        assert all(r == [{"video_id": "vid-1", "title": "Video 1"}] for r in saturated)
+
+        # The actual assertion: a fresh loop must still work.
+        fresh_svc = self._service()
+
+        async def _after():
+            return await router_module.get_learning_log_v1(data_service=fresh_svc)
+
+        try:
+            result = asyncio.run(_after())
+        except RuntimeError as exc:  # pragma: no cover - the regression path
+            raise AssertionError(
+                "the gate leaked across event loops after being bound by "
+                f"contention: {exc}"
+            ) from exc
+
+        assert result == [{"video_id": "vid-1", "title": "Video 1"}]
+        assert fresh_svc.get_learning_log.call_count == 1


### PR DESCRIPTION
## Canonical issue

Closes #1386

`GET /api/v1/learning-log` runs an unbounded, completely uncached filesystem walk directly on the event loop. This PR moves that walk to a worker thread.

## Outcome

`get_learning_log_v1` was declared `async` but awaited nothing:

```python
async def get_learning_log_v1(data_service: DataService = Depends(get_data_service)):
    try:
        learning_log = data_service.get_learning_log()   # blocking, inline
        return learning_log
```

`DataService.get_learning_log()` (`data_service.py:54-134`) is not cheap:

| Line | Work | Cost |
|---|---|---|
| L71 | `self.enhanced_analysis_dir.rglob("*_enhanced.md")` | full recursive tree walk, **its own**, on every request |
| L79 | `parent_dir.glob(f"{video_id}_*_metadata.json")` | one directory scan **per entry** |
| L83 | `.exists()` | one `stat` per entry |
| L85-86 | `open()` + `json.load()` | one file read + JSON parse per entry |
| L93 | `.stat()` | another `stat` per entry |
| L127 | in-memory sort | over the whole result set |

Because it all ran inline, **the entire process** — every other request on every other endpoint, plus the health check — stalled for the duration.

### Why this one is worse than the two already fixed

This is the third endpoint in this family, and it is the worst of them:

1. **It is completely uncached.** #1237 and #1382 both went through `_get_all_files_cached()`, which has a real 60-second TTL (`data_service.py:48`, `136-160`). `get_learning_log()` bypasses that helper entirely and issues its **own** `rglob` at L71. There is no cache to amortise anything.
2. **It is unbounded.** The `/videos` endpoint fixed in #1382 at least took `limit`/`offset` and capped a page at 50. `get_learning_log_v1` takes **no parameters at all** — the walk, the per-entry reads and the sort all scale linearly with the total number of analysed videos, forever.

So where the earlier fixes bounded a stall, this one removes a stall that grows without limit as the corpus grows.

### The second half of the fix: bounding concurrency

Offloading alone would have traded one problem for another, and CodeRabbit's review caught it as a **blocking** finding before merge.

`asyncio.to_thread` dispatches to the loop's **default** executor — the same pool every other `to_thread` and `run_in_executor(None, …)` caller in the process uses. Since `get_learning_log()` is uncached, each concurrent request starts its own independent walk. The default per-client rate limit is `60/minute` and **permits bursts**, and this endpoint has no limit of its own, so a burst could occupy every worker in the shared pool and delay unrelated executor-backed requests. That is a real change in blast radius: from "one endpoint pins the loop" to "one endpoint starves everyone else's threads".

So the dispatch is gated:

```python
async with _get_learning_log_gate():
    learning_log = await asyncio.to_thread(data_service.get_learning_log)
```

Cap is 4 in-flight walks. Requests over the cap wait **on the event loop holding no worker thread**, so the endpoint degrades by queueing rather than by monopolising the executor. Exactly one `to_thread` hop remains inside the gate.

I chose a semaphore over a dedicated bounded executor because it has no lifecycle or shutdown handling to get wrong.

#### Why the gate is per-loop, and why that is not over-engineering

A plain module-level `asyncio.Semaphore(4)` is **broken** here — but not in the way I first wrote, and the correction (raised by CodeRabbit) makes the case for this design stronger rather than weaker.

I originally claimed the semaphore binds to the first event loop that awaits it. That is wrong. `Semaphore.acquire` in CPython 3.12 reads:

```python
if not self.locked():
    self._value -= 1
    return True                             # returns before _get_loop()
fut = self._get_loop().create_future()       # only the waiting path binds
```

The uncontended path never touches the loop. Binding happens **only when an acquisition actually has to wait**. I verified this from source via `inspect.getsource` and then reproduced it: uncontended acquires under two different `asyncio.run()` loops leave `_loop` as `None` with no error; five concurrent holders against a cap of four pin it to that loop; a fresh loop afterwards raises `RuntimeError: <Semaphore …> is bound to a different event loop`.

So a naive singleton is not an obvious bug that any test would surface — it is a **latent landmine**. It works across any number of loops, and keeps working, right up until the first genuinely contended acquisition. That one pins it, and every later use from a different loop fails. The failure therefore cannot appear in low-concurrency tests; it waits for exactly the burst this gate exists to absorb. Building the gate per running loop and holding it weakly removes the trap outright.

```python
_LEARNING_LOG_MAX_CONCURRENCY = 4
# Maps a running event loop -> the ``asyncio.Semaphore`` bound to that loop.
_learning_log_gates: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
_learning_log_gates_lock = threading.Lock()


def _get_learning_log_gate() -> asyncio.Semaphore:
    """Return the learning-log concurrency gate bound to the running loop."""
    loop = asyncio.get_running_loop()
    with _learning_log_gates_lock:
        gate = _learning_log_gates.get(loop)
        if gate is None:
            gate = asyncio.Semaphore(_LEARNING_LOG_MAX_CONCURRENCY)
            _learning_log_gates[loop] = gate
        return gate
```

The `threading.Lock` is load-bearing, not decorative: `WeakKeyDictionary` is not thread-safe (weakref finalisers can run arbitrary Python between bytecodes) and `TestClient` drives a loop on its own thread. I skipped double-checked locking — one uncontended acquire is ~50 ns against a filesystem walk. Entries drop automatically when their loop is collected, so nothing leaks in a long-lived process.

Both failure modes are covered by tests with negative controls, below.

### Why one `to_thread` hop and not two

The whole of `get_learning_log()` is a single synchronous call. There is no sequencing to break apart — no count-then-page shape like `/videos` had — so there is exactly one thing to dispatch. Splitting it would add a hop and buy nothing, and `test_walk_uses_exactly_one_to_thread_hop` pins that so a future refactor cannot silently add a second context switch.

### Why the blocking implementation is left alone

The fix is confined to the async layer. `data_service.py` is **not** touched.

Deliberately out of scope, each worth its own change:

- routing `get_learning_log()` through `_get_all_files_cached()` so it stops issuing its own `rglob`
- adding `limit`/`offset` so the endpoint stops being unbounded (an API contract change)
- caching the parsed metadata rather than re-reading and re-parsing every file every time

Those are real improvements, but each changes behaviour or the public contract. This PR changes **where** the existing work runs and nothing else, which is what makes it reviewable and safe to land on its own.

## Scope

| File | Change |
|---|---|
| `src/youtube_extension/backend/api/v1/router.py` | one line: `data_service.get_learning_log()` → `await asyncio.to_thread(data_service.get_learning_log)`, plus a 3-line comment explaining why |
| `tests/unit/test_v1_router_extended.py` | new `TestLearningLogOffloading` (4 tests) |

`asyncio` was already imported (L10). No new dependencies. No new imports in the source file.

Not changed: `data_service.py`, the route decorator, the response shape, the status codes, the `except` block.

## Risk

- **Risk level: low**
- **Failure mode:** the walk now runs on a `ThreadPoolExecutor` worker. `get_learning_log()` reads the filesystem and touches no shared mutable state, so there is no new data race. Executor starvation under a concurrent burst was the realistic failure and is now bounded by the semaphore at 4 in-flight walks; the minimum possible default-executor size is `min(32, (os.cpu_count() or 1) + 4)` = 5, so the cap always leaves at least one worker for unrelated callers even on a 1-CPU runner. Beyond the cap, requests queue on the event loop holding no thread. The remaining failure mode is added latency for the 5th-and-beyond concurrent caller — strictly better than today, where the *first* caller stalls the whole loop.
- **Rollback:** revert the two commits. The change is confined to one function plus a module-level helper above it; there is no migration, no persisted state and no config. Reverting only the gate commit leaves a working (if unbounded) offload.
- The response body is byte-for-byte identical — the same object from the same function, just returned from a different thread.
- The error contract is unchanged: an exception inside the worker propagates through `await` into the same `except Exception` and still yields a 500. `test_error_contract_is_unchanged` asserts this directly, and the pre-existing `test_get_learning_log_error` still passes untouched.

## Verification

All commands run at the pushed head of this branch.

### Focused tests

```
tests/unit/test_v1_router_extended.py ... 133 passed in 1.41s
```

125 before, 133 after — the 8 new tests, with no existing test modified or removed.

| Test | What breaks it |
|---|---|
| `test_walk_runs_on_a_worker_thread` | the walk executing on the loop thread |
| `test_event_loop_stays_responsive_while_walk_is_in_flight` | the loop being pinned for the walk's duration |
| `test_walk_uses_exactly_one_to_thread_hop` | a hop being added or removed |
| `test_error_contract_is_unchanged` | the 500 contract regressing |
| `test_concurrent_walks_are_capped_by_the_gate` | the cap being absent, or set so low it serialises the endpoint |
| `test_gate_is_rebuilt_for_each_event_loop` | a module-level singleton — caught by object identity, since a quiet test would never provoke the `RuntimeError` |
| `test_gate_is_shared_within_one_event_loop` | a fresh gate per call, which would bound nothing |
| `test_gate_survives_a_contended_loop_then_a_fresh_loop` | the actual production failure: saturates the gate so at least one caller genuinely waits (the only path that pins the semaphore), then drives the endpoint on a brand-new loop |

### Negative controls

A test that cannot fail is not evidence, so each was mutated and re-run.

| Control | Mutation | Result | Expected |
|---|---|---|---|
| **NC-1** | revert `router.py` to `origin/main` (direct inline call) | **3 failed, 1 passed** | ✅ the 3 offload tests fail; the error-contract test correctly still passes, since the 500 path is genuinely unaffected by the revert |
| **NC-2** | double-dispatch — wrap the call in a second nested `to_thread` | **1 failed, 3 passed** | ✅ **only** `test_walk_uses_exactly_one_to_thread_hop` fails, so it is specific rather than incidentally coupled |
| **NC-3** | `await asyncio.sleep(0)` then call inline — the naive "just add an await" fix | **3 failed, 1 passed** | ✅ proves the tests demand real thread offloading, not merely the presence of an await point |
| **NC-4** | delete the `async with`, keeping `to_thread` — i.e. exactly the state CodeRabbit flagged | **1 failed, 6 passed** | ✅ only the cap test fails, with `assert 7 <= 4` — all `limit + 3` callers walked at once, which is the unbounded burst reported |
| **NC-5** | return a **fresh** `Semaphore` per call instead of a cached one | **2 failed, 5 passed** | ✅ the cap test *and* the shared-gate test fail; a per-call gate bounds nothing |
| **NC-6** | one module-level gate keyed by a constant string in a plain `dict` — the loop-leak bug | **1 failed, 6 passed** | ✅ only the per-loop rebuild test fails, reporting `is not` on two identical object ids |
| **NC-7** | replace the accessor with a true module-level `Semaphore` singleton | **2 failed, 6 passed** | ✅ the identity test *and* the new contention test fail — the latter with the exact production `RuntimeError: … is bound to a different event loop` |

NC-4 is the direct proof of CodeRabbit's finding: with the gate removed the test reports the *true* concurrent count rather than merely failing. The cap test asserts `peak == limit`, not `peak <= limit`, so it fails in **both** directions — an absent bound and an over-restrictive one that quietly serialises the endpoint. It also polls until the first wave saturates and then sleeps 0.25 s **before** sampling the peak, so unbounded overflow has time to appear instead of being masked by a race.

NC-3 matters: it is the mistake this class of fix actually attracts. An `await` makes the function *look* correctly async and satisfies any status-code test, while the loop is still pinned.

NC-7 is the one that closes the loop on the correction above. Because binding requires contention, `test_gate_is_rebuilt_for_each_event_loop` can only detect a singleton through **object identity** — it would never see a `RuntimeError`, since nothing in a quiet test makes an acquisition wait. `test_gate_survives_a_contended_loop_then_a_fresh_loop` closes that gap by manufacturing the contention first, and under NC-7 it fails with the real runtime error rather than a proxy assertion. That is the difference between testing the implementation and testing the failure.

### A vacuous test I caught and fixed before pushing

The first draft of `test_event_loop_stays_responsive_while_walk_is_in_flight` counted loop ticks while the mock blocked on `threading.Event().wait(timeout=2.0)` and asserted `ticks >= 3`.

**It passed under NC-1.** That first NC run returned `2 failed, 2 passed` rather than the expected `3 failed`.

The reason: the blocking call has a timeout, so it eventually returns. In the inline case the loop is pinned for 2s, the wait times out, the task finishes — and *then* the three ticks run freely and the assertion passes. It was measuring nothing.

The rewritten test timestamps each tick with `time.monotonic()` and records when the walk actually finished, then asserts at least 3 ticks completed **strictly before** that moment. Inline, every tick necessarily lands after the walk ends, giving zero qualifying ticks. That version fails NC-1 and NC-3 as it should.

I am calling this out rather than quietly fixing it because the failure mode — an assertion that is true for the wrong reason — is exactly what the negative-control ladder exists to catch, and it is the reason I run one.

### Anti-vacuity assertions

Every test asserts the returned payload equals the mock's return value **before** asserting anything about threads or hops, and the responsiveness test additionally asserts the blocking work ran to completion. Without these, a change that skipped the call entirely would satisfy the thread-identity and hop-count assertions trivially.

### Why the existing tests did not catch this

`tests/unit/test_v1_router_extended.py:191` configures `svc.get_learning_log.return_value = [...]` on a `MagicMock`. The mock returns instantly, so `test_get_learning_log` (L544) passes identically whether the real call blocks for 10ms or 10s — it asserts a status code, and a status code is agnostic to which thread produced it.

`tests/unit/test_data_service.py:47-100` does exercise the real `get_learning_log()`, but calls it synchronously, so it never observes the endpoint's threading behaviour either.

Neither is wrong; they test different things. That gap is why this defect survived two rounds of fixes to its immediate neighbours.

### Lint

```
ruff check src/youtube_extension/backend/ src/youtube_extension/main.py --ignore E402,F811,F401,F821,B904,B020,E701,E722
```

3 errors total, at `deploy/__init__.py:3:1`, `data_service.py:340:16` and `test_v1_router_extended.py:1966:17`. I stashed my changes and re-ran against `origin/main`: **byte-identical, same three locations.** All pre-existing; none introduced here, and none in code this PR touches.

`ruff format --diff` over the two files this PR touches reports **189 changed lines on this branch and 189 on the stashed baseline** — exactly neutral, so this PR adds zero new formatting drift. Reaching parity took two reflows of my own new lines (an over-long annotated assignment, and an `asyncio.create_task(…)` inside a comprehension that ruff wanted collapsed). CI does not run `ruff format`, and `lint-python` is `continue-on-error: true`, but I hold the branch to parity anyway so the signal stays usable.

The `ruff check` findings were also contrasted against the stashed baseline over the same two files: **26 on both sides, differing only by a uniform +7 line shift** from the longer comment block. No new finding of any rule.

`python -m compileall -q src/` — clean, which is the guard CI actually enforces.

### Full suite

```
4 failed, 8278 passed, 18 skipped, 5 xpassed, 89 subtests passed in 761.24s
```

The four failures are the pre-existing ones described below; every other test in the repository passes.

### Pre-existing failures

Four tests fail on clean `main` and are unrelated to this change:

- `tests/test_code_generator.py` ×3 — make live `gemini-2.5-flash` API calls
- `tests/test_sdk_python.py::TestEventRelayClient::test_client_no_api_key_header_absent` — `main.py:57-61` calls `load_dotenv` at import time; a local untracked `.env` supplies `EVENTRELAY_API_KEY`, which `sdk/python/eventrelay_sdk/client.py:57` falls back to, so the header is present. Toggling only that one env var on clean `main` flips the result, which is what identifies it. The hermetic fix (`monkeypatch.delenv`) belongs in its own PR rather than bundled into a perf change.

- [x] Focused tests
- [x] Required CI
- [x] Review threads resolved

## Production evidence

Not applicable — no production surface changes.

This PR alters neither the route, the request signature, the response schema, the status codes nor any persisted state. `GET /api/v1/learning-log` returns the identical list of identical objects; the only difference is which thread assembled it. There is no feature flag, no migration and no deploy-order constraint, so there is no production artefact to attach. The relevant evidence is the negative-control ladder above, which demonstrates the tests fail when the fix is absent, when it is doubled, and when it is faked with a bare `await`.


