### PR TITLE
fix(web): stop /api/transcribe leaking probe status and key config

### DIFF
--- a/apps/web/src/app/api/transcribe/route.ts
+++ b/apps/web/src/app/api/transcribe/route.ts
@@ -19,11 +19,17 @@ export const maxDuration = 120;
  * carry raw upstream provider text (account IDs, quota state, partial API keys)
  * — that text is logged server-side only.
  *
- * The `!result.success` branches keep `fetchTranscript`'s own message in `error`:
- * every one of those values is an app-authored literal, a numeric HTTP status, or
- * our own SSRF-guard message, so none is upstream text. Preserving them verbatim
- * keeps the human-facing string contract intact while `code` carries the stable
- * key for programmatic handling.
+ * The `!result.success` branches keep `fetchTranscript`'s own message in `error`.
+ * That is safe only because every one of those values is now a fixed,
+ * app-authored literal. Two of them were not, and were removed at the source in
+ * `transcription-service.ts` rather than masked here:
+ *   - the caller-supplied `audioUrl`'s HTTP status, which made this route a
+ *     cross-origin probe, and
+ *   - a message that varied on whether provider API keys were configured, which
+ *     disclosed server configuration.
+ * Both are logged server-side instead. Keep that invariant when adding a
+ * strategy: anything interpolated into a `fetchTranscript` error reaches the
+ * client verbatim through the branches below.
  *   - 400: Invalid input (missing URL, malformed JSON) — `input_required` / `invalid_json`
  *   - 429: Rate limited (implement backoff or upgrade service plan) — `rate_limited`
  *   - 500: Service unavailable (check API keys and billing) — `billing_not_configured`
@@ -94,7 +100,9 @@ export async function POST(request: Request) {
             success: false,
             error: result.error,
             code: 'billing_not_configured',
-            details: 'Configure billing in Google Cloud and OpenAI console',
+            // No `details` here: the remediation text named this deployment's
+            // cloud and model vendors, and the PR that sanitized this route
+            // stated `details` was gone from it. `code` is what clients branch on.
             transcript: '',
           },
           { status: 500 }

--- a/apps/web/src/app/api/transcribe/route.ts
+++ b/apps/web/src/app/api/transcribe/route.ts
@@ -20,16 +20,28 @@ export const maxDuration = 120;
  * — that text is logged server-side only.
  *
  * The `!result.success` branches keep `fetchTranscript`'s own message in `error`.
- * That is safe only because every one of those values is now a fixed,
- * app-authored literal. Two of them were not, and were removed at the source in
- * `transcription-service.ts` rather than masked here:
+ * That holds only while every value it can return is a fixed, app-authored
+ * literal — verified as of this change, all seven are. Three were not, and were
+ * corrected at the source in `transcription-service.ts` rather than masked here:
  *   - the caller-supplied `audioUrl`'s HTTP status, which made this route a
- *     cross-origin probe, and
+ *     cross-origin probe,
  *   - a message that varied on whether provider API keys were configured, which
- *     disclosed server configuration.
- * Both are logged server-side instead. Keep that invariant when adding a
- * strategy: anything interpolated into a `fetchTranscript` error reaches the
- * client verbatim through the branches below.
+ *     disclosed server configuration, and
+ *   - the SSRF guard's rejection reason, which named which guard rule fired and
+ *     so leaked hostname-blocklist policy.
+ * All three are logged server-side instead.
+ *
+ * Keep that invariant when adding a strategy: anything interpolated into a
+ * `fetchTranscript` error reaches the client verbatim through the branches
+ * below. `${}` in an error value is the thing to look for.
+ *
+ * What this deliberately does NOT claim: the *choice among* those literals is
+ * still informative. `Rejected audioUrl` versus `Could not retrieve the audio
+ * file` tells a caller whether their host cleared the SSRF guard — i.e. whether
+ * it resolves to a public address. That residue is inherent to a guard that
+ * refuses some inputs and attempts others, it is far coarser than naming the
+ * rule, and this route is session-gated (`apps/web/src/lib/auth-paths.ts`), so
+ * it is accepted rather than papered over.
  *   - 400: Invalid input (missing URL, malformed JSON) — `input_required` / `invalid_json`
  *   - 429: Rate limited (implement backoff or upgrade service plan) — `rate_limited`
  *   - 500: Service unavailable (check API keys and billing) — `billing_not_configured`

--- a/apps/web/src/lib/__tests__/transcription-error-disclosure.test.ts
+++ b/apps/web/src/lib/__tests__/transcription-error-disclosure.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // `fetchTranscript`'s error string is returned to the caller verbatim by
 // `/api/transcribe`'s `!result.success` branches. That is only safe while every
-// value it can carry is a fixed, app-authored literal. These tests pin the two
-// values that were not: the caller-supplied `audioUrl`'s HTTP status, and a
-// message that varied on whether provider API keys were configured.
+// value it can carry is a fixed, app-authored literal. These tests pin the three
+// values that were not: the caller-supplied `audioUrl`'s HTTP status, a message
+// that varied on whether provider API keys were configured, and the SSRF guard's
+// rejection reason, which named which guard rule fired.
 
 vi.mock('server-only', () => ({}));
 vi.mock('@/lib/ssrf-guard', () => ({
@@ -25,8 +26,20 @@ vi.mock('@/lib/vercel-ai-gateway', () => ({
 }));
 
 import { fetchTranscript } from '@/lib/transcription-service';
+import { assertPublicHttpUrl } from '@/lib/ssrf-guard';
 
 const AUDIO_URL = 'https://cdn.example.com/clip.mp3';
+
+// The real messages `assertPublicHttpUrl` throws, as of ssrf-guard.ts. Each
+// names a different guard rule; the point of the test below is that the caller
+// cannot tell them apart.
+const GUARD_REJECTIONS = [
+  'Invalid URL',
+  'Blocked URL scheme: file:',
+  'Blocked host',
+  'Blocked private IP literal',
+  'Host does not resolve to a public address',
+];
 
 let consoleError: ReturnType<typeof vi.spyOn>;
 const savedEnv = { ...process.env };
@@ -77,6 +90,32 @@ describe('fetchTranscript error disclosure', () => {
 
     // One distinguishable message per status would rebuild the oracle.
     expect(new Set(errors).size).toBe(1);
+  });
+
+  it('does not reveal which SSRF guard rule rejected the audioUrl', async () => {
+    process.env.OPENAI_API_KEY = 'sk-test-key';
+    const errors: string[] = [];
+
+    for (const message of GUARD_REJECTIONS) {
+      vi.mocked(assertPublicHttpUrl).mockRejectedValueOnce(new Error(message));
+      const result = await fetchTranscript({ audioUrl: AUDIO_URL });
+      errors.push(result.error ?? '');
+    }
+
+    // A blocklist match and a DNS rejection must be indistinguishable: the first
+    // confirms a hostname is on the server's blocklist, the second only that DNS
+    // returned nothing public. Distinguishing them is a policy oracle.
+    expect(new Set(errors).size).toBe(1);
+    expect(errors[0]).toBe('Rejected audioUrl');
+    // No guard rule name survives into the caller-visible payload.
+    for (const message of GUARD_REJECTIONS) {
+      expect(errors[0]).not.toContain(message);
+    }
+    // Operators still get the real reason.
+    expect(consoleError).toHaveBeenCalledWith(
+      '[transcription] audioUrl rejected by SSRF guard:',
+      expect.objectContaining({ message: 'Blocked host' }),
+    );
   });
 
   it('does not disclose whether provider API keys are configured', async () => {

--- a/apps/web/src/lib/__tests__/transcription-error-disclosure.test.ts
+++ b/apps/web/src/lib/__tests__/transcription-error-disclosure.test.ts
@@ -86,10 +86,10 @@ describe('fetchTranscript error disclosure', () => {
     );
 
     delete process.env.OPENAI_API_KEY;
-    const withoutKeys = await fetchTranscript({ url: 'https://youtu.be/dQw4w9WgXcQ' });
+    const withoutKeys = await fetchTranscript({ url: 'https://youtu.be/auJzb1D-fag' });
 
     process.env.OPENAI_API_KEY = 'sk-test-key';
-    const withKeys = await fetchTranscript({ url: 'https://youtu.be/dQw4w9WgXcQ' });
+    const withKeys = await fetchTranscript({ url: 'https://youtu.be/auJzb1D-fag' });
 
     expect(withoutKeys.success).toBe(false);
     expect(withKeys.success).toBe(false);

--- a/apps/web/src/lib/__tests__/transcription-error-disclosure.test.ts
+++ b/apps/web/src/lib/__tests__/transcription-error-disclosure.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// `fetchTranscript`'s error string is returned to the caller verbatim by
+// `/api/transcribe`'s `!result.success` branches. That is only safe while every
+// value it can carry is a fixed, app-authored literal. These tests pin the two
+// values that were not: the caller-supplied `audioUrl`'s HTTP status, and a
+// message that varied on whether provider API keys were configured.
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/lib/ssrf-guard', () => ({
+  assertPublicHttpUrl: vi.fn(async (input: string) => new URL(input)),
+}));
+vi.mock('@/lib/youtube-metadata', () => ({
+  fetchYouTubeMetadata: vi.fn(async () => null),
+  formatMetadataAsContext: vi.fn(() => ''),
+}));
+vi.mock('@/lib/gemini-client', () => ({
+  getGeminiClient: vi.fn(() => null),
+  hasGeminiKey: vi.fn(() => false),
+}));
+vi.mock('@/lib/vercel-ai-gateway', () => ({
+  gatewayChat: vi.fn(async () => null),
+  hasAiGatewayKey: vi.fn(() => false),
+  toGatewayModelId: vi.fn((m: string) => m),
+}));
+
+import { fetchTranscript } from '@/lib/transcription-service';
+
+const AUDIO_URL = 'https://cdn.example.com/clip.mp3';
+
+let consoleError: ReturnType<typeof vi.spyOn>;
+const savedEnv = { ...process.env };
+
+beforeEach(() => {
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  process.env = { ...savedEnv };
+});
+
+describe('fetchTranscript error disclosure', () => {
+  it('does not echo the status of a caller-supplied audioUrl', async () => {
+    process.env.OPENAI_API_KEY = 'sk-test-key';
+    // 403 from a host the caller chose. Echoing it back is a cross-origin read
+    // the browser's same-origin policy would otherwise deny them.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('forbidden', { status: 403 })),
+    );
+
+    const result = await fetchTranscript({ audioUrl: AUDIO_URL });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Could not retrieve the audio file');
+    // The probe result must not survive anywhere in the caller-visible payload.
+    expect(JSON.stringify(result)).not.toContain('403');
+    // ...but an operator can still see it.
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('403'));
+  });
+
+  it('reports the same status-free message whatever the upstream status is', async () => {
+    process.env.OPENAI_API_KEY = 'sk-test-key';
+    const errors: string[] = [];
+
+    for (const status of [401, 403, 404, 500]) {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response('nope', { status })),
+      );
+      const result = await fetchTranscript({ audioUrl: AUDIO_URL });
+      errors.push(result.error ?? '');
+    }
+
+    // One distinguishable message per status would rebuild the oracle.
+    expect(new Set(errors).size).toBe(1);
+  });
+
+  it('does not disclose whether provider API keys are configured', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 500 })),
+    );
+
+    delete process.env.OPENAI_API_KEY;
+    const withoutKeys = await fetchTranscript({ url: 'https://youtu.be/dQw4w9WgXcQ' });
+
+    process.env.OPENAI_API_KEY = 'sk-test-key';
+    const withKeys = await fetchTranscript({ url: 'https://youtu.be/dQw4w9WgXcQ' });
+
+    expect(withoutKeys.success).toBe(false);
+    expect(withKeys.success).toBe(false);
+    // Configuration state is not a caller-facing fact.
+    expect(withoutKeys.error).toBe(withKeys.error);
+    expect(withoutKeys.error).not.toMatch(/OPENAI_API_KEY|GEMINI_API_KEY|Vercel/i);
+    // The distinction stays available to operators.
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('no OPENAI_API_KEY or GEMINI_API_KEY configured'),
+    );
+  });
+});

--- a/apps/web/src/lib/transcription-service.ts
+++ b/apps/web/src/lib/transcription-service.ts
@@ -282,9 +282,17 @@ ${metadataContext ? `\nKNOWN METADATA:\n${metadataContext}` : ''}`,
 
       const audioResponse = await fetch(audioUrl, { signal: AbortSignal.timeout(30_000) });
       if (!audioResponse.ok) {
+        // The status belongs to a caller-supplied `audioUrl`. Echoing it turns
+        // this route into a probe: the caller learns 401 vs 403 vs 404 vs 500
+        // for any host the SSRF guard admits, which is a cross-origin read the
+        // browser same-origin policy would otherwise deny them. Log it, and
+        // report only that the fetch failed.
+        console.error(
+          `[transcription] audioUrl fetch failed with status ${audioResponse.status}`,
+        );
         return {
           success: false,
-          error: `Failed to fetch audio: ${audioResponse.status}`,
+          error: 'Could not retrieve the audio file',
           transcript: '',
         };
       }
@@ -356,13 +364,23 @@ ${metadataContext ? `\nKNOWN METADATA:\n${metadataContext}` : ''}`,
     }
   }
 
-  // No strategy succeeded
+  // No strategy succeeded.
+  //
+  // Which provider keys this deployment holds is server configuration, not
+  // caller-facing detail: branching the client message on `hasKeys` told any
+  // caller whether OPENAI_API_KEY/GEMINI_API_KEY were set, and named the
+  // variables and the hosting platform. Both outcomes now report the same
+  // string; the distinction survives in the operator log, which is the only
+  // place it was ever actionable.
   const hasKeys = !!(process.env.OPENAI_API_KEY || hasGeminiKey());
+  console.error(
+    hasKeys
+      ? '[transcription] all strategies failed with provider keys configured'
+      : '[transcription] all strategies failed: no OPENAI_API_KEY or GEMINI_API_KEY configured',
+  );
   return {
     success: false,
-    error: hasKeys
-      ? 'Could not transcribe video — all strategies failed'
-      : 'No AI API key configured. Set OPENAI_API_KEY or GEMINI_API_KEY in Vercel environment variables.',
+    error: 'Could not transcribe video — all strategies failed',
     transcript: '',
   };
 }

--- a/apps/web/src/lib/transcription-service.ts
+++ b/apps/web/src/lib/transcription-service.ts
@@ -273,9 +273,18 @@ ${metadataContext ? `\nKNOWN METADATA:\n${metadataContext}` : ''}`,
       try {
         await assertPublicHttpUrl(audioUrl);
       } catch (guardErr) {
+        // The guard throws five distinguishable messages — `Invalid URL`,
+        // `Blocked URL scheme: <protocol>`, `Blocked host`, `Blocked private IP
+        // literal`, and `Host does not resolve to a public address`. Forwarding
+        // them told the caller WHICH rule fired: `Blocked host` confirms a
+        // hostname-blocklist match, while the resolution message confirms only
+        // that DNS gave nothing public. That difference is a policy oracle, and
+        // it sharpens as BLOCKED_HOSTNAMES grows. One fixed message for every
+        // rejection; the real reason goes to the log.
+        console.error('[transcription] audioUrl rejected by SSRF guard:', guardErr);
         return {
           success: false,
-          error: `Rejected audioUrl: ${guardErr instanceof Error ? guardErr.message : 'blocked'}`,
+          error: 'Rejected audioUrl',
           transcript: '',
         };
       }


### PR DESCRIPTION
## Canonical issue

Closes #1441

Filed after `linear-code[bot]` marked this PR ready for review, which armed the full `PR Governance` contract on what had been an intentionally-draft stacked branch. The gate's ask was legitimate and achievable, so #1441 records the defect properly rather than working around the check.

This targets `groupthinking-fix-upstream-error-leakage` rather than `main` — it stacks onto #1381 instead of competing with it. **Merge this into #1381, then merge #1381.**

## Outcome

`/api/transcribe`'s `!result.success` branches no longer return caller-derived or policy-derived information.

#1381 sanitized the thrown and JSON-parse paths, and its docblock argued the remaining branches were safe because "every one of those values is an app-authored literal, a numeric HTTP status, or our own SSRF-guard message, so none is upstream text."

That reasoning is right about *upstream text* and right about most branches — but it scopes the problem to the wrong category. Three values leak something other than upstream text, which is why they survived the first pass:

| Value | Why it leaks |
|---|---|
| `Failed to fetch audio: ${audioResponse.status}` | The status belongs to the **caller-supplied `audioUrl`**. The SSRF guard admits public hosts, so this hands back a cross-origin read (401 vs 403 vs 404 vs 500) that the browser's same-origin policy would otherwise deny. A probe oracle. |
| all-strategies-failed message | Branched on whether provider keys were set, disclosing server configuration and naming both the env vars and the hosting platform. |
| `Rejected audioUrl: ${guardErr.message}` | Named **which SSRF guard rule fired**. `Blocked host` confirms a hostname-blocklist match; `Host does not resolve to a public address` confirms only that DNS returned nothing public. A policy oracle that sharpens as `BLOCKED_HOSTNAMES` grows. *(Found by CodeRabbit on this PR — see "Honest note" below.)* |

All three are fixed **at the source** in `transcription-service.ts` rather than masked at the route, so every current and future caller of `fetchTranscript` inherits the fix. The real status, key state, and guard reason are logged for operators — the only place any of them was actionable.

All seven `error:` values in `transcription-service.ts` are now fixed literals, verified by enumeration rather than assumed: `grep -nE "error:\s*\`"` returns nothing across both service files.

Also drops the residual `details` field from the billing branch, which named this deployment's cloud and model vendors. #1381's description states `details` was removed from this route; this is the one instance that was left.

### Honest note on the docblock

The first revision of this PR replaced #1381's overstated invariant with **another overstated invariant** — it claimed every value was a fixed literal while `transcription-service.ts:278` still forwarded `guardErr.message`. CodeRabbit caught it (P2). Fixed in `e511781`, and the docblock now also carries an explicit *"what this deliberately does NOT claim"* paragraph: the choice among literals still tells a caller whether their host cleared the guard. That residue is inherent to a guard that refuses some inputs and attempts others, is far coarser than naming the rule, and the route is session-gated — accepted, and written down rather than glossed.

## Scope

- **Included:** `apps/web/src/lib/transcription-service.ts` (3 error values), `apps/web/src/app/api/transcribe/route.ts` (docblock + `details`), and `apps/web/src/lib/__tests__/transcription-error-disclosure.test.ts` (new, 4 tests).
- **Explicitly excluded:** `ssrf-guard.ts` itself. This fixes the **call-site boundary**; #1428 fixes the same class at the **guard level** with `SsrfGuardError` (public `message` + private `reason`), which is the better long-term shape. The two are complementary and touch no common file. ⚠️ #1381 and #1428 *do* conflict on `ssrf-guard.ts` — see the note at the bottom.
- **Explicitly excluded:** the `billing-chat-gating` timeout (pre-existing, #1116, addressed by #1230) and the static-literal branches, which are genuinely fine as #1381 argued.
- **Explicitly excluded:** the `auto-label.yml` `synchronized` → `synchronize` typo found while working here. It belongs on a branch off `main`; committing it here would land a CI fix inside #1381. Written up in the thread below.

## Risk

- **Risk level:** low
- **Failure mode:** the client-facing string changes on four failure branches. Callers branch on `code`, which is unchanged; no `code`, status, or success-path semantic is touched.
- **Rollback:** `git revert`. No migration, config, or schema change.

## Verification

Head `e511781`, base `e9bf62d4`. Measured in `apps/web`, not inferred.

- [x] **Focused tests** — 4 tests, each failing against the unfixed service and passing with it. Two assert on the *count* of distinct messages, so a partial fix cannot pass them:

  ```
  # against the unfixed service
  × does not echo the status of a caller-supplied audioUrl
    AssertionError: expected 'Failed to fetch audio: 403' to be 'Could not retrieve the audio file'
  × reports the same status-free message whatever the upstream status is
    AssertionError: expected 4 to be 1
  × does not reveal which SSRF guard rule rejected the audioUrl
    AssertionError: expected 5 to be 1
  × does not disclose whether provider API keys are configured
    AssertionError: expected 'No AI API key configured. Set OPENAI_…' to be 'Could not transcribe video — all stra…'

  # with the fix
  Tests  4 passed (4)
  ```

  The guard test drives all five real messages `assertPublicHttpUrl` throws — `Invalid URL`, `Blocked URL scheme: <protocol>`, `Blocked host`, `Blocked private IP literal`, `Host does not resolve to a public address` — and asserts one distinct caller-visible error.

- [x] **Full suite** — `npx vitest run`: **1 failed | 291 passed (292)**. The single failure is `billing-chat-gating.test.ts` "blocks free tier after daily quota" (5000 ms timeout), **pre-existing and unrelated** — confirmed failing identically on the untouched `e9bf62d4` with this change stashed. Tracked in #1116.
- [x] `npm run type-check` — clean, exit 0.
- [x] `npm run lint` — clean, exit 0.
- [x] `package-lock.json` drift from `npm install` reverted, per #1381's own convention.
- [x] **Required checks on `e511781`** — `PR Governance` ✅, `Canonical issue and evidence` ✅, `gitleaks (working tree)` ✅, `validate` ✅.
- [x] **Review threads** — Vercel VADE's fixture-ID finding fixed in `8d756b6` (marked `ISSUE_RESOLVED`). CodeRabbit's P2 fixed in `e511781`. CodeRabbit auto-review is skipped on this PR by `.coderabbit.yaml` (`drafts: false`, `base_branches: [main]`), so its reviews here are manually triggered.

## Production evidence

Vercel preview builds green on this branch. This diff is under `apps/web/**`, so `MERGE_POLICY.md` gate 4 applies and the preview is the relevant artifact. No runtime behavior is observable from the preview itself — the changed paths are error branches reachable only with provider credentials configured and a caller-supplied `audioUrl` — so the regression tests above carry the real evidence.

## Agent handoff

- [x] One canonical issue is linked — #1441
- [x] No competing PR implements the same issue — #1428 is complementary (guard level vs call site), no shared file
- [x] Acceptance criteria satisfied — all five on #1441
- [x] Up to date with its base, merges cleanly
- [x] Required checks pass on the current head — the red `branch-cleanup.yml` is a **push**-event workflow, not a PR check: it fails identically on every branch in the repo because of an invalid `workflows: write` permission scope, and #1420 fixes it. It does not gate this PR.
- [x] Human decision requested only for: merge approval

## Agent provenance

Agent-authored, under the PR remediation runbook. Found by verifying #1381's outstanding CodeRabbit review rather than trusting its status.

---

### ⚠️ Unrelated merge hazard found while verifying this

**#1381 and #1428 both rewrite `apps/web/src/lib/ssrf-guard.ts`** to close the same CWE-209 DNS oracle, and neither references the other:

- **#1381** (ready, green) unifies the *resolution* branches into one `NOT_PUBLIC` message and deliberately keeps the IP-literal branch distinct, with a documented rationale.
- **#1428** (draft) is strictly broader — it adds an `SsrfGuardError` carrying a public `message` plus a private `reason`, and unifies **every** branch including scheme, blocked host, and IP literal.

They will conflict. #1428's approach is the more complete of the two, so the cheaper order is probably to land #1381 (with this PR merged into it) and then rebase #1428 onto it, keeping #1428's `SsrfGuardError` — rather than the reverse. Flagging rather than acting: which design wins is a call for a human.