### PR TITLE
fix(ci): arm the truth gate only on an issue that declares a contract

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -721,8 +721,20 @@ jobs:
               // issue at all is separately owned by `Canonical issue and
               // evidence`, which states a requirement an author can actually
               // meet.
+              //
+              // "Exists to verify against" means the issue declares the
+              // contract, not merely that an issue is linked. Testing only for
+              // presence left the same defect one level down: a `claude/...`
+              // branch closing an ordinary issue armed the gate, which then
+              // demanded `policy.agent_login` and `policy.run_id` that no
+              // intent snapshot had ever written, so the verdict was
+              // permanently `invalid_payload` (#1401). `declaresAgentContract`
+              // is the same predicate `issueDispatch` already relies on, so
+              // both arms of this disjunction now require the thing the gate
+              // goes on to measure.
               return login !== 'dependabot[bot]' &&
-                (issueDispatch || (pullProvenance && Boolean(selectedIssue)));
+                (issueDispatch ||
+                  (pullProvenance && declaresAgentContract(selectedIssue)));
             }
             function intentContractErrors(issue, comments, pullCreatedAt) {
               const errors = [];
@@ -2047,8 +2059,20 @@ jobs:
               // issue at all is separately owned by `Canonical issue and
               // evidence`, which states a requirement an author can actually
               // meet.
+              //
+              // "Exists to verify against" means the issue declares the
+              // contract, not merely that an issue is linked. Testing only for
+              // presence left the same defect one level down: a `claude/...`
+              // branch closing an ordinary issue armed the gate, which then
+              // demanded `policy.agent_login` and `policy.run_id` that no
+              // intent snapshot had ever written, so the verdict was
+              // permanently `invalid_payload` (#1401). `declaresAgentContract`
+              // is the same predicate `issueDispatch` already relies on, so
+              // both arms of this disjunction now require the thing the gate
+              // goes on to measure.
               return login !== 'dependabot[bot]' &&
-                (issueDispatch || (pullProvenance && Boolean(selectedIssue)));
+                (issueDispatch ||
+                  (pullProvenance && declaresAgentContract(selectedIssue)));
             }
 
             const prNumber = Number(process.env.INPUT_PR_NUMBER || 0);

--- a/tests/unit/test_agent_completion_gate.py
+++ b/tests/unit/test_agent_completion_gate.py
@@ -2894,22 +2894,43 @@ const rows = [
   ['issue label without contract', base, issue(1, ['mcp/agent']), false],
   ['issue label with contract', base, issue(1, ['mcp/agent'], CONTRACT), true],
   // Pull-side provenance identifies the producer; it does not supply a
-  // contract to score against. With no linked issue there is no intent
-  // snapshot, so `policy.agent_login`, `policy.run_id` and `issue.number`
-  // can never be populated and the verdict is permanently `invalid_payload`.
-  // Each of these arms the gate only once an issue exists to verify against.
+  // contract to score against. That contract lives only in the intent
+  // snapshot `snapshot-agent-task-intent` writes for a dispatched issue, so
+  // without one `policy.agent_login`, `policy.run_id` and `issue.number` can
+  // never be populated and the verdict is permanently `invalid_payload`.
+  //
+  // So each of these arms the gate only once a linked issue *declares the
+  // contract*. A merely-present issue is not enough: an ordinary issue has no
+  // snapshot either, and arming on it reproduced the same unsatisfiable gate
+  // one level down (#1401). Both directions are pinned for every provenance
+  // signal — plain issue must not arm, contract issue must.
   ['PR label, no issue', {...base, labels: [{name: 'agent-task'}]}, null, false],
-  ['PR label + issue', {...base, labels: [{name: 'agent-task'}]}, PLAIN, true],
+  ['PR label + plain issue',
+    {...base, labels: [{name: 'agent-task'}]}, PLAIN, false],
+  ['PR label + contract issue',
+    {...base, labels: [{name: 'agent-task'}]}, issue(1, [], CONTRACT), true],
   ['branch, no issue', {...base, head: {ref: 'codex/fix'}}, null, false],
-  ['branch + issue', {...base, head: {ref: 'codex/fix'}}, PLAIN, true],
+  ['branch + plain issue', {...base, head: {ref: 'codex/fix'}}, PLAIN, false],
+  ['branch + contract issue',
+    {...base, head: {ref: 'codex/fix'}}, issue(1, [], CONTRACT), true],
   ['manifest, no issue',
     {...base, body: '<!-- agent-lock-manifest {bad} -->'}, null, false],
-  ['manifest + issue',
-    {...base, body: '<!-- agent-lock-manifest {bad} -->'}, PLAIN, true],
+  ['manifest + plain issue',
+    {...base, body: '<!-- agent-lock-manifest {bad} -->'}, PLAIN, false],
+  ['manifest + contract issue',
+    {...base, body: '<!-- agent-lock-manifest {bad} -->'},
+    issue(1, [], CONTRACT), true],
   ['known agent, no issue',
     {...base, user: {login: 'google-labs-jules[bot]'}}, null, false],
-  ['known agent + issue',
-    {...base, user: {login: 'google-labs-jules[bot]'}}, PLAIN, true],
+  ['known agent + plain issue',
+    {...base, user: {login: 'google-labs-jules[bot]'}}, PLAIN, false],
+  ['known agent + contract issue',
+    {...base, user: {login: 'google-labs-jules[bot]'}},
+    issue(1, [], CONTRACT), true],
+  // The exact shape that was red on #1400: an agent-prefixed branch closing an
+  // ordinary issue. This must resolve `not_applicable`, not `invalid_payload`.
+  ['claude branch + ordinary issue',
+    {...base, head: {ref: 'claude/clever-heisenberg-8k227t'}}, PLAIN, false],
   ['dependabot excluded', {
     ...base,
     user: {login: 'dependabot[bot]'},
@@ -3464,25 +3485,34 @@ const rows = [
   ['unlabelled issue with contract', human, {
     number: 7, labels: [{name: 'bug'}], body: CONTRACT
   }, false],
-  // Pull request provenance applies against a linked issue -- an agent
-  // producing work against a contract-less issue is still applicable, and
-  // therefore still blocked.
-  ['known agent author', {
+  // Pull request provenance applies only against an issue that declares the
+  // contract. A known agent closing a contract-less issue has nothing to be
+  // measured against -- the snapshot job never wrote one -- so arming here
+  // produced a permanent invalid_payload rather than an enforcement (#1401).
+  ['known agent author, contract-less issue', {
     user: {login: 'google-labs-jules[bot]'},
     head: {ref: 'feature/thing'}, labels: [], body: ''
-  }, {number: 7, labels: [{name: 'agent-task'}], body: '## Summary\n'}, true],
-  // ...but with no linked issue there is no intent snapshot and no declared
-  // run id or login, so the required payload fields are unsatisfiable and the
-  // gate would block permanently rather than ever reaching a verdict. These
-  // are `not_applicable`, not violations.
+  }, {number: 7, labels: [{name: 'agent-task'}], body: '## Summary\n'}, false],
+  ['known agent author, declared contract', {
+    user: {login: 'google-labs-jules[bot]'},
+    head: {ref: 'feature/thing'}, labels: [], body: ''
+  }, {number: 7, labels: [{name: 'agent-task'}], body: CONTRACT}, true],
+  // Likewise with no linked issue at all: no intent snapshot, no declared run
+  // id or login, so the required payload fields are unsatisfiable and the gate
+  // would block permanently rather than ever reaching a verdict. These are
+  // `not_applicable`, not violations.
   ['agent branch prefix, no issue', {
     user: {login: 'groupthinking'},
     head: {ref: 'jules/thing'}, labels: [], body: ''
   }, null, false],
-  ['agent branch prefix with issue', {
+  ['agent branch prefix, contract-less issue', {
     user: {login: 'groupthinking'},
     head: {ref: 'jules/thing'}, labels: [], body: ''
-  }, {number: 7, labels: [], body: ''}, true],
+  }, {number: 7, labels: [], body: ''}, false],
+  ['agent branch prefix, declared contract', {
+    user: {login: 'groupthinking'},
+    head: {ref: 'jules/thing'}, labels: [], body: ''
+  }, {number: 7, labels: [], body: CONTRACT}, true],
   ['agent label on the pull request, no issue', {
     user: {login: 'groupthinking'},
     head: {ref: 'feature/thing'},


### PR DESCRIPTION
## Canonical issue

Closes #1401

## Outcome

`agent-completion/truth-gate` stops going permanently red on agent-branch pull requests that close an ordinary issue. #1377 fixed the case where the gate armed with **no** linked issue; this fixes the same defect one level down — arming on a linked issue that declares no agent contract.

```diff
 return login !== 'dependabot[bot]' &&
-  (issueDispatch || (pullProvenance && Boolean(selectedIssue)));
+  (issueDispatch ||
+    (pullProvenance && declaresAgentContract(selectedIssue)));
```

`pullProvenance` is true for any branch matching `/^(?:agent|claude|codex|copilot|jules)[/-]/`, and `Boolean(selectedIssue)` is true for *any* linked issue. So a `claude/…` branch closing an ordinary issue armed the gate, which then demanded `policy.agent_login` and `policy.run_id` — only ever populated from the frozen intent snapshot `snapshot-agent-task-intent` writes for dispatched agent tasks. An ordinary issue has no snapshot, so the verdict was permanently `invalid_payload` regardless of what the author did.

The comment above the return already stated the correct rule — provenance arms the gate once a linked issue exists *"to verify against"* — but `Boolean(selectedIssue)` tests only that an issue **exists**, not that it carries anything to verify against. `declaresAgentContract` is the same predicate `issueDispatch` already relies on, so both arms of the disjunction now require the thing the gate goes on to measure.

The collector was already diagnosing this correctly, reporting `linked_issue_not_agent_task` and `missing_intent_snapshot`. Only the applicability predicate ignored it.

## Scope

- **Included:**
  - `.github/workflows/pr-checks.yml` — the predicate in **both** copies of `agentTaskApplicable()` (lines 725 and 2051), plus a comment recording why presence is not the right test. The two copies remain byte-identical, which an existing test asserts.
  - `tests/unit/test_agent_completion_gate.py` — both assertion blocks.
- **Explicitly excluded:**
  - `scripts/ci/agent_completion_gate.py` — `evaluate()` is correct as written; it returns `not_applicable` whenever `policy.applicable is False`. The bug was entirely in what sets `applicable`.
  - `issueDispatch` — already correct, untouched.
  - Retiring the truth-gate apparatus rather than repairing it — still the open question raised in #1377.

## Risk

- **Risk level:** low
- **Failure mode:** the gate resolves `not_applicable` for a PR that should be gated — specifically an agent PR linking an issue that declares no contract. That state was previously `blocked`-with-no-remedy rather than enforcing anything, so this narrows a permanently-failing check, not a working one. A PR linking a genuinely dispatched issue is gated exactly as before, because `declaresAgentContract` is the same function `issueDispatch` already uses. Binding a PR to a focused issue stays enforced by `Canonical issue and evidence` and `PR Governance`.
- **Rollback:** revert this single commit. Workflow and test changes only — no runtime code path, no schema, no data migration.

## Verification

Current head `39729d2`.

- [x] **Focused tests** — `tests/unit/test_agent_completion_gate.py`: **112 passed, 89 subtests**.
- [x] **Fail-test** — with `pr-checks.yml` reverted and the tests left as fixed, **both** assertion blocks fail (`test_agent_applicability_requires_provenance_or_declared_contract` and `test_scheduled_scanner_detects_frozen_intent_changes`). 2 failed / 110 passed. They pass with the change.
- [x] **Full unit suite** — `tests/unit`: **8114 passed, 5 xpassed, 89 subtests, 0 failed** (261s).
- [x] **Workflow validity** — `yaml.safe_load` parses `pr-checks.yml` (5 jobs); `Boolean(selectedIssue)` now appears 0 times, `declaresAgentContract(selectedIssue)` 4 times (2 per copy), and the byte-identical-copies assertion passes.
- [ ] **Required CI** — pending on this head.
- [ ] **Review threads resolved** — no threads yet.

### Test changes

Both blocks previously **encoded the defect** — a plain issue plus any provenance signal asserted `true`:

```js
['branch + issue', {...base, head: {ref: 'codex/fix'}}, PLAIN, true],   // was
```

Each provenance signal (PR label, branch prefix, lock manifest, known agent author) now pins **both** directions: a contract-less issue must not arm, a contract-bearing one must. Added the exact shape that was red on #1400 — an agent-prefixed branch closing an ordinary issue.

## Production evidence

Not applicable — CI configuration and tests only; no runtime surface, HTTP contract, or deployed artifact changes.

**This PR cannot green its own gate.** `pull_request_target` runs the workflow from the **base** branch, so the fix takes effect for everything else once merged, not here. #1377 hit exactly this and merged with the same status red. Evidence is the fail-test above.

## Agent handoff

- [x] One canonical issue is linked — #1401
- [x] No competing PR implements the same issue
- [x] Acceptance criteria are satisfied — all four in #1401
- [ ] Required checks pass on the current head — all except `agent-completion/truth-gate`, which cannot pass on its own PR (see above)
- [x] Human decision is requested only for: merge approval into protected `main`

---
_Generated by [Claude Code](https://claude.ai/code/session_019baCDT5aP5Z66pLGBCE2Y6)_