### PR TITLE
fix(logging): close the three holes the #1452 fallback shipped with

### DIFF
--- a/src/youtube_extension/backend/config/logging_config.py
+++ b/src/youtube_extension/backend/config/logging_config.py
@@ -10,6 +10,7 @@ Provides consistent log formatting, multiple handlers, and performance monitorin
 import json
 import logging
 import logging.config
+import math
 import os
 import sys
 from datetime import datetime
@@ -74,6 +75,57 @@ def sanitize_log_record(rendered: str) -> str:
     rendered JSON record safe — see the module comment and ``#1429``.
     """
     return rendered.translate(_UNSAFE_LOG_CHARS)
+
+
+# Last-resort record for the serialization fallback. A module-level constant,
+# so emitting it cannot itself fail — which is what lets the guarantee below be
+# stated without a qualifier.
+_JSON_UNSERIALIZABLE_RECORD = (
+    '{"serialization_error": "log record could not be serialized"}'
+)
+
+
+def _describe_exception(exc: BaseException) -> str:
+    """Name an exception without trusting its ``__str__``.
+
+    Used only by the serialization fallback, which exists precisely because a
+    hostile ``__str__`` can raise. Interpolating ``exc`` there unguarded
+    reintroduces that failure *inside the handler for it* — measured on
+    ``8517bf8`` at 2 of 3 records reaching the sink. The class name is a plain
+    attribute and is always renderable, so it is the safe floor.
+    """
+    try:
+        return f"{type(exc).__name__}: {exc}"
+    except Exception:  # noqa: BLE001 - the fallback must not need a fallback
+        return type(exc).__name__
+
+
+def _is_json_safe_scalar(value: object) -> bool:
+    """Is this a value ``json`` emits directly, with no ``default`` and no NaN?
+
+    The filter for the serialization fallback. That fallback's dump carries no
+    ``default=`` — anything reaching ``default`` there would reinstate the
+    raising-``__str__`` hole it exists to close — so this filter is the only
+    thing standing between it and a second, fatal raise. It is exact about two
+    things:
+
+    ``type(value) is``, never ``isinstance``. ``isinstance`` consults
+    ``value.__class__``, which an object can forge with a property returning
+    ``str``. Such a value passes an ``isinstance`` filter, reaches the dump,
+    and costs the record the fallback exists to save — measured on ``8517bf8``
+    at 2 of 3 records reaching the sink. ``json`` dispatches on the real
+    runtime type, which cannot be forged, so matching on it is what makes this
+    filter agree with the encoder rather than merely resemble it.
+
+    Non-finite floats are excluded. ``json`` renders them as the JavaScript
+    literals ``NaN``/``Infinity``, which are not valid JSON: a strict parser
+    rejects the record, so keeping the field loses the record downstream
+    instead of at the sink.
+    """
+    value_type = type(value)
+    if value_type is float:
+        return math.isfinite(value)
+    return value_type in (str, int, bool, type(None))
 
 
 class StructuredFormatter(logging.Formatter):
@@ -164,16 +216,37 @@ class StructuredFormatter(logging.Formatter):
         # the record. The fallback below re-serializes with only the natively
         # encodable fields, so a bad enrichment costs its own value rather than
         # the whole record.
+        # `allow_nan=False` on the *primary* dump is what routes a non-finite
+        # enrichment here rather than emitting `NaN`/`Infinity` — JavaScript
+        # literals that are not valid JSON, so a strict parser rejects the whole
+        # record. Losing it at the sink, where the fallback can degrade it into
+        # something parseable, beats losing it downstream where nothing can.
         try:
-            return json.dumps(payload, ensure_ascii=True, default=str)
+            return json.dumps(payload, ensure_ascii=True, default=str, allow_nan=False)
         except Exception as exc:  # noqa: BLE001 - never lose a record
+            # Three things make this retry unable to fail the way the first
+            # attempt did, and each closes a hole the retry shipped with:
+            #
+            #   * `_is_json_safe_scalar` matches the exact runtime type, so a
+            #     forged `__class__` cannot smuggle a raising `__str__` past it;
+            #   * `_describe_exception` renders `exc` without trusting its own
+            #     `__str__`;
+            #   * no `default=`, so nothing on this path can reach `str()` at
+            #     all — the filter has already excluded everything that would.
+            #
+            # `allow_nan=False` is belt-and-braces over the float check: it
+            # turns any non-finite that somehow survives into a raise caught
+            # below rather than a record no strict parser will accept.
             safe: dict[str, Any] = {
                 key: value
                 for key, value in payload.items()
-                if isinstance(value, (str, int, float, bool, type(None)))
+                if _is_json_safe_scalar(value)
             }
-            safe["serialization_error"] = f"{type(exc).__name__}: {exc}"
-            return json.dumps(safe, ensure_ascii=True, default=str)
+            safe["serialization_error"] = _describe_exception(exc)
+            try:
+                return json.dumps(safe, ensure_ascii=True, allow_nan=False)
+            except Exception:  # noqa: BLE001 - a constant is the floor
+                return _JSON_UNSERIALIZABLE_RECORD
 
     def formatException(self, ei) -> str:
         """Format exception with enhanced stack trace"""

--- a/tests/unit/test_logging_config_crlf.py
+++ b/tests/unit/test_logging_config_crlf.py
@@ -381,6 +381,121 @@ def test_serialization_fallback_still_escapes_attacker_content():
     assert parsed["message"] == _FORGERY
 
 
+# ---------------------------------------------------------------------------
+# #1452, second pass: the *fallback* shipped with the same class of hole it was
+# written to close — a step that can itself raise, inside the handler that
+# exists because raising is the failure mode.
+#
+# Three of them, each measured against `8517bf8` (the merged #1491) before
+# being fixed, using the same healthy → poisoned → healthy probe as above:
+#
+#   1. `isinstance(value, str)` consults `value.__class__`, which a property
+#      can forge. The value passes the filter, reaches a `json.dumps` that
+#      still had `default=str`, and its raising `__str__` kills the record.
+#      Measured: 2 of 3.
+#   2. `f"...{exc}"` renders the caught exception unguarded. An exception whose
+#      own `__str__` raises kills the record. Measured: 2 of 3.
+#   3. A non-finite float serializes to the bare literal `NaN`, which is not
+#      valid JSON. The record reaches the sink and is then rejected by any
+#      strict parser — lost downstream instead of at the sink.
+#
+# Every test below fails on `8517bf8`.
+# ---------------------------------------------------------------------------
+
+
+class _ForgedClass:
+    """`isinstance(v, str)` is True; `str(v)` raises. Exact-type checks see through it."""
+
+    @property
+    def __class__(self):  # noqa: ANN204 - forging the type is the point
+        return str
+
+    def __str__(self) -> str:
+        raise RuntimeError("forged str() exploded")
+
+
+class _UnrenderableExc(Exception):
+    """An exception that cannot be interpolated — `f"{exc}"` raises on it."""
+
+    def __str__(self) -> str:
+        raise RuntimeError("exc.__str__ exploded")
+
+
+class _RaisesUnrenderable:
+    def __str__(self) -> str:
+        raise _UnrenderableExc()
+
+
+def test_forged_class_cannot_smuggle_a_raising_str_into_the_fallback():
+    records = _emit_three("json-forged-class", _ForgedClass())
+
+    assert len(records) == 3
+    poisoned = records[1]
+    assert poisoned["message"] == "poisoned"
+    # The #1429 guarantee still holds on the degraded record.
+    assert poisoned["level"] == "INFO"
+    assert "correlation_id" not in poisoned
+    assert "serialization_error" in poisoned
+
+
+def test_unrenderable_exception_does_not_cost_the_record():
+    records = _emit_three("json-unrenderable-exc", _RaisesUnrenderable())
+
+    assert len(records) == 3
+    poisoned = records[1]
+    assert poisoned["message"] == "poisoned"
+    assert poisoned["level"] == "INFO"
+    assert "correlation_id" not in poisoned
+    # Degraded to the bare class name rather than "Name: message" — the class
+    # name is an attribute, so naming the exception cannot itself raise.
+    assert poisoned["serialization_error"] == "_UnrenderableExc"
+
+
+@pytest.mark.parametrize("poison", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_enrichment_still_yields_strictly_valid_json(poison):
+    logger, buf = _make_json_logger("json-non-finite")
+    logger.info("timing", extra={"request_id": poison})
+    line = buf.getvalue().strip()
+
+    # `json.loads` accepts `NaN`/`Infinity` by default, so asserting it parses
+    # would pass against the bug. `parse_constant` fires on exactly those
+    # literals, which is what a strict downstream parser rejects.
+    def _reject(literal: str) -> None:
+        raise AssertionError(f"non-finite literal reached the sink: {literal}")
+
+    parsed = json.loads(line, parse_constant=_reject)
+    assert parsed["level"] == "INFO"
+    assert parsed["message"] == "timing"
+    assert "correlation_id" not in parsed
+    assert parsed["serialization_error"].startswith("ValueError:")
+
+
+def test_fallback_of_last_resort_is_emitted_rather_than_nothing():
+    # The floor: if even the degraded dump fails, a constant is emitted. Drive
+    # it directly, since no `extra` value can defeat the scalar filter — that
+    # is the point of the filter, and the reason this needs a direct probe.
+    formatter = StructuredFormatter(datefmt="%Y-%m-%d %H:%M:%S", json_output=True)
+    record = logging.LogRecord(
+        "json-floor", logging.INFO, __file__, 1, "floored", None, None
+    )
+    formatter.format(record)  # populates service_name / version
+
+    original_dumps = json.dumps
+
+    def _always_raises(*args, **kwargs):
+        raise RuntimeError("even the degraded dump failed")
+
+    json.dumps = _always_raises
+    try:
+        rendered = formatter.format(record)
+    finally:
+        json.dumps = original_dumps
+
+    assert json.loads(rendered) == {
+        "serialization_error": "log record could not be serialized"
+    }
+
+
 @pytest.fixture
 def _restore_root_logging():
     """`setup_logging` calls dictConfig, which mutates global logging state."""


### PR DESCRIPTION
## Canonical issue

Closes #1452

Reopening the scope of #1452 rather than filing a new issue: its acceptance criterion was *"a record is never lost to a serialization error."* #1491 landed the fallback that makes that mostly true. This PR is what makes it true without a qualifier — the same overclaim #1452 was filed about, one level down.

## Outcome

`_format_json`'s serialization fallback can no longer fail the way the serialization it guards failed.

#1491 landed the #1452 fallback: when `json.dumps` raises, re-serialize from the scalar fields so a bad enrichment costs its own value rather than the whole record. The retry itself contains three steps that can raise — **inside the handler that exists because raising is the failure mode.**

Measured against `8517bf8` (the merged #1491) with the same healthy → poisoned → healthy probe the existing tests use:

| Hole | Mechanism | Measured on `8517bf8` |
|---|---|---|
| Forged `__class__` | `isinstance(value, str)` consults `value.__class__`, which a property can forge. The value passes the filter, reaches a `json.dumps` that still carried `default=str`, and its raising `__str__` kills the record. | **2 of 3** records reach the sink |
| Unrenderable exception | `f"{type(exc).__name__}: {exc}"` renders the caught exception unguarded. An exception whose own `__str__` raises kills the record. | **2 of 3** records reach the sink |
| Non-finite float | Serializes to the bare literal `NaN`, which is not valid JSON. The record reaches the sink and is then rejected by any strict parser. | 3 of 3 at the sink, **0 usable downstream** |

The third is the one worth being precise about: the record is not lost *at* the sink, it is lost *after* it, where nothing can degrade it into something parseable. Routing it through the fallback trades an unparseable record for a degraded one.

### How each is closed

- **`_is_json_safe_scalar`** matches the **exact runtime type**, never `isinstance`. `json` itself dispatches on the real runtime type, which cannot be forged, so matching on it makes the filter *agree with* the encoder rather than merely resemble it. It also excludes non-finite floats.
- **`_describe_exception`** names an exception without trusting its `__str__`, degrading to the bare class name — an attribute, so naming it cannot itself raise.
- **The retry drops `default=` entirely.** Anything reaching `default` there would reinstate the raising-`__str__` hole; the filter has already excluded everything that would, so `default` is not just unnecessary but actively wrong.
- **`allow_nan=False` on the primary dump** is what routes a non-finite enrichment to the fallback instead of emitting an unparseable record.
- **A module-level constant is the floor**, so emitting the last-resort record cannot itself fail.

## Scope

- **Included:**
  - `logging_config.py` — `_describe_exception`, `_is_json_safe_scalar`, `_JSON_UNSERIALIZABLE_RECORD`, and the reworked retry.
  - `tests/unit/test_logging_config_crlf.py` — +6 tests in the existing CWE-117 file, in its established idiom.
- **Explicitly excluded:**
  - **Detection and escaping logic.** The #1429/#1439 CWE-117 field-forgery guarantee is untouched and still pinned by its own 23 tests, including on the degraded path.
  - **The `JSON_LOGGING` default mismatch** (`production_config.py:72` says `"true"`, `logging_config.py` says `"false"`). Scoped out of #1439 and #1491 for the same reason: a behavioural config decision, not a serialization fix.
  - **`record.getMessage()`.** A lazy `%s` argument whose `__str__` raises fails while the payload is still being built, above the retry. It fails identically on the line-oriented path, so it is not specific to JSON and not this PR's to fix.

### Note: this consolidates six competing pull requests

At the time of writing, **six open PRs implement #1452** — #1471, #1472, #1477, #1488, #1493 and #1494 — all opened within eleven minutes of each other, after #1491 had already merged the base fix. Each caught a *different* subset of the residual holes; none caught all three. This PR is their union, verified rather than merged on trust:

- **#1471 / #1477** — the forged-`__class__` hole and the `type()`-not-`isinstance` argument.
- **#1477** — the non-finite float case.
- **#1493 / #1494** — the unguarded exception rendering.
- **#1488** — the constant last-resort record.
- **#1472** — the precise scoping of what the guard does and does not cover, reflected in the exclusions above.

Under `MERGE_POLICY.md` gate 6, the six need a reconciliation decision, not six rebases. Recommendation is on the table in the PR thread; they are left open pending it rather than closed unilaterally.

## Risk

- **Risk level:** low
- **Failure mode:** two of the three paths are reached only when the record is *already* being lost, so the worst case there is a degraded record where today there is none. The one genuine behaviour change is `allow_nan=False` on the primary dump: a record carrying a non-finite `performance_ms` now emits degraded-but-parseable instead of `{"performance_ms": NaN}`. That is a widening of what survives, and the previous output was not valid JSON, so no conforming consumer can regress. A consumer relying on Python's own `json.loads` (which accepts `NaN`) to read that field would see it drop to `serialization_error` — no such consumer exists in-tree.
- **Rollback:** `git revert`. No migration, config, or schema change.

## Verification

Head `7358509`. Measured, not inferred.

- [x] **Focused tests** — `tests/unit/test_logging_config_crlf.py`: **29 passed**. The 23 pre-existing tests are unchanged and still pass, so both the #1429 contract and the #1452 contract are intact.
- [x] **Non-vacuous, and precisely scoped.** Reverting *only* `logging_config.py` to `origin/main` and keeping the tests fails exactly the six new tests and nothing else:

  ```
  FAILED test_forged_class_cannot_smuggle_a_raising_str_into_the_fallback
  FAILED test_unrenderable_exception_does_not_cost_the_record
  FAILED test_non_finite_enrichment_still_yields_strictly_valid_json[nan]
  FAILED test_non_finite_enrichment_still_yields_strictly_valid_json[inf]
  FAILED test_non_finite_enrichment_still_yields_strictly_valid_json[-inf]
  FAILED test_fallback_of_last_resort_is_emitted_rather_than_nothing
  6 failed, 23 passed
  ```

- [x] **The non-finite test cannot pass against the bug.** `json.loads` accepts `NaN`/`Infinity` by default, so asserting "it parses" would pass on unfixed code. The test passes a `parse_constant` that fires on exactly those literals — which is what a strict downstream parser rejects.
- [x] **The degraded path is still not a hole in #1429.** `test_serialization_fallback_still_escapes_attacker_content` (pre-existing) drives the forgery payload through the fallback and still passes; the new tests additionally assert `level` stays authoritative on every degraded record.
- [x] **`except Exception` is deliberate.** A narrow `(TypeError, ValueError, RecursionError)` walks straight past the exploding-`__str__` cases; the tests fail against the narrow version.
- [x] **Blast radius checked, not assumed.** `tests/unit/test_logging_config_crlf.py` is the only test file in the repo referencing `logging_config`.
- [x] **Lint** — `ruff check` clean on both changed files.
- [ ] **Required CI** — pending first run on this head.
- [x] **Review threads resolved** — none open yet.

**Stated honestly:** the wider `tests/unit/` suite could not be run in this sandbox — 61 collection errors, all `ModuleNotFoundError` for project dependencies (`fastapi`, `pydantic`, `aiohttp`, `psutil`, `aiofiles`) that are not installed here. `logging_config` imports none of them, and the file under test collects and runs cleanly. CI covers the rest.

## Production evidence

Not applicable as a preview — backend logging with no `apps/web/**` surface, which is what gate 4 of `MERGE_POLICY.md` scopes previews to.

The runtime evidence that matters is the reproduction, run against the real formatter through a real `StreamHandler` in both directions: 2 of 3 records on `8517bf8` for both raising cases, 3 of 3 on this head, plus strict-parser rejection of the non-finite record before and acceptance after.

## Agent handoff

- [x] One canonical issue is linked — #1452
- [ ] **No competing PR implements the same issue** — six do (#1471, #1472, #1477, #1488, #1493, #1494). This PR is their consolidation and is proposed as the one to land; the others need a reconciliation decision under gate 6. Flagged rather than checked, because checking it would be false.
- [x] Acceptance criteria are satisfied — #1452's fourth criterion ("the comment states the real guarantee") is what this PR is about: the comment #1491 shipped described a guarantee its code did not yet provide.
- [ ] Required checks pass on the current head — first run pending
- [x] Human decision is requested only for: merge approval, and the gate-6 reconciliation of the six competing PRs

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDs1q8Pw4i5y3wbBSaUf8V)_