### PR TITLE
fix(perf): stamp each batched metric with its own timestamp

### DIFF
--- a/src/youtube_extension/backend/services/performance_monitor.py
+++ b/src/youtube_extension/backend/services/performance_monitor.py
@@ -293,13 +293,18 @@ class PerformanceMonitor:
             return
 
         try:
-            now = datetime.now(timezone.utc)
+            # Stamp each record with its own ``datetime.now`` exactly as the
+            # serial ``record_metric`` does. A single shared ``now`` for the
+            # whole batch gives every row an identical timestamp, which
+            # diverges from the parity this method's docstring promises and
+            # erases per-sample ordering for callers that submit genuinely
+            # distinct samples in one call.
             records = [
                 PerformanceMetric(
                     component=entry["component"],
                     metric_name=entry["metric_name"],
                     value=float(entry["value"]),
-                    timestamp=entry.get("timestamp") or now,
+                    timestamp=entry.get("timestamp") or datetime.now(timezone.utc),
                     unit=entry.get("unit", "ms"),
                     tags=entry.get("tags") or {},
                 )

--- a/tests/unit/test_performance_monitor.py
+++ b/tests/unit/test_performance_monitor.py
@@ -1306,6 +1306,96 @@ class TestRecordMetricsBatch:
                 want.component, want.metric_name, want.value, want.unit
             )
 
+    @staticmethod
+    def _walking_clock(instants):
+        """Stand-in for the module's ``datetime`` whose ``now`` walks a list.
+
+        Wall-clock resolution is too coarse to assert on directly -- several
+        ``datetime.now()`` calls in a tight loop can legitimately return the
+        same value -- so distinctness alone would be a flaky proxy for "one
+        stamp per record". Handing out a known sequence instead makes the
+        assertion exact: the Nth record must carry the Nth instant, which is
+        true only if ``now`` was consulted once per record, in order.
+
+        Running out of instants raises ``IndexError``. ``record_metrics``
+        swallows it, so the batch lands nothing and the caller's assertion on
+        buffer contents fails -- an extra clock read cannot pass silently.
+        """
+        remaining = list(instants)
+
+        class _Clock:
+            @staticmethod
+            def now(tz=None):
+                return remaining.pop(0)
+
+        return _Clock
+
+    async def test_batch_stamps_each_record_with_its_own_now(self, monitor):
+        """Every record gets its own stamp, as serial ``record_metric`` does.
+
+        A single shared ``now`` reused across the batch would give all three
+        records instant[0] and leave the last two unconsumed. That is the
+        regression this pins: the docstring promises behaviour identical to
+        calling ``record_metric`` once per entry, and the timestamp is the one
+        field where a batched implementation is tempted to diverge.
+        """
+        instants = [
+            datetime(2026, 1, 1, 0, 0, second, tzinfo=timezone.utc)
+            for second in range(3)
+        ]
+
+        with patch.object(
+            self._impl_module(), "datetime", self._walking_clock(instants)
+        ):
+            await monitor.record_metrics(self._samples(3))
+
+        assert [m.timestamp for m in monitor.metrics_buffer] == instants
+
+    async def test_batch_honours_an_explicitly_supplied_timestamp(self, monitor):
+        """An entry carrying its own ``timestamp`` must not be re-stamped.
+
+        Callers replaying buffered samples depend on this: the clock is only
+        consulted for entries that omit the field.
+        """
+        supplied = datetime(2020, 6, 1, 12, 30, 0, tzinfo=timezone.utc)
+        generated = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        with patch.object(
+            self._impl_module(), "datetime", self._walking_clock([generated])
+        ):
+            await monitor.record_metrics([
+                {"component": "system", "metric_name": "replayed",
+                 "value": 1.0, "unit": "ms", "timestamp": supplied},
+                {"component": "system", "metric_name": "live",
+                 "value": 2.0, "unit": "ms"},
+            ])
+
+        stamped = {m.metric_name: m.timestamp for m in monitor.metrics_buffer}
+        assert stamped == {"replayed": supplied, "live": generated}
+
+    async def test_batch_persists_the_per_record_timestamps(self, monitor):
+        """The distinct stamps must survive the write, not just the buffer."""
+        instants = [
+            datetime(2026, 1, 1, 0, 0, second, tzinfo=timezone.utc)
+            for second in range(3)
+        ]
+
+        with patch.object(
+            self._impl_module(), "datetime", self._walking_clock(instants)
+        ):
+            await monitor.record_metrics(self._samples(3))
+
+        conn = sqlite3.connect(monitor.db_path)
+        try:
+            rows = conn.execute(
+                "SELECT metric_name, timestamp FROM performance_metrics "
+                "ORDER BY metric_name"
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert [r[1] for r in rows] == [i.isoformat() for i in instants]
+
     async def test_empty_batch_does_no_database_work(self, monitor):
         calls: list[int] = []
         with patch.object(perf_mod.sqlite3, "connect", self._counting_connect(calls)):


### PR DESCRIPTION
## Canonical issue

Closes #1399

## Outcome

`PerformanceMonitor.record_metrics` becomes the drop-in for serial `record_metric` that its docstring already claims to be. Each record in a batch is stamped at the moment it is built, instead of all records sharing one timestamp hoisted out of the comprehension.

```diff
-            now = datetime.now(timezone.utc)
             records = [
                 PerformanceMetric(
                     ...
-                    timestamp=entry.get("timestamp") or now,
+                    timestamp=entry.get("timestamp") or datetime.now(timezone.utc),
                 )
                 for entry in metrics
             ]
```

The `entry["timestamp"]` escape hatch is unchanged: an explicitly supplied timestamp is still honoured, and the clock is read only for entries that omit it.

## Scope

- **Included:**
  - `src/youtube_extension/backend/services/performance_monitor.py` — per-record clock read in `record_metrics`, plus a comment recording why the hoist is not a valid optimization here.
  - `tests/unit/test_performance_monitor.py` — three tests pinning the timestamp contract (+90 lines).
- **Explicitly excluded:**
  - `record_metric` (serial path) — already correct, untouched.
  - `_store_metrics` / the batching itself — the one-connection-one-commit win from #1341 is preserved exactly; this changes only which instant each row carries.
  - The `metrics_recorded` count and the SQLite-handle-on-error fix in #1360 — a separate concern on a separate branch.

## Risk

- **Risk level:** low
- **Failure mode:** one additional `datetime.now()` per metric. The background monitor records 7 per 30-second cycle, so this is not measurable against the SQLite commit that `record_metrics` exists to collapse. No schema, query, or API surface changes.
- **Rollback:** revert this single commit. Timestamps are consumed only by range queries (`WHERE timestamp < ?` for retention pruning, `WHERE timestamp >= ?` for windowed reads); rows written under either implementation remain readable by both.

## Verification

Current head `f531eeb`.

- [x] **Focused tests** — `tests/unit/test_performance_monitor.py`: **131 passed** (128 before, +3).
- [x] **Fail-test** — with the source change reverted to shared-`now`, `test_batch_stamps_each_record_with_its_own_now` and `test_batch_persists_the_per_record_timestamps` both **FAIL**; both pass with the change. The third (`test_batch_honours_an_explicitly_supplied_timestamp`) passes either way by design — it guards the explicit-timestamp path, which was never broken.
- [x] **Full unit suite** — `tests/unit`: **8105 passed, 5 xpassed, 89 subtests, 0 failed** (175s).
- [x] **Router tests** — `tests/unit/test_v1_router_extended.py` included above; `record_metrics` is the call the report endpoint makes.
- [x] **Lint** — `ruff check` clean on both changed files.
- [ ] **Required CI** — pending on this head.
- [ ] **Review threads resolved** — no threads yet.

### On how the tests assert

Asserting that timestamps merely *differ* would be flaky: wall-clock resolution is coarse enough that several `now()` calls in a tight loop can legitimately return the same value. The tests instead patch the module clock to walk a known sequence, so the Nth record must carry the Nth instant — true only if the clock is consulted once per record, in order. Running out of instants raises `IndexError`, which `record_metrics` swallows, leaving the batch unwritten and failing the buffer assertion; an extra clock read cannot pass silently.

## Production evidence

Not applicable — no runtime surface, HTTP contract, or deployed artifact changes. The edit is one expression inside an internal service method; there is no user-visible behaviour to observe in a preview deployment. Evidence is the fail-test above, which demonstrates the tests detect the exact regression being fixed.

## Relationship to #1356

#1356 carries this same fix and nothing else that is not already on `main`. Its other three files landed via #1341, so GitHub's "+428" is measured against a pre-#1341 merge base. #1356 is additionally conflicted (`mergeable_state: dirty`, two hunks, both these timestamp lines) and blocked on a red `agent-completion/truth-gate` (`invalid_payload` — its body is still the unfilled template).

This PR takes the fix cleanly off current `main` and adds the test coverage #1356 lacks — its serial-vs-batched parity test asserts buffer and deque contents but never timestamps, so the fix it carries is itself unguarded. **#1356 can be closed as superseded once this lands.**

## Agent handoff

- [x] One canonical issue is linked — #1399
- [x] No competing PR implements the same issue — #1356 overlaps and is recommended for closure as superseded (see above); it cannot land as-is
- [x] Acceptance criteria are satisfied — all five in #1399
- [ ] Required checks pass on the current head — pending
- [x] Human decision is requested only for: merge approval into protected `main`

---
_Generated by [Claude Code](https://claude.ai/code/session_019baCDT5aP5Z66pLGBCE2Y6)_