### PR TITLE
docs: say what the six required security scans actually gate

### DIFF
--- a/MERGE_POLICY.md
+++ b/MERGE_POLICY.md
@@ -93,6 +93,23 @@ listed `Security` among its required six, and dropping every security scan out
 of the required set would be a weakening introduced by the rewrite that set out
 to make this gate precise.
 
+> **What these six actually gate.** They attest that each scan *ran* — not that
+> it found nothing. Every one of them reports `success` with findings present:
+>
+> | Check | Fails the job on | Why findings don't fail it |
+> | --- | --- | --- |
+> | `npm-audit` | `npm install` breaking | `continue-on-error: true` on the `npm audit` step |
+> | `python-safety` | `pip install safety` breaking | `\|\| true` *and* `continue-on-error: true` |
+> | `bandit` | `pip install bandit` breaking | `\|\| true` on the `bandit -r src` step |
+> | `trivy` | the `docker build` breaking | `exit-code: '0'` passed to `trivy-action` |
+> | `Security Scan - python`, `Security Scan - javascript` | CodeQL itself erroring | alerts route to the Security tab; blocking on them is code-scanning merge protection, which is not a required-check setting |
+>
+> So requiring these six catches a scanner that broke or stopped running, which
+> is a real regression this gate can detect. It does **not** mean "no
+> HIGH/CRITICAL finding can merge." Making findings block is a change to
+> `security.yml` and to code-scanning merge protection — not a branch-protection
+> edit, and not something adding a name to the list above achieves.
+
 > **`trivy` is lowercase.** Two distinct check-runs exist on the same head —
 > `trivy` reports `success`, `Trivy` reports `neutral`. Selecting the
 > capitalised one requires a check that never passes. This is exactly the trap


### PR DESCRIPTION
## Canonical issue

Closes #1413

Stacked on #1410 (base is its branch, not `main`), so the diff here is one commit, `MERGE_POLICY.md` +17/−0. This is a follow-up to #1410, **not** a competing implementation of #1412 — #1410 decides *which* checks are required; this records *what passing them means*. Neither claim moves the other's list.

## Outcome

Gate 2 requires six security contexts, and every one of them reports `success` with findings present. A reader configuring branch protection from that list would reasonably conclude a HIGH/CRITICAL finding cannot merge. It can. This records the gap and what requiring them does buy.

Verified against the workflow definitions, not inferred from observed check-run status:

| Check | Fails the job on | Why findings don't fail it |
| --- | --- | --- |
| `npm-audit` | `npm install` breaking | `continue-on-error: true` on the audit step |
| `python-safety` | `pip install safety` breaking | `\|\| true` *and* `continue-on-error: true` |
| `bandit` | `pip install bandit` breaking | `\|\| true` on `bandit -r src` |
| `trivy` | the `docker build` breaking | `exit-code: '0'` passed to `trivy-action` |
| `Security Scan - python`, `- javascript` | CodeQL itself erroring | alerts route to the Security tab; blocking is code-scanning merge protection, not a required-check setting |

CodeRabbit reached the same conclusion independently on #1410 ("requiring these check names ensures the jobs report, but does not necessarily make vulnerability findings fail the merge"). This is the documentation half of the two options its review offered.

## Scope

- **Included:** `MERGE_POLICY.md` — one block quote after the paragraph #1410 adds.
- **Explicitly excluded:**
  - Which checks are required. That is #1412 / #1410, and this does not touch either list.
  - Making the scans fail on findings. That is the other half of CodeRabbit's finding, and it flips CI red repo-wide the moment any HIGH/CRITICAL exists — a maintainer's policy call, not a documentation fix.
  - `security.yml` and code-scanning merge protection are both untouched.

## Risk

- **Risk level:** low
- **Failure mode:** documentation only, no executable surface. The realistic failure is the one this fixes: someone reads gate 2 as a vulnerability gate and ships branch protection that does not block vulnerable merges.
- **Rollback:** `git revert`. Nothing depends on the file.

## Verification

Head `1853285`.

- [x] **All four `security.yml` suppressions confirmed at source** — `continue-on-error: true` (lines 31, 53), `|| true` (lines 52, 69), `exit-code: '0'` (line 94). Each job's *only* unguarded steps are toolchain/build steps, so each fails on a broken scanner and never on a finding.
- [x] **The six do all run on every PR to `main`** — re-checked rather than assumed, because the claim would be wrong if any were absent. `security.yml` and `codeql-analysis.yml` both trigger on `pull_request: branches: [main]` with no `paths:` filter; neither has a job-level `if:`; CodeQL's matrix is `['javascript', 'python']` with `fail-fast: false`. #1410's own premise holds.
- [x] **`verification.yml`'s "Gate 3: Security Scan" is not one of the six** — different check name, and it triggers only on PRs targeting `refactor/hybrid-infra-v2`. Checked because a name collision there would have made the required list strand every PR to `main`.
- [x] **Independent corroboration** — CodeRabbit's full review of #1410 flags the same enforcement caveat from the same evidence.
- [ ] **Required CI** — suppressed by stacking (base is a feature branch); `agent-completion/truth-gate` is red for the arming defect #1409 repairs, which `pull_request_target` runs from the base so no commit here can affect.
- [ ] **Review threads resolved** — none yet.

## Production evidence

Not applicable — one markdown file, no runtime or build surface. Under the policy this file defines, gate 4 scopes previews to `apps/web/**`.

## Agent handoff

- [x] One canonical issue is linked — #1413
- [x] No competing PR implements the same issue — #1413 was filed for this change; #1412 is a disjoint claim about the same paragraph
- [x] Acceptance criteria are satisfied — all four on #1413
- [ ] Required checks pass on the current head — see the stacking note above
- [x] Human decision is requested only for: whether to make the scans actually fail on findings (out of scope here), and merge approval

## Agent provenance

Agent-authored. No `agent-lock-manifest` is filled in: the manifest declares a `run_id` and `agent_login` the truth gate treats as evidence and expects corroborated by append-only result comments. There is no dispatch record behind this change, and fabricating those values would inject false evidence into the mechanism #1409 is repairing.

---
_Generated by [Claude Code](https://claude.ai/code/session_019VsKKnTAKoWJr49zQP95kK)_