### PR TITLE
fix(logging): keep the record when JSON serialization raises

### DIFF
--- a/src/youtube_extension/backend/config/logging_config.py
+++ b/src/youtube_extension/backend/config/logging_config.py
@@ -156,10 +156,31 @@ class StructuredFormatter(logging.Formatter):
             if hasattr(record, attribute):
                 payload[attribute] = getattr(record, attribute)
 
-        # `default=str` keeps a non-serializable `extra` value from raising
-        # inside the logging path, where an exception would be swallowed and
-        # the record lost entirely.
-        return json.dumps(payload, ensure_ascii=True, default=str)
+        # `default=str` handles values `json` cannot natively encode, but it is
+        # not sufficient on its own and must not be described as if it were:
+        # a circular container is rejected structurally *before* `default` is
+        # consulted, and a value whose `__str__` raises propagates out of
+        # `default` itself. Either escapes `json.dumps`, and `logging` then
+        # swallows it via `Handler.handleError` and drops the record entirely.
+        #
+        # The fallback keeps the record instead. Only natively-serializable
+        # scalars are retained, which is every field above except the optional
+        # `performance_ms` / `correlation_id` enrichments -- the two the call
+        # site controls, and so the only ones that can carry the poison.
+        try:
+            return json.dumps(payload, ensure_ascii=True, default=str)
+        except Exception as exc:  # noqa: BLE001 - never lose a record
+            try:
+                detail = f"{type(exc).__name__}: {exc}"
+            except Exception:  # noqa: BLE001 - its `__str__` raises too
+                detail = type(exc).__name__
+            safe = {
+                key: value
+                for key, value in payload.items()
+                if isinstance(value, (str, int, float, bool, type(None)))
+            }
+            safe["serialization_error"] = detail
+            return json.dumps(safe, ensure_ascii=True)
 
     def formatException(self, ei) -> str:
         """Format exception with enhanced stack trace"""

--- a/src/youtube_extension/backend/config/logging_config.py
+++ b/src/youtube_extension/backend/config/logging_config.py
@@ -167,6 +167,15 @@ class StructuredFormatter(logging.Formatter):
         # scalars are retained, which is every field above except the optional
         # `performance_ms` / `correlation_id` enrichments -- the two the call
         # site controls, and so the only ones that can carry the poison.
+        #
+        # `type(value) in ...`, not `isinstance`: `isinstance` consults
+        # `value.__class__`, which an object can forge as a property returning
+        # `str`. Such a value passes the filter, reaches a `json.dumps` with no
+        # `default` to fall back on, and raises `TypeError` -- losing the record
+        # the fallback exists to save. Exact runtime types cannot be forged, so
+        # this enforces the invariant the comment claims rather than asserting
+        # it. Adding `default=str` here instead would reinstate the raising
+        # `__str__` hole; nothing may reach `default` on this path.
         try:
             return json.dumps(payload, ensure_ascii=True, default=str)
         except Exception as exc:  # noqa: BLE001 - never lose a record
@@ -177,7 +186,7 @@ class StructuredFormatter(logging.Formatter):
             safe = {
                 key: value
                 for key, value in payload.items()
-                if isinstance(value, (str, int, float, bool, type(None)))
+                if type(value) in {str, int, float, bool, type(None)}
             }
             safe["serialization_error"] = detail
             return json.dumps(safe, ensure_ascii=True)

--- a/tests/unit/test_logging_config_crlf.py
+++ b/tests/unit/test_logging_config_crlf.py
@@ -360,6 +360,40 @@ def test_unserializable_enrichment_does_not_cost_the_record(poison, expected_err
     assert parsed["serialization_error"].startswith(expected_error)
 
 
+class _ForgedClassStr:
+    """An `extra` value that lies about its type *and* raises from `__str__`.
+
+    `isinstance(x, str)` consults `x.__class__`, so this passes a scalar filter
+    written with `isinstance`. `json.dumps` uses the real runtime type, so the
+    fallback's own dump then raises `TypeError` with no `default` to catch it --
+    losing the record the fallback exists to save.
+    """
+
+    @property
+    def __class__(self):  # type: ignore[override]
+        return str
+
+    def __str__(self) -> str:
+        raise RuntimeError("str() exploded")
+
+
+def test_fallback_filter_is_not_fooled_by_a_forged_class():
+    # Pins `type(value) in {...}` over `isinstance(...)`. With the isinstance
+    # form this value is retained, the fallback's `json.dumps` raises TypeError,
+    # and the record is dropped -- the exact failure the fallback prevents.
+    logger, buf = _make_json_logger("json-forged-class")
+    logger.info("survives a liar", extra={"request_id": _ForgedClassStr()})
+
+    rendered = buf.getvalue()
+    assert rendered.strip(), "the record was dropped entirely"
+    parsed = json.loads(rendered)
+
+    assert parsed["level"] == "INFO"
+    assert parsed["message"] == "survives a liar"
+    assert "correlation_id" not in parsed
+    assert parsed["serialization_error"].startswith("RuntimeError")
+
+
 def test_a_poisoned_record_does_not_break_the_stream():
     # The blast radius that matters: `handleError` drops only the offending
     # record, so a regression here is invisible unless you count what arrives.

--- a/tests/unit/test_logging_config_crlf.py
+++ b/tests/unit/test_logging_config_crlf.py
@@ -309,6 +309,88 @@ def test_line_oriented_path_is_untouched_by_the_json_fix():
     assert buf.getvalue() == "INFO - all good video-123\n"
 
 
+class _ExplodingStr:
+    """An `extra` value whose `__str__` raises.
+
+    `json.dumps(default=str)` *does* consult `default` for this type, and the
+    exception then propagates out of `default` itself.
+    """
+
+    def __str__(self) -> str:
+        raise RuntimeError("str() exploded")
+
+
+def _circular_container() -> dict:
+    """A container `json.dumps` rejects structurally.
+
+    The cycle is detected *before* `default` is consulted, so `default=str`
+    never sees it. This is the case a narrow `except (TypeError, ...)` around
+    the dump would appear to cover and does not.
+    """
+    circular: dict = {}
+    circular["self"] = circular
+    return circular
+
+
+@pytest.mark.parametrize(
+    "poison, expected_error",
+    [
+        (_circular_container(), "ValueError"),
+        (_ExplodingStr(), "RuntimeError"),
+    ],
+    ids=["circular-container", "exploding-str"],
+)
+def test_unserializable_enrichment_does_not_cost_the_record(poison, expected_error):
+    # #1452: `default=str` alone loses the record for both of these. `logging`
+    # swallows the raise via `Handler.handleError`, so the failure is silent --
+    # the record simply never reaches the sink.
+    logger, buf = _make_json_logger(f"json-unserializable-{expected_error}")
+    logger.info("still emitted", extra={"request_id": poison})
+
+    rendered = buf.getvalue()
+    assert rendered.strip(), "the record was dropped entirely"
+    parsed = json.loads(rendered)
+
+    # The record survives with its authoritative metadata intact...
+    assert parsed["level"] == "INFO"
+    assert parsed["message"] == "still emitted"
+    # ...the poisoned enrichment is dropped rather than taking the record with
+    # it, and the reason is recorded rather than silently swallowed.
+    assert "correlation_id" not in parsed
+    assert parsed["serialization_error"].startswith(expected_error)
+
+
+def test_a_poisoned_record_does_not_break_the_stream():
+    # The blast radius that matters: `handleError` drops only the offending
+    # record, so a regression here is invisible unless you count what arrives.
+    logger, buf = _make_json_logger("json-unserializable-stream")
+    logger.info("before")
+    logger.info("poisoned", extra={"request_id": _ExplodingStr()})
+    logger.info("after")
+
+    messages = [
+        json.loads(line)["message"]
+        for line in buf.getvalue().splitlines()
+        if line.strip()
+    ]
+    assert messages == ["before", "poisoned", "after"]
+
+
+def test_fallback_record_still_holds_the_cwe_117_property():
+    # The fallback must not become a hole in #1429: it re-serializes with
+    # `json.dumps`, so the forgery payload stays a value on this path too.
+    logger, buf = _make_json_logger("json-unserializable-forgery")
+    logger.info(_FORGERY, extra={"request_id": _ExplodingStr()})
+
+    rendered = buf.getvalue()
+    assert len(rendered.splitlines()) == 1, "fallback split the record"
+    parsed = json.loads(rendered)
+
+    assert parsed["level"] == "INFO"
+    assert "forged" not in parsed
+    assert parsed["message"] == _FORGERY
+
+
 @pytest.fixture
 def _restore_root_logging():
     """`setup_logging` calls dictConfig, which mutates global logging state."""


### PR DESCRIPTION
## Canonical issue

Closes #1452

Follow-up to #1439, landed as that issue specified: `_format_json` did not exist on `main` until #1439 merged at 20:48 UTC, so this could not be written earlier without reading as a competing implementation of #1429. It is branched from `main` **after** that merge and carries none of #1439's diff.

## Outcome

A log record is no longer lost when `json.dumps` raises inside the logging path.

`_format_json` claimed `default=str` meant *"a record is never lost to a serialization error"*. It does not. `default` is consulted only for values `json` cannot natively encode, and it is called unguarded, so two inputs still escape:

- **a circular container** is rejected structurally *before* `default` is consulted — `default=str` never sees it;
- **a value whose `__str__` raises** propagates out of `default` itself.

Either way `logging` swallows the raise via `Handler.handleError` and drops the record silently.

Reproduced against `main` (`f96601b`) before changing anything — three `logger.info` calls through a real `StreamHandler`, the middle one poisoned:

```
--- circular:      records reaching sink = 2 of 3
     healthy one
     after poison
--- exploding_str: records reaching sink = 2 of 3
     healthy one
     after poison
```

After this change, **3 of 3** in both cases.

## Scope

- **Included:**
  - `logging_config.py` — guarded `json.dumps` fallback in `_format_json`, and the comment that promised more than the code delivered.
  - `tests/unit/test_logging_config_crlf.py` — +4 tests in the existing CWE-117 file.
- **Explicitly excluded:**
  - **The CWE-117 field-forgery fix itself.** #1429/#1439 is sound and unaffected; the fallback re-serializes with `json.dumps`, so that property holds on this path too — asserted by a test rather than assumed.
  - **The line-oriented path.** Untouched. `json_output` still defaults to `False` and that branch still applies `sanitize_log_record`.
  - **The `JSON_LOGGING` default mismatch** between `production_config.py:72` (`"true"`) and `logging_config.py` (`"false"`). Still a separate behavioural config decision, as #1429 recorded.

## Risk

- **Risk level:** low
- **Failure mode:** the fallback is on the `except` path, so it cannot alter any record that serializes today — the happy path is the same `json.dumps` call it always was. The realistic risk is the fallback itself raising; it retains only natively-serializable scalars and guards the error-detail string, so it has no unserializable input left to choke on.
- **Rollback:** `git revert`. No migration, config, or schema change. The emitted field set is unchanged except for `serialization_error`, which appears only on records that would previously have been dropped entirely.

Reachable through `extra={"request_id": ...}`, which `format()` copies to `correlation_id` and the enrichment loop pulls into the payload. **Not a regression** — the pre-#1439 `json_format` template never referenced `correlation_id`, so this input was unreachable on the JSON path before it. **Not reachable from request content** — headers arrive as strings, and strings serialize correctly. A self-referential container or an exploding `__str__` would have to be introduced by a future call site.

## Verification

Head `e2393fe`. Measured, not inferred.

- [x] **Focused tests** — `tests/unit/test_logging_config_crlf.py`: **24 passed**.

- [x] **Non-vacuous.** Against `main`'s `_format_json`, all four new tests fail:

  ```
  FAILED test_unserializable_enrichment_does_not_cost_the_record[circular-container]
  FAILED test_unserializable_enrichment_does_not_cost_the_record[exploding-str]
  FAILED test_a_poisoned_record_does_not_break_the_stream
  FAILED test_fallback_record_still_holds_the_cwe_117_property
  4 failed, 20 passed
  ```

  The 20 pre-existing tests pass either way, so the line-oriented contract and the #1429 fix are demonstrably untouched.

- [x] **`except Exception` is required, not stylistic.** The narrower `(TypeError, ValueError, RecursionError)` looks more correct and misses the exploding-`__str__` case outright — verified directly: `narrow tuple MISSED -> RuntimeError`. Recorded because the wrong version is the more attractive one.

- [x] **Lint** — `ruff check src/youtube_extension/backend/ src/youtube_extension/main.py --ignore E402,F811,F401,F821,B904,B020,E701,E722`, run exactly as CI does: **`Found 2 errors` before and after**, byte-identical, both pre-existing. Clean on both changed files individually.

- [ ] **Required CI** — will populate on this head.
- [x] **Review threads resolved** — none open yet.

## Production evidence

Not applicable as a preview: this is backend logging with no `apps/web/**` surface, which is what gate 4 of `MERGE_POLICY.md` scopes previews to.

The runtime evidence that matters is the reproduction above, run against the real formatter through a real handler in both directions — 2 of 3 records on `main`, 3 of 3 on this head. Exposure is bounded rather than theoretical: `production_config.py:72` defaults `JSON_LOGGING` to `"true"`, so the JSON path is the production path, but no current call site passes a non-scalar.

## Agent handoff

- [x] One canonical issue is linked — #1452
- [x] No competing PR implements the same issue — #1452 is newly filed and unclaimed; this branch is cut from `main` after #1439 merged and carries none of its diff
- [x] Acceptance criteria are satisfied — all four on #1452: circular container emitted with `level` authoritative; exploding `__str__` emitted with `level` authoritative; regression tests in the shape of the existing ones that fail on the pre-fix implementation; the comment now states the guarantee the code actually provides
- [ ] Required checks pass on the current head — pending first run
- [x] Human decision is requested only for: merge approval

## Agent provenance

Agent-authored under the PR remediation runbook. The finding was not mine — it was derived independently by three red-team passes on #1439 (comments [5221126104](https://github.com/groupthinking/EventRelay/pull/1439#issuecomment-5221126104), [5221344113](https://github.com/groupthinking/EventRelay/pull/1439#issuecomment-5221344113), [5221378002](https://github.com/groupthinking/EventRelay/pull/1439#issuecomment-5221378002)), each of which correctly declined to push it mid-review, and was then filed as #1452 so the fourth pass would read it instead of re-deriving it a fourth time. This is that fourth pass reading it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpTcrsgVsqbGV8dmPZadoe)_