### PR TITLE
fix(logging): stop the serialization fallback from needing a fallback

### DIFF
--- a/src/youtube_extension/backend/config/logging_config.py
+++ b/src/youtube_extension/backend/config/logging_config.py
@@ -76,6 +76,25 @@ def sanitize_log_record(rendered: str) -> str:
     return rendered.translate(_UNSAFE_LOG_CHARS)
 
 
+def _describe_exception(exc: BaseException) -> str:
+    """Name an exception without trusting its ``__str__``.
+
+    Used only by ``StructuredFormatter._format_json``'s serialization
+    fallback. That fallback exists because a value whose ``__str__`` raises
+    costs the record — but the exception it catches is then *whatever that*
+    ``__str__`` *raised*, which is arbitrary and may itself raise on
+    ``str()``. Interpolating it directly would fail inside the handler for
+    the failure, losing the record for the same reason one level down.
+
+    The class name is the guaranteed-safe floor: an attribute lookup that
+    runs no user code.
+    """
+    try:
+        return f"{type(exc).__name__}: {exc}"
+    except Exception:  # noqa: BLE001 - the fallback must not need a fallback
+        return type(exc).__name__
+
+
 class StructuredFormatter(logging.Formatter):
     """
     Custom formatter for structured logging with enhanced metadata.
@@ -172,7 +191,10 @@ class StructuredFormatter(logging.Formatter):
                 for key, value in payload.items()
                 if isinstance(value, (str, int, float, bool, type(None)))
             }
-            safe["serialization_error"] = f"{type(exc).__name__}: {exc}"
+            # Described via `_describe_exception`, not interpolated directly:
+            # `exc` is whatever the offending `__str__` raised, so `str(exc)`
+            # can raise in turn and cost the record here instead.
+            safe["serialization_error"] = _describe_exception(exc)
             return json.dumps(safe, ensure_ascii=True, default=str)
 
     def formatException(self, ei) -> str:

--- a/tests/unit/test_logging_config_crlf.py
+++ b/tests/unit/test_logging_config_crlf.py
@@ -369,6 +369,55 @@ def test_exploding_str_correlation_id_does_not_cost_the_record():
     assert poisoned["serialization_error"] == "RuntimeError: str() exploded"
 
 
+def test_exploding_str_performance_ms_does_not_cost_the_record():
+    # `correlation_id` is covered above, but the enrichment loop reads *two*
+    # attributes and `performance_ms` is the other one. It arrives by a
+    # different route — set from `record.duration` in `format()`, or straight
+    # from `extra=` as here — so covering only `correlation_id` leaves half
+    # the reachable surface untested.
+    logger, buf = _make_json_logger("json-exploding-perf")
+    logger.info("healthy one")
+    logger.info("poisoned", extra={"performance_ms": _ExplodingStr()})
+    logger.info("after poison")
+    records = [json.loads(line) for line in buf.getvalue().splitlines() if line.strip()]
+
+    assert len(records) == 3
+    poisoned = records[1]
+    assert poisoned["message"] == "poisoned"
+    assert poisoned["level"] == "INFO"
+    assert "performance_ms" not in poisoned
+
+
+def test_fallback_survives_an_exception_whose_own_str_raises():
+    """The fallback must not need a fallback.
+
+    `exc` here is not `json`'s own error — it is whatever the offending
+    `__str__` raised, so it is arbitrary caller code. If that exception also
+    raises on `str()`, interpolating it into `serialization_error` fails
+    *inside the handler for the failure*, and the record is lost for exactly
+    the reason the fallback exists to prevent. Measured at 2 of 3 records
+    reaching the sink before `_describe_exception`.
+    """
+
+    class _NastyError(Exception):
+        def __str__(self) -> str:
+            raise RuntimeError("even the error explodes")
+
+    class _RaisesNasty:
+        def __str__(self) -> str:
+            raise _NastyError()
+
+    records = _emit_three("json-nested-explosion", _RaisesNasty())
+
+    assert len(records) == 3
+    poisoned = records[1]
+    assert poisoned["message"] == "poisoned"
+    assert poisoned["level"] == "INFO"
+    assert "correlation_id" not in poisoned
+    # Degraded to the class name alone rather than lost entirely.
+    assert poisoned["serialization_error"] == "_NastyError"
+
+
 def test_serialization_fallback_still_escapes_attacker_content():
     # The fallback must not become a hole in the #1429 fix: a forgery payload
     # in `message` has to stay escaped on the degraded path too.


### PR DESCRIPTION
## Canonical issue

Follow-up to #1452, which #1491 closed while this PR was in flight. Not a competing implementation — this PR is now rebased **onto** `8517bf8` and keeps #1491's design intact. It closes one residual path that fix does not cover.

> **Rescoped mid-run.** This PR originally carried an independent implementation of #1452. #1491 landed the same design first (scalar-only retry, `except Exception`, `serialization_error` key). Rather than argue for a duplicate, the branch was rebuilt on top of it and reduced to the delta below.

## Outcome

`_format_json`'s serialization fallback can still cost the record it exists to save.

The exception the fallback catches is **not `json`'s own error**. In the exploding-`__str__` case it is *whatever that `__str__` raised* — arbitrary caller code. `main` interpolates it directly:

```python
safe["serialization_error"] = f"{type(exc).__name__}: {exc}"
```

`f"...{exc}"` calls `str(exc)`. An exception that also raises on `str()` therefore fails **inside the handler for the failure**, and `Handler.handleError` drops the record for exactly the reason the fallback was added to prevent.

Measured against `main` @ `8517bf8`, three `logger.info` calls with the middle one poisoned:

```
MAIN (post-#1491): records reaching sink = 2 of 3
  NastyError: <exception str() failed>
  RuntimeError: even the error explodes
```

The `<exception str() failed>` line is Python's own logging machinery giving up on the record.

## Scope

- **Included:**
  - `logging_config.py` — `_describe_exception`, which falls back to `type(exc).__name__` (an attribute lookup that runs no user code); the fallback now uses it. **6 lines of behaviour.**
  - `tests/unit/test_logging_config_crlf.py` — 2 tests.
- **Explicitly excluded:**
  - **#1491's design.** Untouched. The scalar filter, `except Exception`, the `serialization_error` key and its format on the normal path all stay exactly as merged. This only changes how the description is *built*.
  - **A lazy `%s` argument whose `__str__` raises.** That fails in `record.getMessage()` while the payload is still being built, *above* the try — and fails identically on the line-oriented path, so it is not specific to JSON and not fixable here.
  - **The `JSON_LOGGING` default mismatch** (`production_config.py:72` says `"true"`, `logging_config.py` says `"false"`). Still a config decision, same as on #1439 and #1491.

## Risk

- **Risk level:** low
- **Failure mode:** the helper is a `try`/`except` around a format string. On every exception with a working `__str__` — which is all of them in practice — the output is byte-identical to `main`'s, so `test_exploding_str_correlation_id_does_not_cost_the_record`'s exact-match assertion (`"RuntimeError: str() exploded"`) still passes unchanged. The degraded form appears only where the alternative today is no record at all.
- **Rollback:** `git revert`. No migration, config, or schema change.

## Verification

Head `618a604`, rebased on `8517bf8`. Measured, not inferred.

- [x] **Focused tests** — `tests/unit/test_logging_config_crlf.py`: **25 passed**. Collection goes 23 → 25, so all 23 tests on `main` — including #1491's three — are unchanged and still pass.

- [x] **Non-vacuous, and honest about which test proves what.** Reverting only `logging_config.py` and re-running:

  ```
  1 failed, 24 passed
  FAILED test_fallback_survives_an_exception_whose_own_str_raises
  ```

  Exactly one test fails against `main`, and it is the one pinning the new behaviour. The other new test (`test_exploding_str_performance_ms_does_not_cost_the_record`) **passes on `main`** — it closes a coverage gap rather than pinning a fix, and both the test's comment and the commit message say so rather than letting it pad a non-vacuity claim.

- [x] **Why the second test earns its place.** The enrichment loop reads two attributes; #1491 tested only `correlation_id`. `performance_ms` arrives by a different route — set from `record.duration` inside `format()`, or straight from `extra=` — so half the reachable surface had no test.

- [x] **Lint** — `ruff check` clean on both changed files.

- [x] **Type checking** — `mypy` reports **17 errors on `main` and 17 on this head**, a byte-identical set. All 17 are pre-existing, at lines this PR does not touch.

- [x] **Blast radius** — `_describe_exception` is module-private with exactly one caller. `_format_json` is reached only via `StructuredFormatter.format` when `json_output` is set, which only `setup_logging`'s dictConfig sets. `test_logging_config_crlf.py` is the only test file importing the module.

- [ ] **Required CI** — see the note below; no `pull_request`-event workflow has fired on this PR.
- [x] **Review threads resolved** — none open.

## A CI observation, not a claim about this PR

This PR has received **no `pull_request`-event workflow runs at all** — no `CI`, `Coverage`, `Security Scan`, `CodeQL`, `Secret Scan`, or `Dependency Review`. Only `pull_request_target` workflows (`PR Governance`, `PR Checks`) and Vercel appeared, and two of those sat `queued` for the entire run.

`ci.yml`, `coverage.yml` and `security.yml` all carry an unfiltered `pull_request:` trigger, so a base-branch filter is not the cause — #1447 removed those. The distinguishing feature is that this PR was **opened automatically by repository automation on push**, not by a session. `ci.yml`'s own header comment already records a sibling failure mode ("a PR stacked onto another PR's branch ran no CI at all", #1440).

I have not diagnosed the mechanism and am not guessing at one. Flagging it because the consequence is concrete: **a PR can reach `mergeable_state: clean` here having run no engineering gate at all**, and nothing in the check list makes that visible — the absent checks simply are not listed. The local evidence above is what stands in for CI on this head; it is not a substitute for it.

## Production evidence

Not applicable as a preview: backend logging, no `apps/web/**` surface, which is what gate 4 of `MERGE_POLICY.md` scopes previews to.

The runtime evidence is the reproduction itself, run against the real formatter through a real `StreamHandler` in both directions — 2 of 3 records on `main` @ `8517bf8`, 3 of 3 on this head. `production_config.py:72` defaults `JSON_LOGGING` to `"true"`, so the JSON path is live.

**Severity: low**, and narrower than #1452's. Reaching it needs a call site to pass an object whose `__str__` raises an exception whose *own* `__str__` also raises. No current call site passes a non-scalar at all. This is a correctness gap in a safety net, not an exploitable path.

## Agent handoff

- [x] One canonical issue is linked — #1452, as a post-merge follow-up to #1491
- [x] No competing PR implements the same issue — this PR was **rescoped specifically to avoid being one**; it now builds on #1491 rather than duplicating it
- [x] Acceptance criteria satisfied — #1452's four criteria are met on `main` by #1491; this closes the residual path in criterion 2 and criterion 4's "state the guarantee the code actually provides"
- [ ] Required checks pass on the current head — **no engineering workflow has run**; see the CI note above
- [x] Human decision is requested only for: merge approval

## Agent provenance

Produced by a scheduled, unattended PR-remediation routine running under the repo owner's account. The PR was opened automatically by repository automation on push; the body is the routine's.

Not dispatched through the agent workflow, so it fills in no `agent-lock-manifest` and fabricates no pre-dispatch intent snapshot or terminal-agent-result — consistent with the #810/#1270 directive not to weaken or impersonate `agent-completion/truth-gate`.

The branch was force-pushed once, replacing a single unmerged commit of my own (`f07bed9`) with the rebased-and-narrowed `618a604`. No merged history was discarded.

Left **ready for review** rather than draft: `.coderabbit.yaml` sets `auto_review.drafts: false`, so drafting would suppress the automated review. It **halts at the human/governance gate** — no auto-merge to protected `main` is requested or performed.