### PR TITLE
fix(web): declare the three remaining implicit return types (#1381 review residue)

### DIFF
--- a/apps/web/src/app/api/__tests__/realtime-session-route.test.ts
+++ b/apps/web/src/app/api/__tests__/realtime-session-route.test.ts
@@ -4,7 +4,7 @@ import { GET, POST } from '@/app/api/realtime/session/route';
 const ORIGINAL_OPENAI_KEY = process.env.OPENAI_API_KEY;
 const ORIGINAL_SAFETY_IDENTIFIER = process.env.OPENAI_SAFETY_IDENTIFIER;
 
-function sdpRequest(body: string) {
+function sdpRequest(body: string): Request {
   return new Request('http://localhost/api/realtime/session', {
     method: 'POST',
     headers: { 'content-type': 'application/sdp' },
@@ -12,7 +12,11 @@ function sdpRequest(body: string) {
   });
 }
 
-function upstreamResponse(body: unknown, status = 200, headers: HeadersInit = { 'content-type': 'application/json' }) {
+function upstreamResponse(
+  body: unknown,
+  status = 200,
+  headers: HeadersInit = { 'content-type': 'application/json' },
+): Response {
   return new Response(typeof body === 'string' ? body : JSON.stringify(body), {
     status,
     headers,

--- a/apps/web/src/app/api/realtime/session/route.ts
+++ b/apps/web/src/app/api/realtime/session/route.ts
@@ -85,7 +85,7 @@ function upstreamUnreachable(
   return Response.json({ error, code }, { status: 502 });
 }
 
-function getOpenAiHeaders(contentType?: string) {
+function getOpenAiHeaders(contentType?: string): Record<string, string> | null {
   const apiKey = process.env.OPENAI_API_KEY;
 
   if (!apiKey) {


### PR DESCRIPTION
## Canonical issue

Closes #1383 (shares the canonical issue of its base PR #1381 — stacked follow-up, not a competing implementation).

**Base is `groupthinking-fix-upstream-error-leakage`, not `main`.**

> **This PR was rewritten.** It originally carried the unguarded-`fetch` fix and the error-code contract. While it was open, `ae2be83` and `5e69b7e` landed both directly on #1381's branch from another session. Rather than merge a conflicting duplicate, this branch was reset onto their head and reduced to the only thing still missing. The original commit `f9f964e` is gone; see the note below for why that is the right outcome.

## Outcome

Three helpers still had implicit return types after `ae2be83` and `5e69b7e`. Those commits typed `upstreamFailure`, `upstreamUnreachable`, and the `activateRequest` / `webhookRequest` / `transcribeRequest` helpers; these were missed:

| Helper | Declared type |
|---|---|
| `getOpenAiHeaders` (`realtime/session/route.ts`) | `Record<string, string> \| null` |
| `sdpRequest` (`realtime-session-route.test.ts`) | `Request` |
| `upstreamResponse` (`realtime-session-route.test.ts`) | `Response` |

This closes out CodeRabbit's strict-mode path instruction ("flag implicit any, missing return types") for the routes #1381 touches. `getOpenAiHeaders` already returned exactly that union on both of its paths, so the annotation is descriptive, not a narrowing.

## Scope

- **Included:** types only, in two files.
- **Explicitly excluded:** everything already landed in `ae2be83` / `5e69b7e`, and the "add the `copilot-rabbit` label and obtain an explicit Copilot approval" thread — a repository process gate, not a code change, and not something an agent should self-grant.

## Why the original commit was dropped rather than merged

Both implementations were compared line by line before discarding mine. Theirs is better on every overlapping point:

- **Transport guard.** `upstreamUnreachable` wraps the fetch *and* `await upstream.text()`, so a body read that rejects mid-stream is caught too. My `fetchUpstream` only wrapped the call itself and would have let that case escape. Their version also carries a third regression test for exactly that path.
- **Turnstile code.** Theirs returns a stable `code: 'turnstile_rejected'` while keeping `error` verbatim. Mine made `code` mirror the dynamic `turnstile.error`, which is a weaker contract — a machine-readable key that varies isn't a stable key.

Merging the original would have regressed both. Dropping it was the correct call, not a concession.

## Risk

- **Risk level:** low — type annotations only.
- **Failure mode:** none at runtime; annotations are erased at compile time. No response shape, status code, or test expectation changes.
- **Rollback:** revert this single commit.

## Verification

Run against head `855dcec`.

```
$ cd apps/web && npm run type-check   # tsc --noEmit
  (clean, exit 0)

$ cd apps/web && npm run lint         # eslint src middleware.ts
  (clean, exit 0)

$ cd apps/web && npm test             # vitest run
  Test Files  1 failed | 48 passed (49)
       Tests  1 failed | 271 passed (272)
```

271 passed / 1 failed matches `5e69b7e` exactly — this PR adds no tests and changes no counts. The single failure is `billing-chat-gating.test.ts:35` "blocks free tier after daily quota", 5000 ms timeout: pre-existing, unrelated, tracked in #1116.

- [x] Focused tests — full web suite, counts identical to base
- [ ] Required CI — `agent-completion/truth-gate` is structurally unsatisfiable here; see below
- [x] Review threads resolved — the substantive findings landed in `ae2be83` / `5e69b7e`; this is the residue

## Production evidence

Not applicable: type-only change stacked on an unmerged PR, so there is no independent deployment surface and no runtime behavior to observe. Production evidence belongs to #1381.

## Known blocker — `agent-completion/truth-gate`

Cannot pass on this PR and is not worth retrying. `agentTaskApplicable` (`.github/workflows/pr-checks.yml:646-649`) engages the agent-task policy on any `claude/*` head branch; the gate then requires a GitHub-native closing-issue reference, which GitHub only creates for PRs targeting the **default branch**. This PR targets `groupthinking-fix-upstream-error-leakage`, so no issue resolves and `policy.agent_login` / `policy.run_id` — read from the linked issue body at `pr-checks.yml:2162-2165` — come back empty. Full analysis in [this comment](https://github.com/groupthinking/EventRelay/pull/1402#issuecomment-5190311121).

Merging this into `groupthinking-fix-upstream-error-leakage` moots it: the change is then covered by #1381's own gate, which is green.

## Agent handoff

- [x] One canonical issue is linked
- [x] No competing PR implements the same issue — reduced specifically to avoid overlapping `ae2be83` / `5e69b7e`
- [x] Acceptance criteria are satisfied
- [ ] Required checks pass on the current head — truth-gate blocked structurally, as above
- [x] Human decision is requested only for product, security, irreversible infrastructure, or production approval — **merge is left to a human**; nothing was auto-merged