### PR TITLE
fix(ci): make the Dependabot auto-merge job able to merge, and gate it on real CI

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,6 +15,9 @@ permissions:
   contents: write
   pull-requests: write
   statuses: read
+  # Every gate in MERGE_POLICY.md is a check run, not a commit status, so the
+  # merge job has to read the checks API to see whether CI actually passed.
+  checks: read
 
 jobs:
   approve:
@@ -116,30 +119,100 @@ jobs:
                 continue;
               }
 
-              const metadata = await github.request(
-                'GET /repos/{owner}/{repo}/pulls/{pull_number}',
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pullRequest.number,
-                  mediaType: { previews: ['dorian'] },
-                }
+              // Dependabot records what it did in an `updated-dependencies`
+              // block in its own commit message; that block is the only
+              // first-party source for the update type available here. The
+              // pull request REST resource has no `dependency`/`update_type`
+              // field, and no media-type preview adds one, so reading it from
+              // there always yielded undefined and this job skipped every PR
+              // it was ever handed.
+              const commits = await github.paginate(github.rest.pulls.listCommits, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pullRequest.number,
+                per_page: 100,
+              });
+
+              const dependabotCommit = commits.find((commit) =>
+                /^\s*-\s*dependency-name:/m.test(commit.commit.message)
               );
 
-              const updateType =
-                metadata.data?.dependency?.update_type ??
-                metadata.data?.update_type ??
-                metadata.data?.dependency_update_type;
-
-              if (!updateType) {
+              if (!dependabotCommit) {
                 core.info(
-                  `Could not determine update type for PR #${pullRequest.number}; skipping.`
+                  `No Dependabot metadata block on PR #${pullRequest.number}; skipping.`
                 );
                 continue;
               }
 
-              if (updateType.includes('semver-major')) {
+              const message = dependabotCommit.commit.message;
+              const explicitUpdateType = message.match(/^\s*update-type:\s*(\S+)/m);
+
+              let isMajor;
+              if (explicitUpdateType) {
+                isMajor = explicitUpdateType[1].includes('semver-major');
+              } else {
+                // Dependabot omits `update-type` for some indirect bumps (e.g.
+                // #1433). Fall back to the major components in the title, but
+                // only when the block names exactly one dependency — a grouped
+                // update must never be classified from a single title.
+                const names = message.match(/^\s*-\s*dependency-name:/gm) ?? [];
+                const bump = pullRequest.title.match(
+                  /\bfrom\s+v?(\d+)\.\S*\s+to\s+v?(\d+)\./i
+                );
+
+                if (names.length !== 1 || !bump) {
+                  core.info(
+                    `Could not determine update type for PR #${pullRequest.number}; skipping.`
+                  );
+                  continue;
+                }
+
+                isMajor = bump[1] !== bump[2];
+              }
+
+              if (isMajor) {
                 core.info(`Skipping major update PR #${pullRequest.number}.`);
+                continue;
+              }
+
+              // Commit statuses alone are not evidence that CI passed: on this
+              // repo the only statuses are Vercel's and CodeRabbit's, so the
+              // combined state reads `success` while `build`, `test` and
+              // `lint-*` are still queued. Every check named in MERGE_POLICY.md
+              // gate 2 is a check run, so read those instead.
+              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: pullRequest.head.sha,
+                per_page: 100,
+              });
+
+              // This workflow's own jobs are still in flight while this step
+              // runs; counting them would deadlock the gate against itself.
+              const ownJobNames = new Set(['approve', 'merge']);
+              // `skipped`/`neutral` are how GitHub reports the conditionally
+              // required jobs of gate 2 (E2E, coverage on a docs-only diff).
+              // Gate 2 treats those as satisfied, not as blocking.
+              const passingConclusions = new Set(['success', 'skipped', 'neutral']);
+              const relevant = checkRuns.filter((run) => !ownJobNames.has(run.name));
+
+              const pending = relevant.filter((run) => run.status !== 'completed');
+              if (pending.length > 0) {
+                core.info(
+                  `Skipping PR #${pullRequest.number}; ${pending.length} check(s) still running: ` +
+                    `${pending.map((run) => run.name).join(', ')}.`
+                );
+                continue;
+              }
+
+              const failed = relevant.filter(
+                (run) => !passingConclusions.has(run.conclusion)
+              );
+              if (failed.length > 0) {
+                core.info(
+                  `Skipping PR #${pullRequest.number}; failing check(s): ` +
+                    `${failed.map((run) => `${run.name} (${run.conclusion})`).join(', ')}.`
+                );
                 continue;
               }
 
@@ -149,7 +222,9 @@ jobs:
                 ref: pullRequest.head.sha,
               });
 
-              if (combined.state !== 'success') {
+              // `pending` with zero statuses just means nothing posts statuses
+              // on this ref, which is not a failure.
+              if (combined.total_count > 0 && combined.state !== 'success') {
                 core.info(
                   `Skipping PR #${pullRequest.number} because combined status is ${combined.state}.`
                 );

--- a/tests/unit/test_dependabot_automation_workflow.py
+++ b/tests/unit/test_dependabot_automation_workflow.py
@@ -35,6 +35,9 @@ def test_dependabot_workflow_uses_safe_triggers_and_permissions() -> None:
         "contents": "write",
         "pull-requests": "write",
         "statuses": "read",
+        # Without `checks: read` the merge job's checks.listForRef call 403s and
+        # the readiness gate below can never be evaluated.
+        "checks": "read",
     }
     # The auto-merge feature flag is controlled by a repository variable
     # (vars context), which — unlike env — is available in job-level `if`
@@ -93,6 +96,59 @@ def test_dependabot_workflow_approves_and_merges_without_checkout() -> None:
         and "semver-major" in step.get("with", {}).get("script", "")
         for step in merge_steps
     )
+
+
+def _merge_script() -> str:
+    merge_steps = _load_workflow()["jobs"]["merge"]["steps"]
+    scripts = [step.get("with", {}).get("script", "") for step in merge_steps]
+    script = "\n".join(scripts)
+    assert script.strip(), "Merge job should run a github-script step"
+    return script
+
+
+def test_merge_job_does_not_read_update_type_from_the_pull_request_resource() -> None:
+    """The pull request REST resource carries no dependency metadata.
+
+    `GET /repos/{owner}/{repo}/pulls/{pull_number}` returns no `dependency`,
+    `update_type` or `dependency_update_type` field, and there is no `dorian`
+    preview that adds one. Reading the update type from there yielded
+    `undefined` on every pull request, so the job hit its
+    "Could not determine update type" branch and skipped unconditionally —
+    it could never merge anything.
+    """
+    script = _merge_script()
+
+    assert "dorian" not in script
+    assert "mediaType" not in script
+    assert "previews" not in script
+    assert "dependency?.update_type" not in script
+    assert "dependency_update_type" not in script
+    # The update type must come from Dependabot's own commit-message block.
+    assert "listCommits" in script
+    assert "update-type" in script
+
+
+def test_merge_job_gates_on_check_runs_not_only_commit_statuses() -> None:
+    """Commit statuses are not evidence that CI passed on this repo.
+
+    Every check in MERGE_POLICY.md gate 2 (`build`, `test`, `lint-python`,
+    `CodeQL`, …) is a check run. The only *statuses* are Vercel's and
+    CodeRabbit's, so `getCombinedStatusForRef` reports `success` while CI is
+    still queued — observed live on #1433, whose combined status was green at
+    20:48 UTC while `build`/`test`/`lint-*` were queued. Gating on the combined
+    status alone would merge a Dependabot PR with unfinished or failing CI.
+    """
+    script = _merge_script()
+
+    assert "checks.listForRef" in script, (
+        "Merge readiness must consult the checks API, not just commit statuses"
+    )
+    # Unfinished checks must block, not be read as passing.
+    assert "status !== 'completed'" in script
+    # This workflow's own jobs are in flight while the gate runs; counting them
+    # would deadlock the check against itself.
+    assert "ownJobNames" in script
+    assert "'approve'" in script and "'merge'" in script
 
 
 def test_dependabot_ignores_eslint_v10() -> None:


### PR DESCRIPTION
## Canonical issue

Closes #1476

## Outcome

The `merge` job in `.github/workflows/dependabot-auto-merge.yml` can now actually merge a Dependabot PR, and it will only do so when CI has genuinely passed.

Two independent defects, found while driving the open-PR backlog:

**It could never merge anything.** The update type was read from `metadata.data?.dependency?.update_type` on `GET /repos/{owner}/{repo}/pulls/{pull_number}`. That resource carries no `dependency`, `update_type`, or `dependency_update_type` field, and no media-type preview adds one ([REST docs](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28)). The value was always `undefined`, so the "could not determine update type" guard fired on every pull request. The `approve` job in the same file already does this correctly with `dependabot/fetch-metadata@v3`.

**Its CI gate contained no CI.** Readiness was gated on `getCombinedStatusForRef`, which returns commit *statuses*. Every check in `MERGE_POLICY.md` gate 2 — `validate`, `guards`, `lint-python`, `lint-frontend`, `build`, `test`, `CodeQL`, `gitleaks (working tree)`, `dependency-review`, `PR Governance`, `Canonical issue and evidence` — is a check *run*. The only statuses on this repo are Vercel's two and CodeRabbit's.

Observed live while writing this, on #1433:

| 20:46:48 UTC | `build`, `test`, `lint-python`, `lint-frontend`, `guards` — all `queued` |
| --- | --- |
| 20:48:32 UTC | combined status — `success` (two Vercel statuses) |

Had defect 1 not been short-circuiting first, that PR was mergeable by this job with CI unstarted.

## Scope

- **Included:**
  - `.github/workflows/dependabot-auto-merge.yml` — update-type derivation, check-run readiness gate, `checks: read` permission.
  - `tests/unit/test_dependabot_automation_workflow.py` — permission assertion updated, +2 behavioural tests.
- **Explicitly excluded:**
  - **`vars.DEPENDABOT_AUTO_MERGE_ENABLED`.** It is not `'true'` — on #1433, a Dependabot PR satisfying every other condition in the `approve` job's `if`, that job was **skipped**. Neither job has ever executed, which is why both defects were latent. Setting the variable is a repository-settings decision and belongs to a human, not this PR.
  - **The `approve` job.** Correct as written; untouched.
  - **#1398** (gh-aw toolchain pinned in 4 places, making #1171 unmergeable). Unrelated root cause, already filed.

## Risk

- **Risk level:** low
- **Failure mode:** the job is inert today (feature variable off), so nothing changes until someone enables it. The realistic risk is the readiness scan being *too* strict and silently never merging — mitigated by logging the exact blocking check names on every skip path, so a stuck PR names its own blocker. The opposite risk, merging on unfinished CI, is what this removes.
- **Rollback:** `git revert`. No state, schema, or config migration.

## Verification

Head `1cb1fce`. Measured, not inferred.

- [x] **Focused tests** — `tests/unit/test_dependabot_automation_workflow.py`: **5 passed**. The 3 pre-existing tests still pass.

- [x] **Non-vacuous.** Restoring the workflow from `origin/main` and re-running: **3 failed, 2 passed** — the permission assertion and both new tests fail against the old job.

- [x] **Script parses.** The merge script extracted from the YAML and run through `node --check`: OK. (The previous defect class was runtime-only, so syntax alone is not sufficient — hence the classifier harness below.)

- [x] **Classifier exercised against real Dependabot payloads**, using commit-message blocks and titles taken from this repo's own open PRs:

  | Case | Source | Result |
  |---|---|---|
  | #1433 js-yaml 4.3.0→4.3.1, `dependency-type: indirect`, **no** `update-type` | title fallback | not major ✅ |
  | #1459 hono 4.12.32→4.13.1, has `update-type` | commit metadata | not major ✅ |
  | #1171-style 0.82.14→0.84.2 (major component `0` both sides) | title fallback | not major ✅ |
  | openai 6.49.0→7.3.0 with `update-type: semver-major` | commit metadata | **blocked** ✅ |
  | openai 6.49.0→7.3.0 with `update-type` omitted | title fallback | **blocked** ✅ |
  | grouped "bump the npm group with 5 updates" | unclassifiable | **skipped**, not guessed ✅ |

- [x] **Self-deadlock checked.** The workflow's own `approve`/`merge` check runs are in `in_progress` while the readiness scan evaluates. They are excluded by name; without that exclusion the "no pending checks" rule could never be satisfied.

- [x] **Lint** — `ruff check` clean on the changed test file. YAML parses under `yaml.safe_load`.

- [ ] **Required CI** — will populate on this head.
- [x] **Review threads resolved** — none open yet.

### Why the existing tests missed this

They asserted the merge script *contained the substrings* `"dependabot[bot]"`, `"pulls.merge"` and `"semver-major"`. All three were present in a job that could not merge anything. The assertions pinned vocabulary, not behaviour — the new ones pin the two specific regressions instead.

## Production evidence

Not applicable as a preview — this is a GitHub Actions workflow with no `apps/web/**` surface, which is what gate 4 of `MERGE_POLICY.md` scopes previews to.

The runtime evidence that matters is the #1433 observation above: real check-run states and a real combined status on a real Dependabot PR, showing the two surfaces disagreeing in the direction that would have permitted an unsafe merge.

## Agent handoff

- [x] One canonical issue is linked — #1476
- [x] No competing PR implements the same issue — #1476 was opened by this run; no other open PR touches `dependabot-auto-merge.yml`
- [x] Acceptance criteria are satisfied — all six on #1476
- [ ] Required checks pass on the current head — pending first run
- [x] Human decision is requested only for: merge approval, and separately whether to set `DEPENDABOT_AUTO_MERGE_ENABLED` (out of scope here)

---
_Generated by [Claude Code](https://claude.ai/code/session_018AgciXMrEANGUwVsrVKXo2)_