### PR TITLE
chore(web): rename apps/web package to eventrelay-web (F8a)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "building-production-ai-infrastructure-platform",
+  "name": "eventrelay-web",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/docs/F8_WEB_OWNERSHIP.md
+++ b/docs/F8_WEB_OWNERSHIP.md
@@ -21,5 +21,5 @@ Root `vercel.json` already permanent-redirects `v0-uvai.vercel.app` and `event-r
 
 ## Optional hygiene (not blocking)
 
-- Rename `apps/web` package from `building-production-ai-infrastructure-platform` to a clearer name.
+- ~~Rename `apps/web` package~~ **done (F8a):** `eventrelay-web` (was `building-production-ai-infrastructure-platform`).
 - Point `groupthinking/uvai.io` README at EventRelay if that remote is retained for history.

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       }
     },
     "apps/web": {
-      "name": "building-production-ai-infrastructure-platform",
+      "name": "eventrelay-web",
       "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/gateway": "^4.0.36",
@@ -6802,7 +6802,7 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/building-production-ai-infrastructure-platform": {
+    "node_modules/eventrelay-web": {
       "resolved": "apps/web",
       "link": true
     },


### PR DESCRIPTION
## Canonical issue

Closes #1450

## Outcome

The Next.js workspace package is named **`eventrelay-web`**, matching the EventRelay monorepo instead of the leftover boilerplate name `building-production-ai-infrastructure-platform`.

## Scope

- Included: `apps/web/package.json`, root `package-lock.json`, `docs/F8_WEB_OWNERSHIP.md`
- Explicitly excluded: runtime behavior, turbo pipeline renames beyond package name, F11 Payload CMS

## Risk

- Risk level: low
- Failure mode: package name only (`private: true`); no publish surface
- Rollback: revert this PR

## Verification

Head `8090463ecc928fdcb60d7d573e0c1192355bb2cc`.

- [x] Vitest studio-deploy + action-surface (7 pass)
- [x] Live uvicorn `/health` → 200 with `auth_mode=open_dev`, `video_path_ready=true`
- [x] Live `/api/v1/health` → 200 under `ALLOW_UNAUTHENTICATED=1`
- [ ] Required CI green on current head
- [ ] Review threads resolved

## Production evidence

Local backend smoke on this machine (not a production deploy). Package rename has no production URL impact (`private: true`).

## Agent handoff

- [x] One canonical issue is linked
- [x] No competing PR implements the same issue
- [x] Acceptance criteria satisfied
- [ ] Required checks pass on the current head
- [x] Human decision only for product/security/production approval

## Agent provenance

Human-authored (Grok Build on Dev canonical tree).
