### PR TITLE
fix(review): make the CodeRabbit label-gate override actually bind

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,17 +4,30 @@
 # the CodeRabbit dashboard (inheritance, auto_assign_reviewers, finishing
 # touches, knowledge base, issue enrichment, presidio, auto-review label
 # gating) are version-controlled here so every change is reviewable in a PR.
-# `inheritance: true` still lets the org-level config layer underneath this
-# file — so any setting this file leaves unset can be silently overridden from
-# the dashboard. Prefer setting a value explicitly, even at its default, when
-# the default is the behaviour you actually want.
+#
+# Inheritance is OFF so that claim is actually true. With `inheritance: true`
+# the org/dashboard config layers *underneath* this file, and a key set to an
+# empty collection here does not read as "override the inherited value with
+# nothing" — it reads as unset, and the inherited value survives. That is not
+# hypothetical: #1425 set `reviews.auto_review.labels: []` to clear an
+# inherited required-labels gate, and afterwards PRs were still landing
+# "Review skipped: excluded by label configuration" (e.g. #1483, #1494) — a
+# message that can only come from a label gate that is still active. Turning
+# inheritance off is the only in-file lever that makes the empty list bind.
+#
+# Consequence: anything this file leaves unset now falls back to the CodeRabbit
+# *schema* default, not to the dashboard. Set values explicitly — even at their
+# default — when the default is the behaviour you actually want.
 language: en-US
 tone_instructions: >-
   Be assertive and direct. Focus on real bugs, security issues, and performance
   problems — not style nitpicks. Flag anything that could break in production.
   When you find an issue, explain why it matters and suggest a concrete fix.
 early_access: true
-inheritance: true
+# See the header: `true` lets the dashboard's required-labels gate outlive the
+# `reviews.auto_review.labels: []` override below. Do not flip this back without
+# first confirming the gate has been removed dashboard-side.
+inheritance: false
 reviews:
   profile: assertive
   request_changes_workflow: true
@@ -32,6 +45,8 @@ reviews:
     # No label gate. This is the schema default, set explicitly to override an
     # inherited required-labels list from the dashboard/org config, which was
     # deadlocking auto-review against `auto_apply_labels: true` below.
+    # This only takes effect because `inheritance: false` above — on its own
+    # (as shipped in #1425) the empty list read as unset and the gate survived.
     #
     # The inherited gate required at least one of ~26 labels before a review
     # would start — a set that includes `architecture-gap`, `ci-cd`,

--- a/tests/unit/test_coderabbit_config.py
+++ b/tests/unit/test_coderabbit_config.py
@@ -67,14 +67,27 @@ def test_config_parses_as_valid_yaml():
 
 
 # ---------------------------------------------------------------------------
-# inheritance (new field)
+# inheritance
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_inheritance_enabled(config):
-    """inheritance: true lets the org-level config layer underneath this file."""
-    assert config.get("inheritance") is True
+def test_inheritance_disabled(config):
+    """inheritance must stay false, or the label gate silently comes back.
+
+    This asserted ``is True`` until the setting was found to be the reason
+    auto-review never started. With inheritance on, the org/dashboard config
+    layers *underneath* this file, and a key set to an empty collection here
+    reads as unset rather than as an override — so #1425's
+    ``reviews.auto_review.labels: []`` did not clear the inherited
+    required-labels gate, and PRs kept landing "Review skipped: excluded by
+    label configuration".
+
+    Flipping this back to true re-breaks auto-review repo-wide, and does it
+    silently: nothing fails, PRs simply stop being reviewed. Pair any change
+    here with the label-gate comment in ``.coderabbit.yaml``.
+    """
+    assert config.get("inheritance") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Canonical issue

Follow-up to #1425 — that PR's fix did not take effect. This PR is the correction.

> **Scope reduced.** This PR briefly also carried a `ci.yml` concurrency fix. #1510 implements the same fix across 16 workflows rather than one, so those commits have been dropped and #1510 should own that work. See the note at the bottom. This PR is now a single-file change again.

## Outcome

CodeRabbit auto-review starts on PRs again. Today it silently does not — every PR gets `Review skipped: excluded by label configuration`, and nothing surfaces that the PR went unreviewed.

## Scope

- **Included:** `inheritance: true` → `false` in `.coderabbit.yaml`, plus comments recording the evidence so it doesn't get reverted as cosmetic. One file, +20/-5.
- **Explicitly excluded:** the dashboard-side required-labels list (not reachable from the repo); CI concurrency (now #1510's); the `auto-label.yml` race described at the bottom.

## Details

#1425 set `reviews.auto_review.labels: []` to clear an inherited required-labels gate. It is still active. CodeRabbit confirmed why, on this PR:

> **Configuration used**: Repository YAML (base), Repository UI (inherited), Organization UI (inherited)

With `inheritance: true` the repository YAML is layered over by two inherited sources, and a key set to an empty collection reads as **unset** rather than "override with nothing" — so the inherited list survives. The gate is self-deadlocking: of its 26 required labels, `architecture-gap`, `ci-cd`, `pipeline-critical` and `placeholder-code` are ones CodeRabbit applies *during* a review, and a PR opens unlabelled.

Reproduced five times on PRs based on a `main` that already carried the empty list — #1483, #1486, #1494, and twice on this PR across two heads.

`inheritance: false` is the only in-file lever that stops both inherited layers being consulted.

## Risk

- **Risk level:** low
- **Failure mode:** CodeRabbit settings this file leaves unset now fall back to the schema default rather than the dashboard value. The file already sets the review, tooling, labeling, chat, knowledge-base and issue-enrichment blocks explicitly — which is what its header claims. If a dashboard-only setting turns out to matter, add it to this file rather than re-enabling inheritance.
- **Rollback:** revert the single commit.

## Verification

Head `aa31594`.

- [x] YAML parses; `inheritance == False`, `auto_review.labels == []`, `auto_review.enabled == True` via `yaml.safe_load`
- [x] **Reviewed by CodeRabbit** (requested manually, since auto-review is the thing that's broken): *"Full review complete. I found no blocking issues… The `inheritance: false` change correctly prevents the repository and organization UI layers from preserving the inherited label gate."*
- [ ] Required CI — has not produced a conclusion. Do not read the absence of a red check as a green one.
- [ ] **Cannot verify itself pre-merge.** CodeRabbit reads config from **base**, so this has no effect until it is on `main`. After merge, open any unlabelled PR — it should get a review, not a skip. If it still skips, the gate is enforced dashboard-side and must be cleared by hand; repo config cannot reach it.

## Production evidence

Not applicable — review-bot configuration only, no runtime code path touched.

## Agent handoff

- [x] Canonical issue linked (#1425)
- [x] **No competing PR implements the same issue** — verified; #1510 covers CI concurrency, which is why that work was removed from here
- [ ] Acceptance criteria satisfied — the real check is behavioural and post-merge
- [ ] Required checks pass on current head — no conclusion yet
- [x] Human decision requested only for the merge itself

### Why the concurrency commits were dropped

I added a `ci.yml` concurrency group here, then found #1510 had opened a minute earlier doing the same thing better — same SHA-keyed grouping, applied to 16 workflows instead of one. Keeping both would have produced exactly the competing-PR situation this repo's template has a checkbox against. #1510 should land; the reasoning I worked out about why `push` must be keyed by `github.sha` and not `github.ref` is posted there.

### Related finding, not fixed here

`auto-label.yml` labels by changed path but queues like any Actions job, while CodeRabbit evaluates the gate at PR-open time. Under a saturated queue the PR is still unlabelled when the gate runs, and labelling afterwards does not retro-trigger. Removing the gate makes the race harmless — but it returns if the gate is reinstated dashboard-side.