### PR TITLE
ci: supersede stale workflow runs with concurrency groups

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   pull-requests: write
   issues: write
+# See the note in ci.yml. Keyed on the PR/issue number rather than
+# `github.ref`, which is the default branch for the `issues` event and would
+# collapse every issue into a single group.
+concurrency:
+  group: auto-label-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,17 @@ permissions:
   contents: read
   actions: read
 
+# Supersede a PR's own older runs. Without this, every push to a branch left
+# its previous CI run queued, and a burst of PR activity saturated the Actions
+# concurrency limit with runs whose results nothing would ever read.
+# `github.ref` is `refs/pull/<n>/merge` on `pull_request`, so PRs never share a
+# group with each other or with main.
+concurrency:
+  group: ci-${{ github.ref }}
+  # PRs only. A push to main is the record of whether main is green; cancelling
+  # it would leave that question unanswered for the commit that landed.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   guards:
     # Fail fast on the class of breakage that shipped to main un-caught:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,13 @@ permissions:
   security-events: write
   actions: read
 
+# See the note in ci.yml.
+concurrency:
+  group: codeql-${{ github.ref }}
+  # PRs only. A cancelled run on main or on the weekly schedule uploads no
+  # SARIF, which would silently stale the security dashboard rather than fail.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: "Security Scan - ${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,12 @@ permissions:
   contents: read
   pull-requests: write
 
+# See the note in ci.yml. This workflow is `pull_request`-only, so every run
+# is superseded by the next push to the same PR.
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,6 +12,11 @@ permissions:
   issues: write
   deployments: read
 
+# See the note in ci.yml.
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   # By default the E2E suite runs against production. To validate a PR's own
   # Vercel preview instead, two things are needed:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,6 +6,13 @@ on:
 
 permissions: {}
 
+# See the note in ci.yml. Keyed on the PR number, not `github.ref`: on
+# `pull_request_target` the ref is the *base* branch, so every open PR would
+# share one group and cancel the others. Mirrors pr-governance.yml.
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,13 @@ permissions:
   security-events: write
   actions: read
 
+# See the note in ci.yml.
+concurrency:
+  group: security-scan-${{ github.ref }}
+  # PRs only — this workflow also uploads security results on main and on the
+  # weekly schedule.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   npm-audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Canonical issue

Closes # — no issue filed; this was found by the PR-remediation routine while trying to clear the CI gate on #1483 / #1485 / #1486 / #1494. Happy to file one if the repo wants the paper trail.

## Outcome

Seven PR-triggered workflows had no `concurrency` block, so every push to a branch left its previous run **queued** rather than cancelling it.

Measured at 2026-08-07T21:12Z: **66 workflow runs live — 63 queued behind 3 executing.** Nothing was failing; nothing could finish either. Every non-draft PR sat at `mergeable_state: unstable` with its checks queued, so no PR could reach a green gate.

**21 of the 66 were superseded duplicates** — a newer run for the same workflow on the same branch already existed, and nothing would ever read the older one's result:

| Duplicates | Workflow | Branch |
|---|---|---|
| 5x | CI | `main` |
| 4x | PR Checks | `claude/clever-heisenberg-kltzfb` |
| 3x | CI | `claude/clever-heisenberg-j1yx9l` |
| 3x | Phase Goal Tracker | `main` |
| 3x | Auto Label | `main` |
| 2x each | Dependency Review, PR Checks, CI ×5, Issue Triage | various |

That is ~⅓ of the queue reclaimable by configuration alone.

## Scope

- **Included** — a `concurrency` block on `ci.yml`, `codeql-analysis.yml`, `security.yml`, `e2e-tests.yml`, `pr-checks.yml`, `dependency-review.yml`, `auto-label.yml`. 49 added lines, ~20 of them comments. No job, step, trigger, or permission changed.
- **Explicitly excluded:**
  - **The other 45 live runs.** Those are legitimate distinct runs; concurrency groups do not touch them. The queue is oversubscribed for a second reason this PR does not address — see below.
  - **The workload itself.** Whether ~8 workflows per PR event is the right gate is a policy question, not a config bug.
  - **Cancelling the current backlog.** A one-off operator action; this PR only stops it recurring.
  - **The CodeRabbit label gate** (see the reviewer note) — a dashboard/org-level setting, not fixable in-repo.
  - `phase-goal-tracker.yml` and `issue-triage.yml`, which also showed duplicates. Both are `issues`-triggered automation outside this PR's PR-gate scope.

## Two traps in the group keys

Worth a reviewer's eye, because the obvious `${{ github.ref }}` key is wrong in both cases:

1. **`pr-checks.yml` runs on `pull_request_target`**, where `github.ref` is the **base** branch (`refs/heads/main`) — not the PR. A `github.ref` key would put *every open PR in one group* and have them cancel each other, converting a queue problem into a correctness problem. Keyed on `github.event.pull_request.number`, matching what `pr-governance.yml` already does.
2. **`auto-label.yml` also runs on `issues`**, where `github.ref` is likewise the default branch — every issue would collapse into a single group. Keyed on `pull_request.number || issue.number`. PRs and issues share one numbering sequence on GitHub, so the two branches of that fallback cannot collide.

For the five `pull_request`-triggered workflows `github.ref` is `refs/pull/<n>/merge`, which is already unique per PR.

## `cancel-in-progress` is deliberately not uniform

`true` only on the two PR-only workflows (`dependency-review`, `pr-checks`). The four that also run on `push`/`schedule` use `${{ github.event_name == 'pull_request' }}`:

- A push to `main` is the record of whether main is green. Cancelling it leaves that unanswered for the commit that landed.
- A cancelled **CodeQL** or **Security Scan** run uploads no SARIF. That stales the security dashboard *silently* rather than failing loudly — the worst failure shape for a security gate.

This diverges from `coverage.yml` / `secret-scan.yml`, which use an unconditional `true`. Flagging rather than quietly matching them: those two may want the same treatment, but changing them is not this PR's business.

## Risk

- **Risk level:** low — configuration only, no job logic touched.
- **Failure mode:** a mis-scoped group key cancels runs that should have proceeded. That is exactly the trap called out above, and the reason two of the seven are keyed on issue/PR number instead of `github.ref`. A cancelled required check reports as `cancelled`, not `success`, so the failure would be visible at the merge gate rather than silent.
- **Rollback:** `git revert`. Behaviour returns to unbounded queuing immediately; no state to migrate.

## Verification

Head `a095dc6`.

- [x] **actionlint 1.7.7** — clean on all seven files.
- [x] **YAML parses**, and each `concurrency` block was read back to confirm the group key and cancel condition resolve as intended per triggering event.
- [x] **Trigger sets unchanged** — `on:` blocks re-parsed and compared; no workflow gained or lost an event.
- [ ] **Required CI** — cannot be demonstrated on this head. This PR's own checks enter the same saturated queue it exists to drain. The first real evidence will be the run count settling after it lands.
- [x] **Review threads resolved** — none open.

## Production evidence

Not applicable — CI configuration, no runtime or UI surface.

The operational evidence is the queue measurement above, taken from the Actions API rather than inferred: 63 queued / 3 in progress, grouped by `(workflow, branch)` to identify the 21 superseded runs.

## Agent handoff

- [ ] One canonical issue is linked — none filed; see the top of this PR
- [x] No competing PR implements the same issue — no other open PR touches these `concurrency` blocks
- [x] Acceptance criteria are satisfied — superseded runs are cancelled; no gate loses coverage on main or on schedule
- [ ] Required checks pass on the current head — blocked on the backlog this PR addresses
- [x] Human decision is requested only for: merge approval

## Note for reviewers

Two things this PR does **not** fix, both found alongside it.

### 1. The queue is oversubscribed at the source

Nine PRs (#1475–#1497) were opened in an 11-minute window by an automated remediation routine, each firing ~8 workflows. Concurrency groups reclaim the duplicate third; they do not address the burst. If that routine keeps opening PRs at that rate, the queue stays saturated.

### 2. #1425's CodeRabbit fix did not take — auto-review is still off

**This supersedes a vaguer note in the first revision of this description; the mechanism is now pinned.**

`.coderabbit.yaml:45` sets `labels: []`, added by **#1425** (`c576b54`) specifically to override an inherited org-level required-labels gate. Its comment describes the deadlock exactly: the gate demands one of ~26 labels, a PR opens unlabelled, so the review is skipped and no label is ever applied to un-skip it.

**The override is not working.** CodeRabbit's own run report on this PR (Run ID `60743c8d-31da-4804-8e23-e241981b2918`) says:

> Review skipped — Auto reviews are limited based on label configuration.
> Required labels (at least one): `['architecture-gap', 'bug', 'ci-cd', 'ci/cd', 'copilot-rabbit', … 'v0']`
>
> Configuration used: **Repository YAML (base), Repository UI (inherited), Organization UI (inherited)**

That is the same ~26-label set #1425's comment describes, still armed, with the repo YAML loaded. Evidence it is not merely the draft rule (`drafts: false`):

| PR | Draft? | Labels | CodeRabbit |
|---|---|---|---|
| #1483 | **no** | none | `Review skipped: excluded by label configuration` |
| #1494 | **no** | none | `Review skipped: excluded by label configuration` |
| #1486 | **no** | `javascript`, `tests` | `Review rate limited` — passed the gate, hit quota |
| #1511 | yes | none | `Review skipped: excluded by label configuration` |

Two non-draft PRs skipped for labels, and the one non-draft PR that *had* a matching label got through to a different failure. So the gate is live and `labels: []` is not clearing it.

Likely cause is the hazard `.coderabbit.yaml`'s own header warns about (lines 7–10): with `inheritance: true`, an empty list reads as *unset* and the inherited value layers back in. The two candidate remedies — `inheritance: false`, or removing the required-labels list in the Organization UI — both have blast radius beyond this PR (the first drops **all** org-level config), so I am flagging rather than guessing. **Not fixable in-repo either way if it is the org setting.**

Practical consequence today: **any process step that assumes a CodeRabbit review gates these PRs is a no-op**, and has been since before #1425 was believed to fix it. Reviews must be requested by hand with `@coderabbitai review`.

## Agent provenance

Produced by a scheduled, unattended PR-remediation routine running under the repo owner's account. Left as a **draft**; it halts at the human merge-approval gate and requests no auto-merge to protected `main`.