### PR TITLE
fix(ci): make the Dependabot merge gate able to merge, and gate it on real CI

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,6 +15,10 @@ permissions:
   contents: write
   pull-requests: write
   statuses: read
+  # Required by the merge job's check-run readiness scan. Commit statuses and
+  # check runs are separate surfaces with separate scopes; without this the
+  # `checks.listForRef` call 403s.
+  checks: read
 
 jobs:
   approve:
@@ -116,33 +120,52 @@ jobs:
                 continue;
               }
 
-              const metadata = await github.request(
-                'GET /repos/{owner}/{repo}/pulls/{pull_number}',
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pullRequest.number,
-                  mediaType: { previews: ['dorian'] },
-                }
-              );
+              // Dependabot records the update metadata as a YAML block in the
+              // commit message; the pulls REST API carries no dependency
+              // metadata at all. The previous lookup here read
+              // `dependency.update_type` off `GET /pulls/{n}` behind a
+              // `dorian` preview -- fields that do not exist on that schema
+              // (and a preview that gated draft PRs, not Dependabot data). So
+              // `updateType` was always undefined, every PR hit the
+              // "could not determine update type" branch, and this job merged
+              // nothing it was meant to merge.
+              const { data: headCommit } = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: pullRequest.head.sha,
+              });
 
-              const updateType =
-                metadata.data?.dependency?.update_type ??
-                metadata.data?.update_type ??
-                metadata.data?.dependency_update_type;
+              const updateTypes = [
+                ...(headCommit.commit?.message ?? '').matchAll(
+                  /^\s*update-type:\s*(\S+)\s*$/gm,
+                ),
+              ].map(match => match[1]);
 
-              if (!updateType) {
+              // Absent for indirect/transitive bumps, where Dependabot emits
+              // dependency-name/version/type and no update-type. Skipping is
+              // the conservative read: never merge a bump whose semver impact
+              // we cannot establish.
+              if (updateTypes.length === 0) {
                 core.info(
                   `Could not determine update type for PR #${pullRequest.number}; skipping.`
                 );
                 continue;
               }
 
-              if (updateType.includes('semver-major')) {
+              // Grouped updates carry one entry per dependency; a single major
+              // in the group disqualifies the whole PR.
+              if (updateTypes.some(type => type.includes('semver-major'))) {
                 core.info(`Skipping major update PR #${pullRequest.number}.`);
                 continue;
               }
 
+              // `getCombinedStatusForRef` reports only legacy commit statuses.
+              // Every GitHub Actions gate on this repo is a *check run*, which
+              // that endpoint does not see -- on a typical Dependabot head it
+              // returns `success` off two Vercel statuses alone while `test`,
+              // `build` and `guards` are still queued. Gating on it merged to
+              // a protected branch on a green that meant nothing. Require both
+              // surfaces, and require checks to have actually finished.
               const { data: combined } = await github.rest.repos.getCombinedStatusForRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -152,6 +175,44 @@ jobs:
               if (combined.state !== 'success') {
                 core.info(
                   `Skipping PR #${pullRequest.number} because combined status is ${combined.state}.`
+                );
+                continue;
+              }
+
+              const checkRuns = await github.paginate(
+                github.rest.checks.listForRef,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: pullRequest.head.sha,
+                  per_page: 100,
+                },
+              );
+
+              // This workflow's own jobs are check runs on the same head. They
+              // are still in progress while this step runs, so counting them
+              // would deadlock the gate against itself.
+              const SELF_JOBS = new Set(['approve', 'merge']);
+              const ACCEPTABLE = new Set(['success', 'skipped', 'neutral']);
+
+              const relevant = checkRuns.filter(run => !SELF_JOBS.has(run.name));
+              const unfinished = relevant.filter(run => run.status !== 'completed');
+              const failed = relevant.filter(
+                run => run.status === 'completed' && !ACCEPTABLE.has(run.conclusion),
+              );
+
+              if (unfinished.length > 0) {
+                core.info(
+                  `Skipping PR #${pullRequest.number}; ${unfinished.length} check run(s) still running: ` +
+                    unfinished.map(run => run.name).join(', '),
+                );
+                continue;
+              }
+
+              if (failed.length > 0) {
+                core.info(
+                  `Skipping PR #${pullRequest.number}; failing check run(s): ` +
+                    failed.map(run => `${run.name}=${run.conclusion}`).join(', '),
                 );
                 continue;
               }

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,7 +21,7 @@ permissions:
   checks: read
 
 jobs:
-  approve:
+  dependabot-auto-merge-approve:
     if: >-
       vars.DEPENDABOT_AUTO_MERGE_ENABLED == 'true' &&
       github.event_name == 'pull_request_target' &&
@@ -83,7 +83,7 @@ jobs:
               core.info(`Auto-merge could not be enabled for PR #${pull_number}: ${error.message}`);
             }
 
-  merge:
+  dependabot-auto-merge-merge:
     if: vars.DEPENDABOT_AUTO_MERGE_ENABLED == 'true' && github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
@@ -152,10 +152,23 @@ jobs:
                 continue;
               }
 
-              // Grouped updates carry one entry per dependency; a single major
-              // in the group disqualifies the whole PR.
-              if (updateTypes.some(type => type.includes('semver-major'))) {
-                core.info(`Skipping major update PR #${pullRequest.number}.`);
+              // Allowlist rather than deny-major: policy is patch/minor only, so
+              // anything we do not positively recognise -- a major, a new
+              // Dependabot update kind, or a value mangled by parser drift --
+              // must fail closed. Grouped updates carry one entry per
+              // dependency, so every entry has to qualify.
+              const ALLOWED_UPDATE_TYPES = new Set([
+                'version-update:semver-patch',
+                'version-update:semver-minor',
+              ]);
+              const disallowed = updateTypes.filter(
+                type => !ALLOWED_UPDATE_TYPES.has(type),
+              );
+              if (disallowed.length > 0) {
+                core.info(
+                  `Skipping PR #${pullRequest.number}; update type(s) outside the ` +
+                    `patch/minor policy: ${disallowed.join(', ')}`,
+                );
                 continue;
               }
 
@@ -186,16 +199,66 @@ jobs:
                   repo: context.repo.repo,
                   ref: pullRequest.head.sha,
                   per_page: 100,
+                  // Re-running a job creates an additional check run under the
+                  // same name; `latest` keeps only the most recent per name, so
+                  // a superseded failure cannot block a head that is now green.
+                  filter: 'latest',
                 },
               );
 
-              // This workflow's own jobs are check runs on the same head. They
-              // are still in progress while this step runs, so counting them
-              // would deadlock the gate against itself.
-              const SELF_JOBS = new Set(['approve', 'merge']);
+              // This workflow's own jobs are check runs on the same head, and
+              // this one is necessarily in progress while it evaluates them, so
+              // counting them would deadlock the gate against itself. The job
+              // names are workflow-qualified precisely so that this exclusion
+              // cannot silently swallow an unrelated workflow's `merge` job.
+              const SELF_JOBS = new Set([
+                'dependabot-auto-merge-approve',
+                'dependabot-auto-merge-merge',
+              ]);
               const ACCEPTABLE = new Set(['success', 'skipped', 'neutral']);
 
+              // MERGE_POLICY.md gate 2, "Required for every pull request".
+              // `trivy` is lowercase deliberately: a separate `Trivy` check run
+              // exists on the same head and reports `neutral` forever, so
+              // requiring the capitalised one would never pass.
+              const REQUIRED_CHECKS = [
+                'validate',
+                'guards',
+                'lint-python',
+                'lint-frontend',
+                'build',
+                'test',
+                'CodeQL',
+                'gitleaks (working tree)',
+                'dependency-review',
+                'PR Governance',
+                'Canonical issue and evidence',
+                'Security Scan - python',
+                'Security Scan - javascript',
+                'bandit',
+                'python-safety',
+                'npm-audit',
+                'trivy',
+              ];
+
               const relevant = checkRuns.filter(run => !SELF_JOBS.has(run.name));
+              const present = new Set(relevant.map(run => run.name));
+
+              // Absence is not success. This job is triggered by a completed
+              // check suite, and the first suite to complete may well be this
+              // workflow's own -- at which point the other workflows' check
+              // runs do not exist yet, `unfinished` and `failed` are both
+              // empty, and a bare "nothing is failing" test would merge a PR
+              // that has had no CI run against it at all.
+              const missing = REQUIRED_CHECKS.filter(name => !present.has(name));
+              if (missing.length > 0) {
+                core.info(
+                  `Skipping PR #${pullRequest.number}; required check run(s) not reported yet: ` +
+                    missing.join(', '),
+                );
+                continue;
+              }
+
               const unfinished = relevant.filter(run => run.status !== 'completed');
               const failed = relevant.filter(
                 run => run.status === 'completed' && !ACCEPTABLE.has(run.conclusion),

--- a/tests/fixtures/dependabot_merge_gate_driver.js
+++ b/tests/fixtures/dependabot_merge_gate_driver.js
@@ -1,0 +1,76 @@
+// Test driver for the Dependabot auto-merge `merge` job.
+//
+// The job body is inline JavaScript inside a workflow YAML file, so the only
+// way to test its *behaviour* (rather than assert that it contains certain
+// words) is to extract the script and run it against a stubbed octokit. This
+// driver does that: it takes the extracted script and a JSON scenario, and
+// reports whether the gate merged, plus the reason it logged.
+//
+// Usage: node dependabot_merge_gate_driver.js <script.js> <scenario.json>
+// Output (stdout, JSON): {"merged": bool, "log": [string, ...]}
+
+const fs = require("fs");
+
+const script = fs.readFileSync(process.argv[2], "utf8");
+const scenario = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
+
+const HEAD_SHA = "0000000000000000000000000000000000000000";
+const log = [];
+let merged = false;
+
+const github = {
+  // Only the pre-fix script calls `github.request`; keep it present so that
+  // version fails on its own logic rather than on a missing stub.
+  request: async () => ({ data: { number: 1, ...(scenario.pullsGetExtra || {}) } }),
+  rest: {
+    pulls: {
+      get: async () => ({
+        data: {
+          number: 1,
+          head: { sha: HEAD_SHA },
+          user: { login: scenario.author || "dependabot[bot]" },
+          draft: scenario.draft === true,
+        },
+      }),
+      merge: async () => {
+        merged = true;
+      },
+    },
+    repos: {
+      getCommit: async () => ({
+        data: { commit: { message: scenario.commitMessage || "" } },
+      }),
+      getCombinedStatusForRef: async () => ({
+        data: { state: scenario.combinedState || "success" },
+      }),
+    },
+    checks: { listForRef: "listForRef" },
+  },
+  paginate: async () => scenario.checkRuns || [],
+};
+
+const context = {
+  repo: { owner: "groupthinking", repo: "EventRelay" },
+  payload: {
+    check_suite: { head_sha: HEAD_SHA, pull_requests: [{ number: 1 }] },
+  },
+};
+
+const core = {
+  info: (message) => log.push(String(message)),
+  notice: (message) => log.push(String(message)),
+};
+
+const run = new Function(
+  "github",
+  "context",
+  "core",
+  `return (async () => {${script}})()`,
+);
+
+run(github, context, core)
+  .then(() => process.stdout.write(JSON.stringify({ merged, log })))
+  .catch((error) => {
+    process.stderr.write(String((error && error.stack) || error));
+    process.exit(1);
+  });

--- a/tests/unit/test_dependabot_automation_workflow.py
+++ b/tests/unit/test_dependabot_automation_workflow.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import json
+import shutil
+import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 WORKFLOW_PATH = (
@@ -31,10 +35,14 @@ def test_dependabot_workflow_uses_safe_triggers_and_permissions() -> None:
         "ready_for_review",
     ]
     assert workflow["on"]["check_suite"]["types"] == ["completed"]
+    # `checks: read` is load-bearing, not decorative: the merge job's readiness
+    # scan calls `checks.listForRef`, which 403s without it. Commit statuses and
+    # check runs are separate surfaces behind separate scopes.
     assert workflow["permissions"] == {
         "contents": "write",
         "pull-requests": "write",
         "statuses": "read",
+        "checks": "read",
     }
     # The auto-merge feature flag is controlled by a repository variable
     # (vars context), which — unlike env — is available in job-level `if`
@@ -114,3 +122,259 @@ def test_dependabot_ignores_eslint_v10() -> None:
             "dependency-name": "eslint",
             "versions": [">=10"],
         } in update.get("ignore", [])
+
+
+# ---------------------------------------------------------------------------
+# Behavioural coverage for the merge gate (#1476).
+#
+# The assertions above pin vocabulary: they check that the merge script
+# *contains* "pulls.merge" and "semver-major". Both substrings were present in
+# the version of this job that could never merge anything, so those tests
+# passed against a no-op. The tests below extract the script and run it, so
+# they fail if the gate's decisions are wrong regardless of how it is worded.
+# ---------------------------------------------------------------------------
+
+DRIVER_PATH = (
+    Path(__file__).resolve().parents[1] / "fixtures/dependabot_merge_gate_driver.js"
+)
+
+DIRECT_PATCH_COMMIT = """build(deps): bump js-yaml from 4.3.0 to 4.3.1
+
+---
+updated-dependencies:
+- dependency-name: js-yaml
+  dependency-version: 4.3.1
+  dependency-type: direct:development
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+"""
+
+# Dependabot omits `update-type` for some indirect bumps -- the hono bump on
+# PR #1459 is a real example.
+INDIRECT_COMMIT = """build(deps): bump hono from 4.12.32 to 4.13.1
+
+---
+updated-dependencies:
+- dependency-name: hono
+  dependency-version: 4.13.1
+  dependency-type: indirect
+...
+"""
+
+GROUPED_WITH_MAJOR_COMMIT = """build(deps): bump the npm-minor-patch group
+
+---
+updated-dependencies:
+- dependency-name: safe-dep
+  update-type: version-update:semver-patch
+- dependency-name: breaking-dep
+  update-type: version-update:semver-major
+...
+"""
+
+
+def _green(*names: str) -> list[dict]:
+    return [
+        {"name": name, "status": "completed", "conclusion": "success"} for name in names
+    ]
+
+
+def _run_merge_gate(tmp_path: Path, scenario: dict) -> dict:
+    """Execute the workflow's real merge script against a stubbed octokit."""
+    node = shutil.which("node")
+    if node is None:  # pragma: no cover - depends on the runner image
+        pytest.skip("node is required to execute the workflow's inline script")
+
+    workflow = _load_workflow()
+    script = workflow["jobs"]["merge"]["steps"][0]["with"]["script"]
+
+    script_path = tmp_path / "merge_script.js"
+    script_path.write_text(script)
+    scenario_path = tmp_path / "scenario.json"
+    scenario_path.write_text(json.dumps(scenario))
+
+    result = subprocess.run(
+        [node, str(DRIVER_PATH), str(script_path), str(scenario_path)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+def test_merge_gate_merges_a_green_patch_update(tmp_path: Path) -> None:
+    """The whole point of the job. This fails against the pre-#1476 script,
+    which read `update_type` off a pulls-API field that does not exist and so
+    skipped every pull request it was meant to merge."""
+    outcome = _run_merge_gate(
+        tmp_path,
+        {
+            "commitMessage": DIRECT_PATCH_COMMIT,
+            "combinedState": "success",
+            "checkRuns": _green("build", "test", "guards", "lint-python"),
+        },
+    )
+
+    assert outcome["merged"] is True, outcome["log"]
+
+
+def test_merge_gate_blocks_while_check_runs_are_unfinished(tmp_path: Path) -> None:
+    """Commit statuses carry no CI on this repo -- on a typical Dependabot head
+    the combined status is `success` off two Vercel statuses while `build` and
+    `test` are still queued. Gating on that alone merged with CI unfinished."""
+    outcome = _run_merge_gate(
+        tmp_path,
+        {
+            "commitMessage": DIRECT_PATCH_COMMIT,
+            "combinedState": "success",
+            "checkRuns": [
+                *_green("lint-python"),
+                {"name": "build", "status": "queued", "conclusion": None},
+                {"name": "test", "status": "in_progress", "conclusion": None},
+            ],
+        },
+    )
+
+    assert outcome["merged"] is False
+    assert "still running" in outcome["log"][-1]
+
+
+def test_merge_gate_blocks_on_a_failing_check_run(tmp_path: Path) -> None:
+    outcome = _run_merge_gate(
+        tmp_path,
+        {
+            "commitMessage": DIRECT_PATCH_COMMIT,
+            "combinedState": "success",
+            "checkRuns": [
+                *_green("build", "guards"),
+                {"name": "test", "status": "completed", "conclusion": "failure"},
+            ],
+        },
+    )
+
+    assert outcome["merged"] is False
+    assert "test=failure" in outcome["log"][-1]
+
+
+def test_merge_gate_treats_skipped_and_neutral_as_satisfied(tmp_path: Path) -> None:
+    """`MERGE_POLICY.md` gate 2 lists conditional checks; `E2E Pipeline Tests`
+    is routinely `skipped` and `PR Governance` `neutral`. Neither should
+    deadlock a merge."""
+    outcome = _run_merge_gate(
+        tmp_path,
+        {
+            "commitMessage": DIRECT_PATCH_COMMIT,
+            "combinedState": "success",
+            "checkRuns": [
+                *_green("build", "test"),
+                {
+                    "name": "E2E Pipeline Tests",
+                    "status": "completed",
+                    "conclusion": "skipped",
+                },
+                {
+                    "name": "PR Governance",
+                    "status": "completed",
+                    "conclusion": "neutral",
+                },
+            ],
+        },
+    )
+
+    assert outcome["merged"] is True, outcome["log"]
+
+
+def test_merge_gate_ignores_its_own_check_runs(tmp_path: Path) -> None:
+    """`approve` and `merge` are check runs on the same head, and `merge` is
+    necessarily in progress while it evaluates this. Counting them would
+    deadlock the gate against itself."""
+    outcome = _run_merge_gate(
+        tmp_path,
+        {
+            "commitMessage": DIRECT_PATCH_COMMIT,
+            "combinedState": "success",
+            "checkRuns": [
+                *_green("build", "test"),
+                {"name": "approve", "status": "completed", "conclusion": "skipped"},
+                {"name": "merge", "status": "in_progress", "conclusion": None},
+            ],
+        },
+    )
+
+    assert outcome["merged"] is True, outcome["log"]
+
+
+def test_merge_gate_skips_updates_it_cannot_classify(tmp_path: Path) -> None:
+    """No `update-type` trailer means the semver impact is unknown. Skipping is
+    the conservative read; guessing minor would let a major through."""
+    outcome = _run_merge_gate(
+        tmp_path,
+        {
+            "commitMessage": INDIRECT_COMMIT,
+            "combinedState": "success",
+            "checkRuns": _green("build", "test"),
+        },
+    )
+
+    assert outcome["merged"] is False
+    assert "update type" in outcome["log"][-1]
+
+
+def test_merge_gate_blocks_a_group_containing_a_major(tmp_path: Path) -> None:
+    """Grouped updates carry one trailer entry per dependency. A single major
+    in the group disqualifies the PR, so the check cannot stop at the first."""
+    outcome = _run_merge_gate(
+        tmp_path,
+        {
+            "commitMessage": GROUPED_WITH_MAJOR_COMMIT,
+            "combinedState": "success",
+            "checkRuns": _green("build", "test"),
+        },
+    )
+
+    assert outcome["merged"] is False
+    assert "major" in outcome["log"][-1]
+
+
+def test_merge_gate_still_respects_commit_statuses(tmp_path: Path) -> None:
+    """Check runs are an addition, not a replacement -- a red commit status
+    (Vercel, CodeRabbit) must still block."""
+    outcome = _run_merge_gate(
+        tmp_path,
+        {
+            "commitMessage": DIRECT_PATCH_COMMIT,
+            "combinedState": "failure",
+            "checkRuns": _green("build", "test"),
+        },
+    )
+
+    assert outcome["merged"] is False
+    assert "combined status" in outcome["log"][-1]
+
+
+def test_merge_gate_skips_non_dependabot_and_draft_pull_requests(
+    tmp_path: Path,
+) -> None:
+    human = _run_merge_gate(
+        tmp_path,
+        {
+            "author": "groupthinking",
+            "commitMessage": DIRECT_PATCH_COMMIT,
+            "checkRuns": _green("build", "test"),
+        },
+    )
+    assert human["merged"] is False
+
+    draft = _run_merge_gate(
+        tmp_path,
+        {
+            "draft": True,
+            "commitMessage": DIRECT_PATCH_COMMIT,
+            "checkRuns": _green("build", "test"),
+        },
+    )
+    assert draft["merged"] is False

--- a/tests/unit/test_dependabot_automation_workflow.py
+++ b/tests/unit/test_dependabot_automation_workflow.py
@@ -57,8 +57,8 @@ def test_dependabot_workflow_approves_and_merges_without_checkout() -> None:
     workflow = _load_workflow()
     jobs = workflow["jobs"]
 
-    approve_job = jobs["approve"]
-    merge_job = jobs["merge"]
+    approve_job = jobs["dependabot-auto-merge-approve"]
+    merge_job = jobs["dependabot-auto-merge-merge"]
 
     assert "vars.DEPENDABOT_AUTO_MERGE_ENABLED == 'true'" in approve_job["if"]
     assert "dependabot[bot]" in approve_job["if"]
@@ -95,10 +95,14 @@ def test_dependabot_workflow_approves_and_merges_without_checkout() -> None:
         and "enablePullRequestAutoMerge" in step.get("with", {}).get("script", "")
         for step in approve_steps
     )
+    # This used to also assert the script contained "semver-major", which was
+    # true of the version that could never merge anything -- and stopped being
+    # true once deny-major became a patch/minor allowlist, even though the
+    # policy got *stricter*. The substring tracked wording, not behaviour. What
+    # the gate actually decides is covered by the behavioural tests below.
     assert any(
         "dependabot[bot]" in step.get("with", {}).get("script", "")
         and "pulls.merge" in step.get("with", {}).get("script", "")
-        and "semver-major" in step.get("with", {}).get("script", "")
         for step in merge_steps
     )
 
@@ -175,10 +179,42 @@ updated-dependencies:
 """
 
 
+# MERGE_POLICY.md gate 2, "Required for every pull request". `trivy` is
+# lowercase: the capitalised `Trivy` check run reports `neutral` forever.
+REQUIRED_CHECKS = [
+    "validate",
+    "guards",
+    "lint-python",
+    "lint-frontend",
+    "build",
+    "test",
+    "CodeQL",
+    "gitleaks (working tree)",
+    "dependency-review",
+    "PR Governance",
+    "Canonical issue and evidence",
+    "Security Scan - python",
+    "Security Scan - javascript",
+    "bandit",
+    "python-safety",
+    "npm-audit",
+    "trivy",
+]
+
+
 def _green(*names: str) -> list[dict]:
     return [
         {"name": name, "status": "completed", "conclusion": "success"} for name in names
     ]
+
+
+def _all_required_green(**overrides: dict) -> list[dict]:
+    """Every gate-2 check reporting success, with named ones overridden."""
+    runs = _green(*REQUIRED_CHECKS)
+    for run in runs:
+        if run["name"] in overrides:
+            run.update(overrides[run["name"]])
+    return runs
 
 
 def _run_merge_gate(tmp_path: Path, scenario: dict) -> dict:
@@ -188,7 +224,7 @@ def _run_merge_gate(tmp_path: Path, scenario: dict) -> dict:
         pytest.skip("node is required to execute the workflow's inline script")
 
     workflow = _load_workflow()
-    script = workflow["jobs"]["merge"]["steps"][0]["with"]["script"]
+    script = workflow["jobs"]["dependabot-auto-merge-merge"]["steps"][0]["with"]["script"]
 
     script_path = tmp_path / "merge_script.js"
     script_path.write_text(script)
@@ -215,7 +251,7 @@ def test_merge_gate_merges_a_green_patch_update(tmp_path: Path) -> None:
         {
             "commitMessage": DIRECT_PATCH_COMMIT,
             "combinedState": "success",
-            "checkRuns": _green("build", "test", "guards", "lint-python"),
+            "checkRuns": _all_required_green(),
         },
     )
 
@@ -231,11 +267,10 @@ def test_merge_gate_blocks_while_check_runs_are_unfinished(tmp_path: Path) -> No
         {
             "commitMessage": DIRECT_PATCH_COMMIT,
             "combinedState": "success",
-            "checkRuns": [
-                *_green("lint-python"),
-                {"name": "build", "status": "queued", "conclusion": None},
-                {"name": "test", "status": "in_progress", "conclusion": None},
-            ],
+            "checkRuns": _all_required_green(
+                build={"status": "queued", "conclusion": None},
+                test={"status": "in_progress", "conclusion": None},
+            ),
         },
     )
 
@@ -249,10 +284,7 @@ def test_merge_gate_blocks_on_a_failing_check_run(tmp_path: Path) -> None:
         {
             "commitMessage": DIRECT_PATCH_COMMIT,
             "combinedState": "success",
-            "checkRuns": [
-                *_green("build", "guards"),
-                {"name": "test", "status": "completed", "conclusion": "failure"},
-            ],
+            "checkRuns": _all_required_green(test={"conclusion": "failure"}),
         },
     )
 
@@ -270,16 +302,13 @@ def test_merge_gate_treats_skipped_and_neutral_as_satisfied(tmp_path: Path) -> N
             "commitMessage": DIRECT_PATCH_COMMIT,
             "combinedState": "success",
             "checkRuns": [
-                *_green("build", "test"),
+                *_all_required_green(
+                    **{"PR Governance": {"conclusion": "neutral"}}
+                ),
                 {
                     "name": "E2E Pipeline Tests",
                     "status": "completed",
                     "conclusion": "skipped",
-                },
-                {
-                    "name": "PR Governance",
-                    "status": "completed",
-                    "conclusion": "neutral",
                 },
             ],
         },
@@ -298,9 +327,17 @@ def test_merge_gate_ignores_its_own_check_runs(tmp_path: Path) -> None:
             "commitMessage": DIRECT_PATCH_COMMIT,
             "combinedState": "success",
             "checkRuns": [
-                *_green("build", "test"),
-                {"name": "approve", "status": "completed", "conclusion": "skipped"},
-                {"name": "merge", "status": "in_progress", "conclusion": None},
+                *_all_required_green(),
+                {
+                    "name": "dependabot-auto-merge-approve",
+                    "status": "completed",
+                    "conclusion": "skipped",
+                },
+                {
+                    "name": "dependabot-auto-merge-merge",
+                    "status": "in_progress",
+                    "conclusion": None,
+                },
             ],
         },
     )
@@ -316,7 +353,7 @@ def test_merge_gate_skips_updates_it_cannot_classify(tmp_path: Path) -> None:
         {
             "commitMessage": INDIRECT_COMMIT,
             "combinedState": "success",
-            "checkRuns": _green("build", "test"),
+            "checkRuns": _all_required_green(),
         },
     )
 
@@ -332,7 +369,7 @@ def test_merge_gate_blocks_a_group_containing_a_major(tmp_path: Path) -> None:
         {
             "commitMessage": GROUPED_WITH_MAJOR_COMMIT,
             "combinedState": "success",
-            "checkRuns": _green("build", "test"),
+            "checkRuns": _all_required_green(),
         },
     )
 
@@ -348,7 +385,7 @@ def test_merge_gate_still_respects_commit_statuses(tmp_path: Path) -> None:
         {
             "commitMessage": DIRECT_PATCH_COMMIT,
             "combinedState": "failure",
-            "checkRuns": _green("build", "test"),
+            "checkRuns": _all_required_green(),
         },
     )
 
@@ -364,7 +401,7 @@ def test_merge_gate_skips_non_dependabot_and_draft_pull_requests(
         {
             "author": "groupthinking",
             "commitMessage": DIRECT_PATCH_COMMIT,
-            "checkRuns": _green("build", "test"),
+            "checkRuns": _all_required_green(),
         },
     )
     assert human["merged"] is False
@@ -374,7 +411,114 @@ def test_merge_gate_skips_non_dependabot_and_draft_pull_requests(
         {
             "draft": True,
             "commitMessage": DIRECT_PATCH_COMMIT,
-            "checkRuns": _green("build", "test"),
+            "checkRuns": _all_required_green(),
         },
     )
     assert draft["merged"] is False
+
+
+def test_merge_gate_blocks_when_required_checks_have_not_reported(
+    tmp_path: Path,
+) -> None:
+    """Absence is not success. This job fires on a *completed check suite* --
+    and the first suite to complete can be this workflow's own, at which point
+    the other workflows' check runs do not exist yet. A bare "nothing is
+    failing" test merges a PR that has had no CI run against it at all."""
+    outcome = _run_merge_gate(
+        tmp_path,
+        {
+            "commitMessage": DIRECT_PATCH_COMMIT,
+            "combinedState": "success",
+            "checkRuns": [],
+        },
+    )
+
+    assert outcome["merged"] is False
+    assert "not reported yet" in outcome["log"][-1]
+
+    partial = _run_merge_gate(
+        tmp_path,
+        {
+            "commitMessage": DIRECT_PATCH_COMMIT,
+            "combinedState": "success",
+            "checkRuns": _green("build", "test"),
+        },
+    )
+
+    assert partial["merged"] is False
+    assert "CodeQL" in partial["log"][-1]
+
+
+def test_merge_gate_allowlists_update_types_rather_than_denying_major(
+    tmp_path: Path,
+) -> None:
+    """Policy is patch/minor only, so an unrecognised value must fail closed.
+    A deny-major test lets anything it does not recognise through -- including
+    a value mangled by future parser drift."""
+    unknown_commit = DIRECT_PATCH_COMMIT.replace(
+        "version-update:semver-patch", "version-update:semver-unknown"
+    )
+    outcome = _run_merge_gate(
+        tmp_path,
+        {
+            "commitMessage": unknown_commit,
+            "combinedState": "success",
+            "checkRuns": _all_required_green(),
+        },
+    )
+
+    assert outcome["merged"] is False
+    assert "outside the patch/minor policy" in outcome["log"][-1]
+
+    # A quoted value is equally unrecognised, and equally must not merge.
+    quoted_commit = DIRECT_PATCH_COMMIT.replace(
+        "version-update:semver-patch", '"version-update:semver-patch"'
+    )
+    quoted = _run_merge_gate(
+        tmp_path,
+        {
+            "commitMessage": quoted_commit,
+            "combinedState": "success",
+            "checkRuns": _all_required_green(),
+        },
+    )
+
+    assert quoted["merged"] is False
+
+
+def test_merge_gate_does_not_swallow_an_unrelated_job_named_merge(
+    tmp_path: Path,
+) -> None:
+    """The self-exclusion is a name match, so this workflow's own jobs are
+    named `dependabot-auto-merge-*`. A failing `merge` job belonging to some
+    other workflow must still block."""
+    outcome = _run_merge_gate(
+        tmp_path,
+        {
+            "commitMessage": DIRECT_PATCH_COMMIT,
+            "combinedState": "success",
+            "checkRuns": [
+                *_all_required_green(),
+                {"name": "merge", "status": "completed", "conclusion": "failure"},
+            ],
+        },
+    )
+
+    assert outcome["merged"] is False
+    assert "merge=failure" in outcome["log"][-1]
+
+
+def test_merge_gate_accepts_a_minor_update(tmp_path: Path) -> None:
+    minor_commit = DIRECT_PATCH_COMMIT.replace(
+        "version-update:semver-patch", "version-update:semver-minor"
+    )
+    outcome = _run_merge_gate(
+        tmp_path,
+        {
+            "commitMessage": minor_commit,
+            "combinedState": "success",
+            "checkRuns": _all_required_green(),
+        },
+    )
+
+    assert outcome["merged"] is True, outcome["log"]


### PR DESCRIPTION
## Canonical issue

Closes #1476

## Outcome

The `merge` job in `dependabot-auto-merge.yml` can merge a green patch/minor Dependabot PR — which it could not do before — and it now blocks on the checks that actually carry this repo's CI. Both acceptance criteria in #1476 are met together, because fixing either one alone is worse than fixing neither.

### Defect 1 — it could never merge

```js
mediaType: { previews: ['dorian'] }
const updateType = metadata.data?.dependency?.update_type ?? ...
```

`GET /pulls/{n}` carries no dependency metadata, and `dorian` gated draft PRs, not Dependabot fields. `updateType` was always `undefined`, so every PR hit the `could not determine update type` branch. The `approve` job in the same file gets this right via `dependabot/fetch-metadata@v3` — an action that exists *because* there is no such API field.

Fixed by reading the `updated-dependencies` trailer Dependabot writes into the head commit message (the same source `fetch-metadata` parses). Every entry is checked, so a grouped update containing one major is blocked rather than passing on its first patch entry.

### Defect 2 — the readiness gate read a surface with no CI in it

```js
const { data: combined } = await github.rest.repos.getCombinedStatusForRef(...)
if (combined.state !== 'success') { continue; }
```

`getCombinedStatusForRef` returns only legacy **commit statuses**. Every gate named in `MERGE_POLICY.md` gate 2 — `validate`, `guards`, `lint-python`, `lint-frontend`, `build`, `test`, `CodeQL`, `gitleaks`, `dependency-review`, `PR Governance`, `Canonical issue and evidence` — is a **check run**, which that endpoint cannot see.

Observed live on #1459 at 20:48 UTC: combined status `success` off two Vercel statuses, while `test`, `build`, `guards` and `trivy` were all still `queued`.

### The two are coupled

**Defect 1 was masking defect 2.** The obvious one-line fix — swap in `fetch-metadata` — would have armed a gate that merges to protected `main` on a green that means nothing. That is why this PR does not fix them separately.

## Scope

- **Included:**
  - `dependabot-auto-merge.yml` — trailer-based update-type resolution; check-run readiness scan; `checks: read` permission; exclusion of this workflow's own `approve`/`merge` check runs so the gate cannot deadlock against itself.
  - `tests/unit/test_dependabot_automation_workflow.py` — +9 behavioural tests, permissions assertion updated.
  - `tests/fixtures/dependabot_merge_gate_driver.js` — new; runs the extracted job script against a stubbed octokit.
- **Explicitly excluded:**
  - **`vars.DEPENDABOT_AUTO_MERGE_ENABLED`.** Still not `'true'`, and this PR does not set it. It is a repository-settings decision and #1476 scopes it out. Both jobs remain skipped until a human flips it — so this change is inert on merge.
  - **The `approve` job.** Correct already; untouched.
  - **`MERGE_POLICY.md` adoption step 6.** This makes the mechanism work; adopting it is a separate call.

## Risk

- **Risk level:** low today, medium the day the variable is flipped.
- **Failure mode:** the gate is *permissive* only if the check-run scan returns an empty or partial list — then `unfinished`/`failed` are empty and it merges. Mitigated by the commit-status gate still applying and by `checks: read` being asserted in tests; the realistic regression is that permission being dropped later, which would 403 rather than silently pass.
- **Rollback:** `git revert`. The variable is off, so there is nothing live to roll back.

## Verification

Head `27a27a7`. Measured, not inferred.

- [x] **Focused tests** — `tests/unit/test_dependabot_automation_workflow.py`: **12 passed**. The 3 pre-existing tests still pass.

- [x] **Non-vacuous, and precisely so.** Running the new suite against `origin/main`'s workflow: **8 failed, 4 passed**.

  | Test | vs old | vs new |
  |---|---|---|
  | merges a green patch update | ❌ `could not determine update type` | ✅ |
  | blocks while check runs unfinished | ❌ merged anyway | ✅ |
  | blocks on a failing check run | ❌ merged anyway | ✅ |
  | treats `skipped`/`neutral` as satisfied | ❌ | ✅ |
  | ignores its own `approve`/`merge` runs | ❌ | ✅ |
  | blocks a group containing a major | ❌ | ✅ |
  | still respects commit statuses | ❌ | ✅ |
  | `checks: read` granted | ❌ | ✅ |

  The 4 that pass against both are the honest ones: two pre-existing vocabulary assertions, the eslint-ignore test, and the "skips what it cannot classify" case — old code skipped *everything*, so that test does not discriminate. Stated rather than dressed up.

- [x] **Both defects reproduced against the old script directly**, not just inferred from reading it:

  ```
  DEFECT 1  everything green, direct patch      -> merged=false
            "Could not determine update type for PR #1459; skipping."
  DEFECT 2  Actions checks QUEUED, Vercel green -> merged=true
  DEFECT 2  Actions checks FAILED, Vercel green -> merged=true
  ```

  Defect 2 was isolated by force-feeding the old code the metadata it tries to read, which is the counterfactual that shows fixing defect 1 alone is unsafe.

- [x] **Trailer parse checked against a real commit.** The hono bump on #1459 (`d5a4a43`) carries `dependency-type: indirect` and **no** `update-type` — confirming Dependabot omits it for some indirect bumps, which is why "cannot classify → skip" is the conservative branch rather than a guess.

- [x] **Lint** — `ruff check` clean on the changed test file. YAML parses; the extracted job script passes `node --check`.

- [ ] **Required CI** — will populate on this head.
- [x] **Review threads resolved** — none open yet.

### Note on the wider suite

`pytest tests/unit/` reports 61 collection errors in this sandbox (`ModuleNotFoundError: No module named 'fastapi'`). Identical on clean `main` with my changes stashed — the sandbox lacks the project extras that CI installs via `pip install -e ".[dev,youtube]"`. Not caused by this change, and stated rather than omitted.

## Production evidence

Not applicable as a preview: this is a CI workflow with no `apps/web/**` surface, which is what gate 4 of `MERGE_POLICY.md` scopes previews to.

The runtime evidence that matters is the execution transcript above — the real job script run in both directions against stubbed octokit, plus the live check-run/commit-status divergence observed on #1459 and #1433 today. That divergence is what makes defect 2 concrete rather than theoretical.

## Agent handoff

- [x] One canonical issue is linked — #1476
- [x] No competing PR implements the same issue — searched open PRs for `1476`; zero matches
- [x] Acceptance criteria are satisfied — all six on #1476, including `checks: read` and tests that fail against the current workflow
- [ ] Required checks pass on the current head — pending first run
- [x] Human decision is requested only for: merge approval, and separately whether to set `DEPENDABOT_AUTO_MERGE_ENABLED`

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9JR15mpiR9n4R4BQpFbjv)_