### PR TITLE
fix(ci): repair auto-label's dead trigger and truncated file list

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,7 +1,9 @@
 name: Auto Label
 on:
   pull_request:
-    types: [opened, reopened, synchronized]
+    # `synchronize` is the GitHub activity type for "new commits pushed to the PR".
+    # It is NOT `synchronized` — unknown types are silently ignored, not rejected.
+    types: [opened, reopened, synchronize]
   issues:
     types: [opened, edited]
 permissions:
@@ -18,10 +20,13 @@ jobs:
 
             // --- Label pull requests by changed file paths ---
             if (context.eventName === 'pull_request') {
-              const { data: files } = await github.rest.pulls.listFiles({
+              // Paginate: listFiles returns only the first 30 files by default, so a
+              // large PR would otherwise be labelled from an arbitrary prefix of its diff.
+              const files = await github.paginate(github.rest.pulls.listFiles, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number
+                pull_number: context.payload.pull_request.number,
+                per_page: 100
               });
 
               for (const file of files) {

--- a/tests/unit/test_auto_label_workflow.py
+++ b/tests/unit/test_auto_label_workflow.py
@@ -1,0 +1,127 @@
+"""Regression tests for the Auto Label workflow.
+
+Both defects these cover were silent: an unknown `pull_request` activity type is
+ignored rather than rejected, and an unpaginated `listFiles` still concludes
+green on a truncated diff. Neither produced a red check, so static assertions
+alone would not have caught them — the pagination test below executes the
+workflow's own embedded script and fails against the previous implementation.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/auto-label.yml"
+
+
+def _load_workflow() -> dict:
+    assert WORKFLOW_PATH.exists(), "Auto Label workflow should exist"
+    return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+
+def _get_script(workflow: dict) -> str:
+    return workflow["jobs"]["label"]["steps"][0]["with"]["script"]
+
+
+def test_auto_label_workflow_file_is_valid_yaml() -> None:
+    workflow = _load_workflow()
+    assert workflow["name"] == "Auto Label"
+
+
+def test_auto_label_triggers_on_synchronize_not_synchronized() -> None:
+    """`synchronized` is not a GitHub activity type; the real one is `synchronize`.
+
+    GitHub ignores unknown activity types instead of rejecting the workflow, so
+    the typo silently stopped the workflow from ever running on a push to an
+    open PR.
+    """
+    workflow = _load_workflow()
+    # PyYAML parses the YAML 'on' key as Python True.
+    types = workflow[True]["pull_request"]["types"]
+    assert "synchronize" in types
+    assert "synchronized" not in types
+    assert "opened" in types
+    assert "reopened" in types
+
+
+def test_auto_label_paginates_changed_files() -> None:
+    """`pulls.listFiles` defaults to 30 per page; a larger PR must not truncate."""
+    script = _get_script(_load_workflow())
+    assert "github.paginate" in script
+    assert "per_page: 100" in script
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
+def test_auto_label_labels_files_beyond_the_first_page(tmp_path: Path) -> None:
+    """Execute the workflow's embedded script over a 120-file diff.
+
+    The 120th file is the only `.py` in the diff, so the `python` label can only
+    appear if the listing paginated past the first page. The mocked client
+    raises if the unpaginated `pulls.listFiles` is called at all, which is what
+    makes this fail against the previous implementation rather than pass
+    vacuously.
+    """
+    script = _get_script(_load_workflow())
+    script_path = tmp_path / "auto_label.js"
+    script_path.write_text(script)
+
+    harness = tmp_path / "harness.mjs"
+    harness.write_text(textwrap.dedent("""
+            import fs from 'fs';
+            const script = fs.readFileSync(process.argv[2], 'utf8');
+
+            const files = [];
+            for (let i = 0; i < 119; i++) files.push({ filename: `apps/web/src/x${i}.ts` });
+            files.push({ filename: 'src/late.py' });  // only reachable via pagination
+
+            let added = null;
+            const github = {
+              paginate: async (_fn, opts) => {
+                if (opts.per_page !== 100) throw new Error('per_page not set to 100');
+                return files;
+              },
+              rest: {
+                pulls: {
+                  listFiles: async () => {
+                    throw new Error('unpaginated listFiles called');
+                  },
+                },
+                issues: { addLabels: async (o) => { added = o.labels; } },
+              },
+            };
+            const context = {
+              eventName: 'pull_request',
+              repo: { owner: 'o', repo: 'r' },
+              payload: { pull_request: { number: 1 } },
+            };
+            const core = { warning: () => {} };
+
+            await new Function(
+              'github', 'context', 'core',
+              `return (async () => { ${script} })()`
+            )(github, context, core);
+
+            process.stdout.write(JSON.stringify(added ?? []));
+            """).strip())
+
+    result = subprocess.run(
+        ["node", str(harness), str(script_path)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, f"harness failed: {result.stderr}"
+
+    labels = json.loads(result.stdout)
+    assert "python" in labels, (
+        "the 120th changed file was not labelled, so the changed-file listing "
+        "was truncated to the first page"
+    )
+    assert "javascript" in labels


### PR DESCRIPTION
## Canonical issue

Closes #1442

## Outcome

`Auto Label` runs on pushes to an open PR, and labels the whole diff rather than its first 30 files.

Two silent defects in `.github/workflows/auto-label.yml`:

| Defect | Why it was invisible |
|---|---|
| `pull_request.types` listed **`synchronized`** | Not a GitHub activity type — the real one is `synchronize`. GitHub *ignores* unknown activity types instead of rejecting the file, so there was no validation error. The trigger was simply inert, and labels were only ever applied at `opened`/`reopened`. |
| `pulls.listFiles` called without pagination | Defaults to `per_page: 30`. A larger PR was labelled from an arbitrary 30-file prefix of its diff. The job still concluded green. |

The pagination fix follows the convention already established in `.github/workflows/pr-governance.yml` (`github.paginate(github.rest.pulls.list, ...)`); this call site had not adopted it.

## Scope

- **Included:** `.github/workflows/auto-label.yml` — the trigger type, the paginated listing, and a comment on each recording why. Plus `tests/unit/test_auto_label_workflow.py` (new, 4 tests).
- **Explicitly excluded:** the CodeRabbit label gate itself (#1424, fixed by #1425) — a different file and a different mechanism. This PR does not make that gate satisfiable; it restores the labeller the gate depends on.
- **Explicitly excluded:** the label taxonomy and keyword regexes. Unchanged.

## Risk

- **Risk level:** low
- **Failure mode:** more label-application API calls than before — one run per push instead of one per open, over a paginated listing. `addLabels` is already wrapped in `try/catch` with `core.warning`, so a rate-limit or permission error warns rather than fails the job. Labels are additive; nothing is removed.
- **Rollback:** `git revert`. No runtime, deployed, or data surface.

## Verification

Head `2fe3ecb`, base `8cd4a10`. Two files, workflow +9/−3 and a new test module.

`tests/unit/test_auto_label_workflow.py` follows the existing `tests/unit/test_pr_governance_workflow.py` pattern: load the workflow YAML, extract the embedded `github-script` body, and assert against **the script that actually ships** rather than a copy of it.

- [x] **Focused tests** — 4 tests. Static coverage asserts `synchronize` is present and `synchronized` is not, and that the listing paginates with `per_page: 100`. The behavioral test executes the embedded script under `node` against a mocked client with a 120-file diff whose **120th** file is the only `.py`; the mock raises if the unpaginated `pulls.listFiles` is called at all.

- [x] **Non-vacuity checked in both directions**, not asserted:

  ```
  # against the pre-fix workflow from origin/main
  3 failed, 1 passed      # the pass is the YAML-validity check, true either way

  # against the fixed workflow
  4 passed in 0.15s
  ```

- [x] `ruff check` — clean. `black --check` — clean.
- [ ] **Required CI** — not complete on this head.
- [x] **Review threads** — resolved. CodeRabbit requested changes on `f9f9688` for exactly one thing: the verification above existed only locally and was never committed, so nothing in the repo prevented regression. Correct, and fixed in `2fe3ecb`. CodeRabbit re-verified against the commit and reported *"no new correctness, security, or production-impacting issue."*

## Production evidence

Not applicable. One GitHub Actions workflow file and one test module; no runtime or deployed surface, and nothing under `apps/web/**`, so `MERGE_POLICY.md` gate 4 (preview) does not apply.

The honest limit on the evidence above: **the corrected trigger cannot be observed firing from this PR.** GitHub reads `pull_request` triggers from the *base* branch, so `synchronize` only takes effect once this is on `main`. The post-merge check is to push a commit to any open PR and confirm an `Auto Label` run appears for the `synchronize` event.

## On the #1424 link — what this PR does and does not evidence

An earlier comment claimed #1443 was a clean reproduction of the #1424 label-gate deadlock. **That claim is withdrawn, and the reason it was withdrawn has since changed. Both states are recorded here rather than quietly overwritten.**

- **When first withdrawn:** this PR was a draft, and `.coderabbit.yaml` sets `auto_review.drafts: false`, which is sufficient on its own to explain a skip. Two sufficient causes, so the skip notice naming label configuration was suggestive but not decisive.
- **Now:** `linear-code[bot]` marked this PR ready for review, so it is no longer a draft, and it carries `python` and `ci/cd` — both in the required-labels list. The `CodeRabbit` status at `19:30:29Z` still reads `Review skipped: excluded by label configuration`.
- **Still not decisive.** The ready-for-review transition lands at roughly `19:30:36Z`, *after* that skip was written. The skip was therefore probably still evaluated against a draft. The ordering is too tight to call, so this PR remains confounded and should not be cited as proof.

**#1440 is the unconfounded case** and is what #1424/#1425 should be argued from: not a draft when its status was written, carries `javascript` and `tests` (both in the required list), and still shows `Review skipped: excluded by label configuration`.

What holds without qualification, and is the part that actually affects merge decisions: **a green `CodeRabbit` commit status does not distinguish "reviewed" from "skipped" or "rate limited."** This PR alone has produced skip statuses reading `success` for three different reasons — label configuration, draft exclusion, and `path_filters` (`tests/**`) — every one of them green.

## Agent handoff

- [x] One canonical issue is linked — #1442
- [x] No competing PR implements the same issue — no other open PR touches `auto-label.yml`
- [x] Acceptance criteria are satisfied — all four on #1442, including the non-vacuous behavioral test
- [ ] Required checks pass on the current head — CI not complete on `2fe3ecb`; `mergeable_state` is `unstable`
- [x] Human decision is requested only for: merge approval

## Agent provenance

Agent-authored, under the PR remediation runbook. Found while verifying #1440, whose notes flagged this typo as out of scope for a stacked branch and deferred it to a branch off `main` — which is what this is.