### PR TITLE
fix(logging): close three residual record-loss holes in the JSON fallback

### DIFF
--- a/src/youtube_extension/backend/config/logging_config.py
+++ b/src/youtube_extension/backend/config/logging_config.py
@@ -10,6 +10,7 @@ Provides consistent log formatting, multiple handlers, and performance monitorin
 import json
 import logging
 import logging.config
+import math
 import os
 import sys
 from datetime import datetime
@@ -74,6 +75,42 @@ def sanitize_log_record(rendered: str) -> str:
     rendered JSON record safe — see the module comment and ``#1429``.
     """
     return rendered.translate(_UNSAFE_LOG_CHARS)
+
+
+def _is_json_safe_scalar(value: object) -> bool:
+    """Is this a value ``json.dumps`` emits directly, under ``allow_nan=False``?
+
+    The retention filter for the serialization fallback (#1452). Two details
+    matter, and both are load-bearing:
+
+    ``type(value) in``, not ``isinstance``: ``isinstance`` consults
+    ``value.__class__``, which an object can forge as a property returning
+    ``str``. Such a value passes an ``isinstance`` filter, reaches the fallback
+    ``json.dumps``, and raises — losing the record the fallback exists to save.
+    Exact runtime types cannot be forged.
+
+    Non-finite floats are excluded: ``json`` renders them as the JavaScript
+    literals ``NaN``/``Infinity``, which are not valid JSON, so a strict
+    downstream parser rejects the whole record.
+    """
+    if type(value) is float:
+        return math.isfinite(value)
+    return type(value) in {str, bool, int, type(None)}
+
+
+def _describe_exception(exc: BaseException) -> str:
+    """Describe an exception without ever raising a second one.
+
+    Used on the JSON serialization fallback path (#1452), where the entire
+    point is that the record survives. ``str(exc)`` is itself hostile there:
+    the exception can originate in a call site's own ``__str__``, so it may be
+    an instance of a class whose ``__str__`` raises too. The type name is a
+    plain attribute lookup and is always safe.
+    """
+    try:
+        return f"{type(exc).__name__}: {exc}"
+    except Exception:  # noqa: BLE001 - the type name alone still identifies it
+        return type(exc).__name__
 
 
 class StructuredFormatter(logging.Formatter):
@@ -162,18 +199,35 @@ class StructuredFormatter(logging.Formatter):
         # whose `__str__` raises propagates straight out of `default`. Either
         # way `logging` swallows the raise via `Handler.handleError` and drops
         # the record. The fallback below re-serializes with only the natively
-        # encodable fields, so a bad enrichment costs its own value rather than
+        # encodable scalars, so a bad enrichment costs its own value rather than
         # the whole record.
+        #
+        # `allow_nan=False` because Python's default emits the JavaScript
+        # literals `NaN`/`Infinity`, which are not valid JSON. A strict
+        # downstream parser rejects such a record — the same loss as dropping it
+        # here, only moved to the consumer where it is harder to diagnose.
+        # Raising instead routes it to the fallback, which drops the offending
+        # enrichment and keeps a record every parser accepts.
+        #
+        # SCOPE: this covers *serializing* the payload. Building it can still
+        # raise upstream of here — `record.getMessage()` on mismatched %-args is
+        # the reachable case — and that is out of scope because it fails the
+        # line-oriented path identically. This is not a "no record is ever lost"
+        # guarantee; it is "serialization never loses one".
         try:
-            return json.dumps(payload, ensure_ascii=True, default=str)
+            return json.dumps(payload, ensure_ascii=True, allow_nan=False, default=str)
         except Exception as exc:  # noqa: BLE001 - never lose a record
             safe: dict[str, Any] = {
                 key: value
                 for key, value in payload.items()
-                if isinstance(value, (str, int, float, bool, type(None)))
+                if _is_json_safe_scalar(value)
             }
-            safe["serialization_error"] = f"{type(exc).__name__}: {exc}"
-            return json.dumps(safe, ensure_ascii=True, default=str)
+            safe["serialization_error"] = _describe_exception(exc)
+            # Cannot raise: `_is_json_safe_scalar` admits only values the
+            # encoder emits directly, so there is nothing for `default` to be
+            # consulted for and nothing left for `allow_nan` to reject. Passing
+            # `default=str` here would reinstate the raising-`__str__` hole.
+            return json.dumps(safe, ensure_ascii=True, allow_nan=False)
 
     def formatException(self, ei) -> str:
         """Format exception with enhanced stack trace"""

--- a/src/youtube_extension/backend/config/logging_config.py
+++ b/src/youtube_extension/backend/config/logging_config.py
@@ -104,8 +104,13 @@ def _describe_exception(exc: BaseException) -> str:
     Used on the JSON serialization fallback path (#1452), where the entire
     point is that the record survives. ``str(exc)`` is itself hostile there:
     the exception can originate in a call site's own ``__str__``, so it may be
-    an instance of a class whose ``__str__`` raises too. The type name is a
-    plain attribute lookup and is always safe.
+    an instance of a class whose ``__str__`` raises too.
+
+    The bare type name is the fallback because it is an attribute lookup rather
+    than a dunder call, so no call-site code runs to produce it. That is not the
+    same as "cannot raise" — a hostile *metaclass* could still make ``__name__``
+    a raising property — but such a class cannot be reached from the enrichment
+    path this guards, which carries values, not exception classes.
     """
     try:
         return f"{type(exc).__name__}: {exc}"

--- a/tests/unit/test_logging_config_crlf.py
+++ b/tests/unit/test_logging_config_crlf.py
@@ -381,6 +381,107 @@ def test_serialization_fallback_still_escapes_attacker_content():
     assert parsed["message"] == _FORGERY
 
 
+# ---------------------------------------------------------------------------
+# #1452 follow-up: the fallback added above is not self-sufficient either.
+#
+# Three inputs still cost the record — or its validity — after that fix:
+#
+#   1. a value that forges `__class__`, defeating the `isinstance` retention
+#      filter and reaching a `json.dumps` whose `default=str` then raises;
+#   2. an exception whose own `__str__` raises, detonating the
+#      `f"{type(exc).__name__}: {exc}"` that builds `serialization_error`;
+#   3. a non-finite float, which serializes to the bare JavaScript literals
+#      `NaN`/`Infinity` — accepted by Python's lenient `json.loads`, rejected
+#      by every strict downstream parser.
+#
+# All three fail on the pre-follow-up implementation.
+# ---------------------------------------------------------------------------
+
+
+class _ForgedClass:
+    """Forges `__class__` as `str`, so an `isinstance` filter admits it."""
+
+    @property  # type: ignore[misc]
+    def __class__(self):  # type: ignore[override]
+        return str
+
+    def __str__(self) -> str:
+        raise RuntimeError("forged value exploded")
+
+
+class _ExplodingExc(Exception):
+    """An exception whose own `__str__` raises, as one from `__str__` may."""
+
+    def __str__(self) -> str:
+        raise RuntimeError("exception str() exploded")
+
+
+class _RaisesExplodingExc:
+    def __str__(self) -> str:
+        raise _ExplodingExc()
+
+
+def _strict_loads(line: str) -> dict:
+    """Parse as a *strict* JSON consumer would — `NaN`/`Infinity` are errors."""
+
+    def _reject(constant: str):
+        raise ValueError(f"not valid JSON: {constant}")
+
+    return json.loads(line, parse_constant=_reject)
+
+
+def test_forged_class_value_does_not_cost_the_record():
+    # `isinstance` consults `__class__`, which this value forges as `str`; an
+    # `isinstance`-based filter keeps it, and the fallback dump then raises.
+    records = _emit_three("json-forged-class", _ForgedClass())
+
+    assert len(records) == 3
+    poisoned = records[1]
+    assert poisoned["message"] == "poisoned"
+    assert poisoned["level"] == "INFO"
+    assert "correlation_id" not in poisoned
+
+
+def test_exception_with_exploding_str_does_not_cost_the_record():
+    # The fallback must describe the failure without re-detonating it.
+    records = _emit_three("json-exploding-exc", _RaisesExplodingExc())
+
+    assert len(records) == 3
+    poisoned = records[1]
+    assert poisoned["message"] == "poisoned"
+    assert poisoned["level"] == "INFO"
+    # Degrades to the type name alone rather than losing the record.
+    assert poisoned["serialization_error"] == "_ExplodingExc"
+
+
+@pytest.mark.parametrize(
+    "value", [float("nan"), float("inf"), float("-inf")], ids=["nan", "inf", "-inf"]
+)
+def test_non_finite_enrichment_stays_strictly_valid_json(value):
+    logger, buf = _make_json_logger(f"json-non-finite-{value}")
+    logger.info("poisoned", extra={"performance_ms": value})
+
+    line = buf.getvalue().strip()
+    # Pre-fix this emits a bare `NaN` / `Infinity` literal and raises here.
+    parsed = _strict_loads(line)
+
+    assert parsed["message"] == "poisoned"
+    assert parsed["level"] == "INFO"
+    # The non-finite value costs itself, not the record.
+    assert "performance_ms" not in parsed
+    assert parsed["serialization_error"].startswith("ValueError:")
+
+
+def test_finite_float_enrichment_is_still_retained():
+    # The non-finite guard must not cost well-behaved floats their value.
+    logger, buf = _make_json_logger("json-finite-float")
+    logger.info("healthy", extra={"performance_ms": 12.5})
+
+    parsed = _strict_loads(buf.getvalue().strip())
+    assert parsed["performance_ms"] == 12.5
+    assert "serialization_error" not in parsed
+
+
 @pytest.fixture
 def _restore_root_logging():
     """`setup_logging` calls dictConfig, which mutates global logging state."""


### PR DESCRIPTION
## Canonical issue

Closes #1505

Follow-up to #1452, which landed as #1491 (`8517bf8`). This is not a competing implementation of that issue: the defects below are in the fallback #1491 *added*, and each is reproduced against a `main` that already contains it.

## Outcome

The JSON serialization fallback now delivers the guarantee its comment claims. Three inputs that still cost a record — or its validity — on current `main` no longer do.

Reproduced through a real `StreamHandler`, healthy → poisoned → healthy:

| Input | On `main` today | After this PR |
|---|---|---|
| Value forging `__class__` as `str` | **2 of 3 records** — poisoned record dropped | 3 of 3 |
| Exception whose own `__str__` raises | **2 of 3 records** — poisoned record dropped | 3 of 3 |
| `performance_ms=float("nan")` | emits bare `NaN` — **invalid JSON**, strict parsers reject the record | 3 of 3, strictly valid |

Why each survives the merged fallback:

1. `isinstance(value, (str, int, float, bool, type(None)))` consults `value.__class__`, which an object can forge as a property returning `str`. Such a value passes the retention filter, reaches the fallback `json.dumps` — which still passes `default=str` — and its raising `__str__` propagates. `logging` swallows it via `Handler.handleError` and drops the record.
2. `serialization_error` is built as `f"{type(exc).__name__}: {exc}"`. The exception being described can itself originate in a call site's `__str__`, so `{exc}` can raise a second time — inside the handler that was recovering from the first.
3. Non-finite floats never reach the fallback: `default` is not consulted for them, and `json` renders them as the JavaScript literals `NaN`/`Infinity`. Python's own lenient `json.loads` accepts these, which is why the existing tests missed it, but they are not valid JSON.

## Scope

- Included: `_is_json_safe_scalar` (exact runtime type, since exact types cannot be forged; excludes non-finite floats), `_describe_exception` (guarded, degrades to the type name alone), `allow_nan=False` on the primary dump, and removal of `default=str` from the fallback dump so nothing on that path can reach a raising `__str__`.
- Explicitly excluded: payload *construction* failures upstream of serialization — `record.getMessage()` on mismatched `%`-args is the reachable case. Out of scope because it fails the line-oriented path identically. Documented inline as a SCOPE note so the guarantee is not overstated a third time.
- Explicitly excluded: reformatting the file. `main` is not black-clean here (pre-existing quote style); the black delta is unchanged at 59 lines before and after this change.

## Risk

- Risk level: low
- Failure mode: a well-behaved float enrichment could in principle be dropped by an over-broad guard; pinned against by `test_finite_float_enrichment_is_still_retained`. A `serialization_error` field now appears on records that previously produced no output at all, so downstream consumers see a new optional key only on records they were never receiving.
- Not attacker-reachable — every live call site passes a scalar, and an attacker-supplied header is a string — so this is robustness, not a security fix. The CWE-117 work in #1429/#1439 is unaffected, and the existing test pinning that the degraded path still escapes attacker content continues to pass.
- Rollback: `git revert`. No migration, config, or schema change. The success path's field set is byte-identical.

## Verification

Head `77a095c`. Measured, not inferred.

- [x] Focused tests: `pytest tests/unit/test_logging_config_crlf.py` — **29 passed** (collection 23 → 29, so all 23 pre-existing tests are unchanged and still pass).
- [x] Non-vacuous, and precisely so. Reverting only `logging_config.py` and re-running: **5 failed, 24 passed**. Five of the six new tests fail against the pre-fix code. The sixth (`test_finite_float_enrichment_is_still_retained`) passes on both — which makes it a control rather than a gap.
- [x] The strict-parser assertion is real: `_strict_loads` passes `parse_constant` so `NaN`/`Infinity` raise. A test that used a bare `json.loads` would pass against the bug, which is exactly how this was missed the first time.
- [x] Lint: `ruff check` clean on both changed files. Black delta vs `main` measured before and after — unchanged at 59 pre-existing lines, so no new formatting debt.
- [ ] Required CI — the repo's Actions queue is currently saturated (277 queued runs against ~23 concurrent), so checks on this head are still queued rather than failing.
- [x] Review threads resolved — none open. CodeRabbit could not review: the org's review allowance was exhausted by the PR burst described below.

## Production evidence

Not applicable as a preview: backend logging with no `apps/web/**` surface, which is what gate 4 of `MERGE_POLICY.md` scopes previews to.

The runtime evidence that matters is the record-loss reproduction, run against the real formatter through a real `StreamHandler` in both directions. Exposure is live rather than theoretical: `production_config.py:72` defaults `JSON_LOGGING` to `"true"`.

## Agent handoff

- [x] One canonical issue is linked — #1505, open, no competing implementation
- [x] Acceptance criteria satisfied in code — all five on #1505
- [ ] Required checks pass on the current head — queued, see above
- [x] Human decision is requested only for merge approval

## Agent provenance

Produced by a scheduled, unattended PR-remediation routine running under the repo owner's account. Not dispatched through the agent workflow, so it fills in no `agent-lock-manifest` and fabricates no pre-dispatch intent snapshot — consistent with the directive on #810/#1270 not to weaken or impersonate the retired `agent-completion/truth-gate`.

Two process notes surfaced by this run, recorded here because they explain the state of the board rather than this diff:

- **Eight PRs were opened against #1452 within about five minutes** (#1471, #1472, #1477, #1488, #1491, #1493, #1494, and this one) by concurrent unattended runs of the same routine, none aware of the others. #1491 merged; the rest are closed or obsolete. This exhausted the CodeRabbit review allowance for the repo and is the proximate cause of the Actions queue backlog.
- **14 open PRs are red on `agent-completion/truth-gate`, a check that no longer exists on `main`.** It was retired in #1431 and its workflow deleted, but all 14 branches still carry `.github/workflows/agent-completion-enforcement.yml`, and the workflow runs from the PR head. Verified 14/14 (#734, #810, #1122, #1223, #1241, #1242, #1256, #1259, #1356, #1360, #1361, #1363, #1367, #1409). Merging `main` into each branch deletes the file and clears the check — no code fix. This includes #1409, which is itself the fix for that gate.