### PR TITLE
ci: run apps/web vitest as required test-frontend job (#1449)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,29 @@ jobs:
         continue-on-error: true
         run: cd apps/web && npm run lint
 
+  # Required for apps/web unit tests (see #1449). The Python `test` job only
+  # runs pytest; without this job, ~300 frontend tests including CWE-209 /
+  # Stripe-leak regressions never gate merges.
+  test-frontend:
+    name: test-frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm install --legacy-peer-deps
+      - name: Unit tests (apps/web)
+        # Hermetic: do not inject ambient AI/billing keys (see #1230).
+        env:
+          OPENAI_API_KEY: ""
+          AI_GATEWAY_API_KEY: ""
+          VERCEL_AI_GATEWAY_API_KEY: ""
+          STRIPE_SECRET_KEY: ""
+          STRIPE_WEBHOOK_SECRET: ""
+        run: cd apps/web && npx vitest run --reporter=default
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/MERGE_POLICY.md
+++ b/MERGE_POLICY.md
@@ -73,7 +73,7 @@ The real contexts, as observed on live pull requests:
 
 | Surface | Check-run names |
 | --- | --- |
-| CI | `validate`, `guards`, `lint-python`, `lint-frontend`, `build`, `test` |
+| CI | `validate`, `guards`, `lint-python`, `lint-frontend`, `build`, `test`, `test-frontend` |
 | Static analysis | `CodeQL` |
 | Security | `Security Scan - python`, `Security Scan - javascript`, `bandit`, `python-safety`, `npm-audit`, `trivy` |
 | Secrets | `gitleaks (working tree)` |
@@ -81,10 +81,17 @@ The real contexts, as observed on live pull requests:
 | Binding | `PR Governance`, `Canonical issue and evidence` |
 
 Required for every pull request: `validate`, `guards`, `lint-python`,
-`lint-frontend`, `build`, `test`, `CodeQL`, `gitleaks (working tree)`,
-`dependency-review`, `PR Governance`, `Canonical issue and evidence`,
-`Security Scan - python`, `Security Scan - javascript`, `bandit`,
-`python-safety`, `npm-audit`, `trivy`.
+`lint-frontend`, `build`, `test`, `test-frontend`, `CodeQL`,
+`gitleaks (working tree)`, `dependency-review`, `PR Governance`,
+`Canonical issue and evidence`, `Security Scan - python`,
+`Security Scan - javascript`, `bandit`, `python-safety`, `npm-audit`,
+`trivy`.
+
+> **`test` vs `test-frontend`.** The CI job id/name `test` runs **Python**
+> pytest only. Frontend unit tests (apps/web vitest, including CWE-209 /
+> billing disclosure regressions) are the separate required check
+> **`test-frontend`** (#1449). Do not treat a green `test` check as evidence
+> that web unit tests ran.
 
 All six were verified to report `success` on a documentation-only pull request
 (#1408 head `27b2ecf`, and again on #1410 head `7af6028`), so none of them can


### PR DESCRIPTION
## Canonical issue

Closes #1449

## Outcome

Every pull request runs **apps/web** unit tests as a required CI check named `test-frontend`. A green `test` check no longer falsely implies frontend coverage — that job remains Python-only.

## Scope

- Included: `.github/workflows/ci.yml` job `test-frontend` (hermetic env); `MERGE_POLICY.md` gate 2 lists `test-frontend` and documents the split
- Explicitly excluded: making type-check fail-closed (`continue-on-error` still on build type-check — separate call per #1449)

## Risk

- Risk level: medium (new required check may red if ambient keys or flaky tests reappear)
- Failure mode: job fails the PR; hermetic env clears AI/Stripe keys per #1230
- Rollback: revert this PR and remove `test-frontend` from branch protection if added

## Verification

Head `9b25d575a60ae4b7fea777eaf79664702ada677e`.

- [x] Local: `cd apps/web && npx vitest run` — 55 files / 323 tests pass
- [ ] Required CI green including new `test-frontend` on this PR
- [ ] Review threads resolved

## Production evidence

Not applicable — CI configuration only.

## Agent handoff

- [x] One canonical issue is linked
- [x] No competing PR implements the same issue
- [x] Acceptance criteria satisfied in code
- [ ] Required checks pass on the current head
- [x] Human decision only for product/security/production approval

## Agent provenance

Human-authored (Grok Build on Dev canonical tree).
