### PR TITLE
fix(ci): add concurrency groups so the Actions queue can drain

### DIFF
--- a/.github/workflows/anthropic-wif-test.yml
+++ b/.github/workflows/anthropic-wif-test.yml
@@ -16,10 +16,15 @@ permissions:
 # Supersede superseded work instead of stacking it. Without this, every push
 # to a PR branch queued a brand-new full run alongside the ones it obsoleted;
 # with ~30 workflows and dozens of open PRs the Actions queue could not drain.
-# PR runs cancel their predecessors; push/schedule runs queue instead, so each
-# merged commit keeps its own verdict.
+#
+# PR runs are keyed by PR number and cancel their predecessors -- that is where
+# all the queue pressure comes from, since every `push:` trigger here is already
+# filtered to main. Non-PR runs (push, schedule) are keyed by commit SHA so they
+# land in singleton groups: keying them on github.ref would collide every merge
+# to main into one group, and GitHub cancels the *pending* run in a group, so a
+# burst of merges would silently drop the middle commits' verdicts.
 concurrency:
-  group: anthropic-wif-test-${{ github.event.pull_request.number || github.ref }}
+  group: anthropic-wif-test-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:

--- a/.github/workflows/anthropic-wif-test.yml
+++ b/.github/workflows/anthropic-wif-test.yml
@@ -12,6 +12,16 @@ permissions:
   id-token: write
   contents: read
 
+
+# Supersede superseded work instead of stacking it. Without this, every push
+# to a PR branch queued a brand-new full run alongside the ones it obsoleted;
+# with ~30 workflows and dozens of open PRs the Actions queue could not drain.
+# PR runs cancel their predecessors; push/schedule runs queue instead, so each
+# merged commit keeps its own verdict.
+concurrency:
+  group: anthropic-wif-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   call-claude:
     runs-on: ubuntu-latest

--- a/.github/workflows/api-cost-postgres.yml
+++ b/.github/workflows/api-cost-postgres.yml
@@ -29,6 +29,16 @@ on:
 permissions:
   contents: read
 
+
+# Supersede superseded work instead of stacking it. Without this, every push
+# to a PR branch queued a brand-new full run alongside the ones it obsoleted;
+# with ~30 workflows and dozens of open PRs the Actions queue could not drain.
+# PR runs cancel their predecessors; push/schedule runs queue instead, so each
+# merged commit keeps its own verdict.
+concurrency:
+  group: api-cost-postgres-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   migration-matrix:
     name: PostgreSQL migration matrix (${{ matrix.scenario }})

--- a/.github/workflows/api-cost-postgres.yml
+++ b/.github/workflows/api-cost-postgres.yml
@@ -33,10 +33,15 @@ permissions:
 # Supersede superseded work instead of stacking it. Without this, every push
 # to a PR branch queued a brand-new full run alongside the ones it obsoleted;
 # with ~30 workflows and dozens of open PRs the Actions queue could not drain.
-# PR runs cancel their predecessors; push/schedule runs queue instead, so each
-# merged commit keeps its own verdict.
+#
+# PR runs are keyed by PR number and cancel their predecessors -- that is where
+# all the queue pressure comes from, since every `push:` trigger here is already
+# filtered to main. Non-PR runs (push, schedule) are keyed by commit SHA so they
+# land in singleton groups: keying them on github.ref would collide every merge
+# to main into one group, and GitHub cancels the *pending* run in a group, so a
+# burst of merges would silently drop the middle commits' verdicts.
 concurrency:
-  group: api-cost-postgres-${{ github.event.pull_request.number || github.ref }}
+  group: api-cost-postgres-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -12,8 +12,13 @@ permissions:
 # Supersede superseded work instead of stacking it. Without this, every push
 # to a PR branch queued a brand-new full run alongside the ones it obsoleted;
 # with ~30 workflows and dozens of open PRs the Actions queue could not drain.
-# PR runs cancel their predecessors; push/schedule runs queue instead, so each
-# merged commit keeps its own verdict.
+#
+# PR runs are keyed by PR number and cancel their predecessors -- that is where
+# all the queue pressure comes from, since every `push:` trigger here is already
+# filtered to main. Non-PR runs (push, schedule) are keyed by commit SHA so they
+# land in singleton groups: keying them on github.ref would collide every merge
+# to main into one group, and GitHub cancels the *pending* run in a group, so a
+# burst of merges would silently drop the middle commits' verdicts.
 concurrency:
   group: auto-assign-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -8,6 +8,16 @@ on:
 permissions:
   issues: write
 
+
+# Supersede superseded work instead of stacking it. Without this, every push
+# to a PR branch queued a brand-new full run alongside the ones it obsoleted;
+# with ~30 workflows and dozens of open PRs the Actions queue could not drain.
+# PR runs cancel their predecessors; push/schedule runs queue instead, so each
+# merged commit keeps its own verdict.
+concurrency:
+  group: auto-assign-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   auto-assign:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -13,8 +13,13 @@ permissions:
 # Supersede superseded work instead of stacking it. Without this, every push
 # to a PR branch queued a brand-new full run alongside the ones it obsoleted;
 # with ~30 workflows and dozens of open PRs the Actions queue could not drain.
-# PR runs cancel their predecessors; push/schedule runs queue instead, so each
-# merged commit keeps its own verdict.
+#
+# PR runs are keyed by PR number and cancel their predecessors -- that is where
+# all the queue pressure comes from, since every `push:` trigger here is already
+# filtered to main. Non-PR runs (push, schedule) are keyed by commit SHA so they
+# land in singleton groups: keying them on github.ref would collide every merge
+# to main into one group, and GitHub cancels the *pending* run in a group, so a
+# burst of merges would silently drop the middle commits' verdicts.
 concurrency:
   group: auto-label-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -9,6 +9,16 @@ on:
 permissions:
   pull-requests: write
   issues: write
+
+# Supersede superseded work instead of stacking it. Without this, every push
+# to a PR branch queued a brand-new full run alongside the ones it obsoleted;
+# with ~30 workflows and dozens of open PRs the Actions queue could not drain.
+# PR runs cancel their predecessors; push/schedule runs queue instead, so each
+# merged commit keeps its own verdict.
+concurrency:
+  group: auto-label-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -53,10 +53,15 @@ permissions:
 # Supersede superseded work instead of stacking it. Without this, every push
 # to a PR branch queued a brand-new full run alongside the ones it obsoleted;
 # with ~30 workflows and dozens of open PRs the Actions queue could not drain.
-# PR runs cancel their predecessors; push/schedule runs queue instead, so each
-# merged commit keeps its own verdict.
+#
+# PR runs are keyed by PR number and cancel their predecessors -- that is where
+# all the queue pressure comes from, since every `push:` trigger here is already
+# filtered to main. Non-PR runs (push, schedule) are keyed by commit SHA so they
+# land in singleton groups: keying them on github.ref would collide every merge
+# to main into one group, and GitHub cancels the *pending* run in a group, so a
+# burst of merges would silently drop the middle commits' verdicts.
 concurrency:
-  group: branch-cleanup-${{ github.event.pull_request.number || github.ref }}
+  group: branch-cleanup-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -49,6 +49,16 @@ permissions:
   contents: write
   pull-requests: read
 
+
+# Supersede superseded work instead of stacking it. Without this, every push
+# to a PR branch queued a brand-new full run alongside the ones it obsoleted;
+# with ~30 workflows and dozens of open PRs the Actions queue could not drain.
+# PR runs cancel their predecessors; push/schedule runs queue instead, so each
+# merged commit keeps its own verdict.
+concurrency:
+  group: branch-cleanup-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,15 @@ permissions:
 # Supersede superseded work instead of stacking it. Without this, every push
 # to a PR branch queued a brand-new full run alongside the ones it obsoleted;
 # with ~30 workflows and dozens of open PRs the Actions queue could not drain.
-# PR runs cancel their predecessors; push/schedule runs queue instead, so each
-# merged commit keeps its own verdict.
+#
+# PR runs are keyed by PR number and cancel their predecessors -- that is where
+# all the queue pressure comes from, since every `push:` trigger here is already
+# filtered to main. Non-PR runs (push, schedule) are keyed by commit SHA so they
+# land in singleton groups: keying them on github.ref would collide every merge
+# to main into one group, and GitHub cancels the *pending* run in a group, so a
+# burst of merges would silently drop the middle commits' verdicts.
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,16 @@ permissions:
   contents: read
   actions: read
 
+
+# Supersede superseded work instead of stacking it. Without this, every push
+# to a PR branch queued a brand-new full run alongside the ones it obsoleted;
+# with ~30 workflows and dozens of open PRs the Actions queue could not drain.
+# PR runs cancel their predecessors; push/schedule runs queue instead, so each
+# merged commit keeps its own verdict.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   guards:
     # Fail fast on the class of breakage that shipped to main un-caught:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,16 @@ permissions:
   security-events: write
   actions: read
 
+
+# Supersede superseded work instead of stacking it. Without this, every push
+# to a PR branch queued a brand-new full run alongside the ones it obsoleted;
+# with ~30 workflows and dozens of open PRs the Actions queue could not drain.
+# PR runs cancel their predecessors; push/schedule runs queue instead, so each
+# merged commit keeps its own verdict.
+concurrency:
+  group: codeql-analysis-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   analyze:
     name: "Security Scan - ${{ matrix.language }}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,10 +18,15 @@ permissions:
 # Supersede superseded work instead of stacking it. Without this, every push
 # to a PR branch queued a brand-new full run alongside the ones it obsoleted;
 # with ~30 workflows and dozens of open PRs the Actions queue could not drain.
-# PR runs cancel their predecessors; push/schedule runs queue instead, so each
-# merged commit keeps its own verdict.
+#
+# PR runs are keyed by PR number and cancel their predecessors -- that is where
+# all the queue pressure comes from, since every `push:` trigger here is already
+# filtered to main. Non-PR runs (push, schedule) are keyed by commit SHA so they
+# land in singleton groups: keying them on github.ref would collide every merge
+# to main into one group, and GitHub cancels the *pending* run in a group, so a
+# burst of merges would silently drop the middle commits' verdicts.
 concurrency:
-  group: codeql-analysis-${{ github.event.pull_request.number || github.ref }}
+  group: codeql-analysis-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,9 +17,13 @@ permissions:
   contents: read
   actions: read
 
+# Keyed by PR number for PR runs and by commit SHA otherwise. The previous
+# github.ref key collided every merge to main into one group, where GitHub
+# cancels the pending run -- a burst of merges silently dropped the middle
+# commits' verdicts. See the fuller note in ci.yml.
 concurrency:
-  group: coverage-${{ github.ref }}
-  cancel-in-progress: true
+  group: coverage-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:
   coverage:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,6 +16,16 @@ permissions:
   pull-requests: write
   statuses: read
 
+
+# Supersede superseded work instead of stacking it. Without this, every push
+# to a PR branch queued a brand-new full run alongside the ones it obsoleted;
+# with ~30 workflows and dozens of open PRs the Actions queue could not drain.
+# PR runs cancel their predecessors; push/schedule runs queue instead, so each
+# merged commit keeps its own verdict.
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   approve:
     if: >-

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,10 +20,15 @@ permissions:
 # Supersede superseded work instead of stacking it. Without this, every push
 # to a PR branch queued a brand-new full run alongside the ones it obsoleted;
 # with ~30 workflows and dozens of open PRs the Actions queue could not drain.
-# PR runs cancel their predecessors; push/schedule runs queue instead, so each
-# merged commit keeps its own verdict.
+#
+# PR runs are keyed by PR number and cancel their predecessors -- that is where
+# all the queue pressure comes from, since every `push:` trigger here is already
+# filtered to main. Non-PR runs (push, schedule) are keyed by commit SHA so they
+# land in singleton groups: keying them on github.ref would collide every merge
+# to main into one group, and GitHub cancels the *pending* run in a group, so a
+# burst of merges would silently drop the middle commits' verdicts.
 concurrency:
-  group: dependabot-auto-merge-${{ github.event.pull_request.number || github.ref }}
+  group: dependabot-auto-merge-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -28,7 +28,12 @@ permissions:
 # to main into one group, and GitHub cancels the *pending* run in a group, so a
 # burst of merges would silently drop the middle commits' verdicts.
 concurrency:
-  group: dependabot-auto-merge-${{ github.event.pull_request.number || github.sha }}
+  # check_suite is the exception to the github.sha fallback used elsewhere:
+  # on that event GITHUB_SHA is the default branch tip, identical for every
+  # PR, so github.sha alone would collapse all concurrent check-suite runs
+  # into one group and drop merge-gate verdicts. check_suite.head_sha is the
+  # PR head and keeps them isolated.
+  group: dependabot-auto-merge-${{ github.event.pull_request.number || github.event.check_suite.head_sha || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,10 +13,15 @@ permissions:
 # Supersede superseded work instead of stacking it. Without this, every push
 # to a PR branch queued a brand-new full run alongside the ones it obsoleted;
 # with ~30 workflows and dozens of open PRs the Actions queue could not drain.
-# PR runs cancel their predecessors; push/schedule runs queue instead, so each
-# merged commit keeps its own verdict.
+#
+# PR runs are keyed by PR number and cancel their predecessors -- that is where
+# all the queue pressure comes from, since every `push:` trigger here is already
+# filtered to main. Non-PR runs (push, schedule) are keyed by commit SHA so they
+# land in singleton groups: keying them on github.ref would collide every merge
+# to main into one group, and GitHub cancels the *pending* run in a group, so a
+# burst of merges would silently drop the middle commits' verdicts.
 concurrency:
-  group: dependency-review-${{ github.event.pull_request.number || github.ref }}
+  group: dependency-review-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,16 @@ permissions:
   contents: read
   pull-requests: write
 
+
+# Supersede superseded work instead of stacking it. Without this, every push
+# to a PR branch queued a brand-new full run alongside the ones it obsoleted;
+# with ~30 workflows and dozens of open PRs the Actions queue could not drain.
+# PR runs cancel their predecessors; push/schedule runs queue instead, so each
+# merged commit keeps its own verdict.
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -30,6 +30,16 @@ env:
   TEST_YOUTUBE_URL: https://www.youtube.com/watch?v=auJzb1D-fag
   VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
+
+# Supersede superseded work instead of stacking it. Without this, every push
+# to a PR branch queued a brand-new full run alongside the ones it obsoleted;
+# with ~30 workflows and dozens of open PRs the Actions queue could not drain.
+# PR runs cancel their predecessors; push/schedule runs queue instead, so each
+# merged commit keeps its own verdict.
+concurrency:
+  group: e2e-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   e2e:
     name: E2E Pipeline Tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,10 +34,15 @@ env:
 # Supersede superseded work instead of stacking it. Without this, every push
 # to a PR branch queued a brand-new full run alongside the ones it obsoleted;
 # with ~30 workflows and dozens of open PRs the Actions queue could not drain.
-# PR runs cancel their predecessors; push/schedule runs queue instead, so each
-# merged commit keeps its own verdict.
+#
+# PR runs are keyed by PR number and cancel their predecessors -- that is where
+# all the queue pressure comes from, since every `push:` trigger here is already
+# filtered to main. Non-PR runs (push, schedule) are keyed by commit SHA so they
+# land in singleton groups: keying them on github.ref would collide every merge
+# to main into one group, and GitHub cancels the *pending* run in a group, so a
+# burst of merges would silently drop the middle commits' verdicts.
 concurrency:
-  group: e2e-tests-${{ github.event.pull_request.number || github.ref }}
+  group: e2e-tests-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:

--- a/.github/workflows/gh-aw-validation.yml
+++ b/.github/workflows/gh-aw-validation.yml
@@ -20,6 +20,16 @@ on:
 permissions:
   contents: read
 
+
+# Supersede superseded work instead of stacking it. Without this, every push
+# to a PR branch queued a brand-new full run alongside the ones it obsoleted;
+# with ~30 workflows and dozens of open PRs the Actions queue could not drain.
+# PR runs cancel their predecessors; push/schedule runs queue instead, so each
+# merged commit keeps its own verdict.
+concurrency:
+  group: gh-aw-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   validate-gh-aw:
     runs-on: ubuntu-latest

--- a/.github/workflows/gh-aw-validation.yml
+++ b/.github/workflows/gh-aw-validation.yml
@@ -24,10 +24,15 @@ permissions:
 # Supersede superseded work instead of stacking it. Without this, every push
 # to a PR branch queued a brand-new full run alongside the ones it obsoleted;
 # with ~30 workflows and dozens of open PRs the Actions queue could not drain.
-# PR runs cancel their predecessors; push/schedule runs queue instead, so each
-# merged commit keeps its own verdict.
+#
+# PR runs are keyed by PR number and cancel their predecessors -- that is where
+# all the queue pressure comes from, since every `push:` trigger here is already
+# filtered to main. Non-PR runs (push, schedule) are keyed by commit SHA so they
+# land in singleton groups: keying them on github.ref would collide every merge
+# to main into one group, and GitHub cancels the *pending* run in a group, so a
+# burst of merges would silently drop the middle commits' verdicts.
 concurrency:
-  group: gh-aw-validation-${{ github.event.pull_request.number || github.ref }}
+  group: gh-aw-validation-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -4,6 +4,16 @@ on:
     types: [opened]
 permissions:
   issues: write
+
+# Supersede superseded work instead of stacking it. Without this, every push
+# to a PR branch queued a brand-new full run alongside the ones it obsoleted;
+# with ~30 workflows and dozens of open PRs the Actions queue could not drain.
+# PR runs cancel their predecessors; push/schedule runs queue instead, so each
+# merged commit keeps its own verdict.
+concurrency:
+  group: issue-triage-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -8,8 +8,13 @@ permissions:
 # Supersede superseded work instead of stacking it. Without this, every push
 # to a PR branch queued a brand-new full run alongside the ones it obsoleted;
 # with ~30 workflows and dozens of open PRs the Actions queue could not drain.
-# PR runs cancel their predecessors; push/schedule runs queue instead, so each
-# merged commit keeps its own verdict.
+#
+# PR runs are keyed by PR number and cancel their predecessors -- that is where
+# all the queue pressure comes from, since every `push:` trigger here is already
+# filtered to main. Non-PR runs (push, schedule) are keyed by commit SHA so they
+# land in singleton groups: keying them on github.ref would collide every merge
+# to main into one group, and GitHub cancels the *pending* run in a group, so a
+# burst of merges would silently drop the middle commits' verdicts.
 concurrency:
   group: issue-triage-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,10 +10,15 @@ permissions: {}
 # Supersede superseded work instead of stacking it. Without this, every push
 # to a PR branch queued a brand-new full run alongside the ones it obsoleted;
 # with ~30 workflows and dozens of open PRs the Actions queue could not drain.
-# PR runs cancel their predecessors; push/schedule runs queue instead, so each
-# merged commit keeps its own verdict.
+#
+# PR runs are keyed by PR number and cancel their predecessors -- that is where
+# all the queue pressure comes from, since every `push:` trigger here is already
+# filtered to main. Non-PR runs (push, schedule) are keyed by commit SHA so they
+# land in singleton groups: keying them on github.ref would collide every merge
+# to main into one group, and GitHub cancels the *pending* run in a group, so a
+# burst of merges would silently drop the middle commits' verdicts.
 concurrency:
-  group: pr-checks-${{ github.event.pull_request.number || github.ref }}
+  group: pr-checks-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,6 +6,16 @@ on:
 
 permissions: {}
 
+
+# Supersede superseded work instead of stacking it. Without this, every push
+# to a PR branch queued a brand-new full run alongside the ones it obsoleted;
+# with ~30 workflows and dozens of open PRs the Actions queue could not drain.
+# PR runs cancel their predecessors; push/schedule runs queue instead, so each
+# merged commit keeps its own verdict.
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,9 +13,13 @@ on:
 permissions:
   contents: read
 
+# Keyed by PR number for PR runs and by commit SHA otherwise. The previous
+# github.ref key collided every merge to main into one group, where GitHub
+# cancels the pending run -- a burst of merges silently dropped the middle
+# commits' verdicts. See the fuller note in ci.yml.
 concurrency:
-  group: secret-scan-${{ github.ref }}
-  cancel-in-progress: true
+  group: secret-scan-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:
   gitleaks:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,10 +19,15 @@ permissions:
 # Supersede superseded work instead of stacking it. Without this, every push
 # to a PR branch queued a brand-new full run alongside the ones it obsoleted;
 # with ~30 workflows and dozens of open PRs the Actions queue could not drain.
-# PR runs cancel their predecessors; push/schedule runs queue instead, so each
-# merged commit keeps its own verdict.
+#
+# PR runs are keyed by PR number and cancel their predecessors -- that is where
+# all the queue pressure comes from, since every `push:` trigger here is already
+# filtered to main. Non-PR runs (push, schedule) are keyed by commit SHA so they
+# land in singleton groups: keying them on github.ref would collide every merge
+# to main into one group, and GitHub cancels the *pending* run in a group, so a
+# burst of merges would silently drop the middle commits' verdicts.
 concurrency:
-  group: security-${{ github.event.pull_request.number || github.ref }}
+  group: security-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,16 @@ permissions:
   security-events: write
   actions: read
 
+
+# Supersede superseded work instead of stacking it. Without this, every push
+# to a PR branch queued a brand-new full run alongside the ones it obsoleted;
+# with ~30 workflows and dozens of open PRs the Actions queue could not drain.
+# PR runs cancel their predecessors; push/schedule runs queue instead, so each
+# merged commit keeps its own verdict.
+concurrency:
+  group: security-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   npm-audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Canonical issue

Closes #1519

## Outcome

Removes the structural amplifier that lets this repository's Actions queue reach hundreds of runs deep and stay there.

Measured via the Actions API:

| Signal | 21:13 UTC | 21:19 UTC | 21:26 UTC |
|---|---|---|---|
| Runs `queued` | **285** | 256 | 207 |
| Runs `in_progress` | 2 | 23 | — |
| Oldest queued run | `20:49:28Z` (~24 min, never started) | — | — |

**Be precise about what this PR does and does not claim.** Between the first two samples, runner capacity recovered on its own and the queue began draining. So the acute stall was a capacity condition, **not** something missing `concurrency:` blocks caused. I am not claiming this PR would have prevented it.

What the missing blocks *do* cause is the standing run volume: with ~26 open PRs, ~30 workflows, and no deduplication, every push stacks a brand-new full run beside the ones it obsoletes. That is why a capacity dip produced a 285-deep backlog rather than a shallow one, why it took ~24 minutes to start moving, and why it will recur on the next dip. This PR shrinks the amplifier. It does not add runners.

The consequence while it lasted was concrete: no PR could reach a green CI gate. Ready PRs all reported `mergeable_state: unstable` purely because their checks were queued — nothing failed, nothing *ran*.

### Why the volume is unbounded

17 of 30 workflows carried no `concurrency:` block, including the heaviest and most-triggered: `ci`, `codeql-analysis`, `security`, `e2e-tests`, `pr-checks`, `auto-label`, `dependency-review`.

#1447 correctly removed those workflows' base-branch filters so every PR runs the gate. That was right and this PR does not touch it — but it raised per-PR run volume without adding any deduplication to absorb it.

## Overlap with #1508 — read this before merging either

**#1508 was opened one minute before this PR and independently adds a `concurrency:` block to `ci.yml`.** An earlier revision of this body claimed no competing PR existed; that was written before #1508 appeared and is corrected here rather than left as a false checkbox.

They are complementary, and neither needs to be closed:

- **#1508's `.coderabbit.yaml` half is right and this PR doesn't have it.** Its `inheritance: false` diagnosis explains a symptom hit directly here: this PR carries `ci/cd` and `github_actions` — both on the inherited required list — and CodeRabbit *still* posts "Review skipped: excluded by label configuration". That is an inherited gate which `labels: []` alone never bound.
- **#1508's `ci.yml` half has the bug described below.** It keys non-PR runs on `github.ref` and carries a comment promising that "a rapid series of merges must not cancel each other" — which that key cannot deliver. Details in [the comment on #1508](https://github.com/groupthinking/EventRelay/pull/1508#issuecomment-5222133803).

Suggested split: #1508 keeps `.coderabbit.yaml` and drops (or re-keys) its `ci.yml` hunk; this PR keeps the workflow scheduling change across all 16 files. The reverse split is equally fine — the only thing that matters is that whichever version lands does not key main's post-merge runs on `github.ref`.

## Scope

- **Included:** a `concurrency:` block on the 14 workflows triggering on `pull_request`, `pull_request_target`, `push`, or `issues` — `ci`, `codeql-analysis`, `security`, `e2e-tests`, `pr-checks`, `dependency-review`, `api-cost-postgres`, `gh-aw-validation`, `anthropic-wif-test`, `branch-cleanup`, `dependabot-auto-merge`, `auto-label`, `auto-assign`, `issue-triage`. Plus a re-key of `coverage` and `secret-scan`, which already had groups carrying the defect below.
- **Explicitly excluded:**
  - **Any job, step, trigger, or permission.** Scheduling only.
  - **#1447's trigger design.** Untouched.
  - **`.coderabbit.yaml`** — that's #1508's, and it should stay there.
  - `bulk-issue-processor`, `real-processing`, `stale` — `workflow_dispatch`/`schedule` only, not queue pressure.
  - **Cancelling the existing backlog.** Lossy and operational; left to a human. See below.

## The design, and two corrections found in review

The first commit (`3ef52a9`) keyed groups on `github.event.pull_request.number || github.ref` with `cancel-in-progress: false` for push events, claiming push runs would "queue, so each merged commit keeps its own verdict."

**That claim was wrong, and `20cc78e` fixes it.** `cancel-in-progress: false` stops a new run cancelling a *running* one. It does not stop GitHub cancelling a *pending* one — when a run is queued into a group that already has one in progress and one pending, the pending run is cancelled. Since `github.ref` is `refs/heads/main` for every merge, all main pushes shared one group, so a burst of merges — ten in twenty minutes here — would have silently dropped the middle commits' verdicts. (This is the same bug #1508's `ci.yml` hunk currently carries.)

**A second defect, caught by the Vercel review bot, is fixed in `c00a664`.** On `check_suite` events `GITHUB_SHA` is the default-branch tip rather than the commit under test, so the `github.sha` fallback collapsed every PR's check suite into one group. `dependabot-auto-merge` now falls back to `github.event.check_suite.head_sha` first.

The shipped design:

1. **PR runs** key on `github.event.pull_request.number` and cancel their predecessors. This is where *all* queue pressure comes from — verified: every `push:` trigger across these workflows is already filtered to `main` (or `claude/branch-cleanup-*`), so pushes to PR branches fire no push runs at all.
2. **Non-PR runs** (push, schedule) key on `github.sha`, landing in singleton groups where they can neither cancel nor be cancelled. Every merged commit keeps its own verdict. This costs nothing given (1).
3. **Not `github.ref` alone** — besides the burst problem, on the two `pull_request_target` workflows `github.ref` resolves to the *base* branch, collapsing every open PR into one group where they would cancel each other.
4. **Issue-triggered workflows** keep `github.event.issue.number`; `github.sha` is meaningless for issues events. `auto-label` fires on both, so it falls through PR → issue → ref.
5. **`coverage` and `secret-scan`** predate this PR and both had the bare `github.ref` group with `cancel-in-progress: true` — the more aggressive form of the same bug. Re-keyed to match.

## Risk

- **Risk level:** low
- **Failure mode:** the change is a scheduling constraint. The realistic risk is over-cancellation — a run cancelled that someone wanted. Bounded by the design above: only PR-event runs cancel, and only by a *newer push to the same PR*, whose result supersedes it by definition. No workflow gains or loses a trigger, so no gate becomes skippable.
- **Rollback:** `git revert`. No migration, config, schema, or permission change.

## Verification

Head `c00a664`. Measured, not inferred.

- [x] **All 28 workflow files parse** — `yaml.safe_load` over `.github/workflows/*.yml`, clean at every commit.
- [x] **Group names checked for collisions** — all 27 group expressions in the repo are distinct.
- [x] **Trigger surface unchanged** — the parsed `on:` keys of all 28 files are byte-identical before and after; the whole diff lives inside new or rewritten `concurrency:` blocks.
- [x] **Push filters audited** — all 13 `push:` triggers confirmed filtered to `main`, except `branch-cleanup` (`claude/branch-cleanup-*`). This is what makes point (2) free rather than a tradeoff.
- [x] **Observed working in production, same SHA, 46-second window.** Two events hit `c00a664`: a push at 21:23:43 and `ready_for_review` at 21:24:29. Dependency Review (`pull_request`, uses the **PR head's** workflow file — has the block) **cancelled** the superseded run. PR Checks (`pull_request_target`, uses the **base branch's** file — no block yet) **stacked both**. Same PR, same commit, same window; the only variable is whether the file in play carries the block.
- [x] **Dependency Review** — passed on this head. (Empty scan is correct: this PR touches no dependency manifests.)
- [ ] **Remaining required CI** — still queued behind the backlog at last check.
- [ ] **CodeRabbit review** — blocked by the inherited label gate that #1508 diagnoses, not by anything in this diff.

**A limitation this evidence exposes:** the fix is partially self-testing but *not* self-deploying. `pull_request` workflows take effect from the PR head and are already deduplicating here. `pull_request_target` workflows (`pr-checks`, `dependabot-auto-merge`) read the *base* branch, so they keep stacking until this lands on `main`, and their behaviour **cannot be verified from this PR**. A green run here is not evidence for that half.

## Production evidence

Not applicable as a deployed artefact — CI configuration, no runtime or `apps/web/**` surface. The Vercel preview built green on all three heads.

The runtime evidence is the queue measurement and the same-SHA A/B above, both taken from the live Actions API rather than reasoned about — including the part that cuts against this PR's original framing. The post-merge check is direct and cheap: standing queue depth should sit materially lower at comparable PR volume.

## Agent handoff

- [x] One canonical issue is linked — #1519
- [ ] **A competing PR overlaps this one — #1508.** Unresolved; a reconciliation decision is requested. See above.
- [x] Acceptance criteria: run volume is deduplicated; no gate is weakened; no commit loses its verdict
- [ ] Required checks pass on the current head
- [x] Human decision requested only for: merge approval, the #1508 split, and the backlog call below

## Recommended companion action (human)

Merging does **not** clear runs already queued — concurrency groups apply to new runs only. To drain immediately, cancel the existing backlog. I did not do this unilaterally: cancelling discards CI verdicts for commits already merged to `main`, which is a call for a human, not an unattended routine.