### PR TITLE
test(web): pin both edges of the SSRF guard's IPv6 bit-mask ranges

### DIFF
--- a/apps/web/src/lib/__tests__/ssrf-guard-range-boundaries.test.ts
+++ b/apps/web/src/lib/__tests__/ssrf-guard-range-boundaries.test.ts
@@ -35,7 +35,11 @@ describe('assertPublicHttpUrl IPv6 range boundaries', () => {
     try {
       await assertPublicHttpUrl(url);
     } catch (err) {
-      return err as Error;
+      // `catch` binds as `unknown`; narrow rather than assert, so a non-Error
+      // throw surfaces as itself instead of being mistyped as an Error and
+      // failing later on a missing `.message`.
+      if (err instanceof Error) return err;
+      throw err;
     }
     throw new Error(`${url} was expected to be rejected, but was allowed`);
   };
@@ -65,8 +69,11 @@ describe('assertPublicHttpUrl IPv6 range boundaries', () => {
   });
 
   describe('100::/64 discard', () => {
-    it('rejects [100::] (first address in the range)', async () => {
-      const err = await rejectionOf('http://[100::]/');
+    it.each([
+      ['100::', 'first address in the range'],
+      ['100:0:0:0:ffff:ffff:ffff:ffff', 'last address in the range'],
+    ])('rejects [%s] (%s)', async (address) => {
+      const err = await rejectionOf(`http://[${address}]/`);
 
       expect(err.message).toBe('Blocked private IP literal');
     });

--- a/apps/web/src/lib/__tests__/ssrf-guard-range-boundaries.test.ts
+++ b/apps/web/src/lib/__tests__/ssrf-guard-range-boundaries.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(),
+}));
+
+import * as dns from 'node:dns/promises';
+import { assertPublicHttpUrl } from '@/lib/ssrf-guard';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.mocked(dns.lookup).mockReset();
+});
+
+/**
+ * Boundary coverage for the IPv6 range checks in `ipIsPrivate`.
+ *
+ * `ssrf-guard.test.ts` establishes that each blocked range *is* blocked — it
+ * walks NAT64, 6to4, IPv4-translated, site-local and discard with an address
+ * squarely inside each. That is the "too narrow" direction: a check that missed
+ * would let an address through.
+ *
+ * Nothing yet holds the other direction. `fec0::/10` and `100::/64` are the two
+ * checks written as bit masks rather than exact matches, and a mask that is too
+ * *wide* fails silently in the opposite way — it refuses public space, and the
+ * only symptom is a legitimate fetch being rejected with the same uniform
+ * message every other rejection uses. Neither edge of either mask is pinned
+ * today, so widening one would break no test.
+ *
+ * Each range therefore gets both edges plus a just-outside neighbour.
+ */
+describe('assertPublicHttpUrl IPv6 range boundaries', () => {
+  const rejectionOf = async (url: string): Promise<Error> => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await assertPublicHttpUrl(url);
+    } catch (err) {
+      return err as Error;
+    }
+    throw new Error(`${url} was expected to be rejected, but was allowed`);
+  };
+
+  describe('fec0::/10 site-local', () => {
+    it.each([
+      ['fec0::', 'first address in the range'],
+      ['feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', 'last address in the range'],
+    ])('rejects [%s] (%s)', async (address) => {
+      const err = await rejectionOf(`http://[${address}]/`);
+
+      expect(err.message).toBe('Blocked private IP literal');
+    });
+
+    /**
+     * `fe00::1` sits below `fec0::/10` and is not caught by `fe80::/10` either,
+     * so it lands in the gap between the two masks. If the site-local check were
+     * widened to `fe00::/8` — an easy slip, since both start `fe` — this is the
+     * address that would start being refused.
+     */
+    it('still allows [fe00::1], which is below the range', async () => {
+      const url = await assertPublicHttpUrl('http://[fe00::1]/');
+
+      expect(url.hostname).toBe('[fe00::1]');
+      expect(dns.lookup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('100::/64 discard', () => {
+    it('rejects [100::] (first address in the range)', async () => {
+      const err = await rejectionOf('http://[100::]/');
+
+      expect(err.message).toBe('Blocked private IP literal');
+    });
+
+    /**
+     * The discard prefix is a /64, not a /16 or /32. Both of these share the
+     * leading `100` hextet and would be refused if the check tested only `h[0]`.
+     */
+    it.each([
+      ['100:0:0:1::1', 'inside 100::/16 but outside the /64'],
+      ['101::1', 'adjacent prefix'],
+    ])('still allows [%s] (%s)', async (address) => {
+      const url = await assertPublicHttpUrl(`http://[${address}]/`);
+
+      expect(url.hostname).toBe(`[${address}]`);
+    });
+  });
+
+  /**
+   * `ipv6ToHextets` folds a trailing dotted quad into two hextets before any
+   * range check runs, so the dotted spelling of a NAT64 address has to reach the
+   * same verdict as the hex one. `ssrf-guard.test.ts` covers
+   * `64:ff9b::a9fe:a9fe`; this is the same destination written the other way.
+   */
+  it('rejects the dotted-quad spelling of a NAT64 address', async () => {
+    const err = await rejectionOf('http://[64:ff9b::169.254.169.254]/');
+
+    expect(err.message).toBe('Blocked private IP literal');
+  });
+
+  /**
+   * The same boundaries via DNS answers rather than URL literals. The two paths
+   * reach `ipIsPrivate` through different branches of `assertPublicHttpUrl` and
+   * report different messages, so a regression could land on one and not the
+   * other.
+   */
+  describe('applied to resolved addresses', () => {
+    it('rejects a site-local answer at the top of the range', async () => {
+      vi.mocked(dns.lookup).mockResolvedValue([{ address: 'feff::1', family: 6 }] as never);
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(assertPublicHttpUrl('https://edge.example/a.mp3')).rejects.toThrow(
+        'Host does not resolve to a public address',
+      );
+    });
+
+    it('still allows an answer just outside the discard prefix', async () => {
+      vi.mocked(dns.lookup).mockResolvedValue([{ address: '101::1', family: 6 }] as never);
+
+      const url = await assertPublicHttpUrl('https://edgeok.example/a.mp3');
+
+      expect(url.hostname).toBe('edgeok.example');
+    });
+  });
+});


### PR DESCRIPTION
## Canonical issue

Closes #1520

> **Rescoped mid-run, and the production change was dropped.** This PR originally carried a fix for the IPv6 transition-prefix gap (NAT64 / 6to4 / IPv4-translated / site-local / discard). **#1486 merged that fix first**, as `f876787`, having absorbed the same CodeRabbit finding. Rather than argue for a duplicate, the branch was rebuilt on top of it and reduced to the one thing `main` still lacks. Details in "What happened to the original change" below — including the case where my version was **worse**.

## Outcome

`ipIsPrivate` blocks two IPv6 ranges with bit masks rather than exact matches:

```ts
if ((h[0] & 0xffc0) === 0xfec0) return true;                                  // fec0::/10 site-local
if (h[0] === 0x0100 && h[1] === 0 && h[2] === 0 && h[3] === 0) return true;   // 100::/64 discard
```

`ssrf-guard.test.ts` covers the **too-narrow** direction thoroughly — every blocked range has an address squarely inside it. Nothing covers **too-wide**, and neither edge of either mask is pinned.

That asymmetry matters because a too-wide mask fails silently. It refuses legitimate public destinations, and the only symptom is a rejection carrying the same uniform message every other rejection uses — the indistinguishability property #1381 introduced on purpose. Nothing separates "correctly blocked" from "wrongly blocked" at the call site.

Both plausible slips are within a character of the current code: `0xffc0`/`0xfec0` → `0xff00`/`0xfe00` widens site-local to `fe00::/8`; dropping the `h[1]`–`h[3]` conjunction widens the discard prefix from a `/64` to a `/16`.

## Scope

- **Included:** `apps/web/src/lib/__tests__/ssrf-guard-range-boundaries.test.ts` — new file, 10 tests. Both edges of each masked range, a just-outside neighbour of each, and the dotted-quad spelling of a NAT64 address that `ssrf-guard.test.ts` already covers in hex.
- **Explicitly excluded:** **all detection logic.** `main` is correct as of #1486. Not one line of `ssrf-guard.ts` changes; this PR is one new test file and nothing else.

## Risk

- **Risk level:** minimal — test-only, no production file touched.
- **Failure mode:** none at runtime. The tests could in principle over-constrain a future deliberate widening of either range, which is the intent: such a change should have to edit a failing test that explains the boundary.
- **Rollback:** delete the file.

## Verification

Head `75a901d`, based on `main` @ `f876787`.

- [x] **Focused tests** — 10 cases, all passing.
- [x] **Non-vacuity shown by mutation, not by failing against `main`.** These pass on `main` by construction — there is no bug here, which is exactly why the usual "revert the fix and watch it fail" check does not apply. Saying so plainly rather than letting them look like fix-pinning tests. Each mutant is caught by precisely the test that claims to cover it:

  | mutation | result |
  |---|---|
  | `(h[0] & 0xffc0) === 0xfec0` → `(h[0] & 0xff00) === 0xfe00` | `1 failed \| 9 passed` — *still allows [fe00::1], which is below the range* |
  | `h[0] === 0x0100 && h[1..3] === 0` → `h[0] === 0x0100` | `1 failed \| 9 passed` — *still allows [100:0:0:1::1] (inside 100::/16, outside the /64)* |
  | `h[0] === 0x0100 && h[1..3] === 0` → exact match on `100::` alone | `1 failed \| 9 passed` — *rejects [100:0:0:0:ffff:ffff:ffff:ffff] (last address in the range)* |

  The third mutant is the regression CodeRabbit identified in review. It **survived the first version of this file** — that gap was real, and closing it is what the second commit does.
- [x] **Both entry paths covered** — URL literals and DNS answers reach `ipIsPrivate` through different branches of `assertPublicHttpUrl` and report different messages (`Blocked private IP literal` vs `Host does not resolve to a public address`), so a regression can land on one and not the other.
- [x] **Full apps/web suite** — 59 files, **355 passed, 0 failed**.
- [x] `npx tsc --noEmit` — clean. `npm run lint` — clean.
- [x] **Required CI green on `75a901d`** — 26 checks, zero failures: `test-frontend`, `test`, `build`, `guards`, `lint-frontend`, `lint-python`, `validate`, `PR Governance`, `Canonical issue and evidence`, both Security Scans, `bandit`, `trivy`, `python-safety`, `npm-audit`, `gitleaks`, `dependency-review`, `CodeQL`, `Coverage`, Vercel.
- [x] **The new tests are genuinely gated, not vacuously green** — `ci.yml`'s `test-frontend` runs `cd apps/web && npx vitest run`, and the job log shows `✓ src/lib/__tests__/ssrf-guard-range-boundaries.test.ts` **by name**. A green total alone would not distinguish "ran and passed" from "never collected".
- [x] **Review threads resolved** — both CodeRabbit findings addressed in `75a901d` and confirmed by CodeRabbit.

## Review findings addressed

CodeRabbit requested changes on `2d65d6d`; both were valid and are fixed in `75a901d`.

1. **`err as Error` in the `rejectionOf` helper** — an unsafe assertion on a value `catch` binds as `unknown`, which `.cursorrules` forbids outright. Narrowed with `instanceof` and rethrow, so a non-Error throw surfaces as itself rather than being mistyped and failing later on a missing `.message`.
2. **`100::/64` was pinned only at its first address.** This contradicted the file's own premise — `fec0::/10` gets both edges, and the entire argument here is that one edge does not hold a range. `100:0:0:0:ffff:ffff:ffff:ffff` added, and the mutation above proves it catches the regression.

## What happened to the original change

Recording this because the conclusion is that I was wrong, and that is worth stating rather than quietly force-pushing over.

This branch originally implemented the transition-prefix fix independently. #1486 landed the same fix first. On comparing them, `main`'s implementation is a **strict superset** — and on one case mine was **less safe**:

| input | mine | `main` (#1486) |
|---|---|---|
| `64:ff9b:1::a00:1` — RFC 8215 local-use NAT64 `64:ff9b:1::/48` | fell through to `return false` → **allowed** | matches `64:ff9b`, is not the exact `/96`, → **blocked** |

`main` blocks the whole of `64:ff9b::/32` outside the well-known `/96`, on the reasoning that anything else in that prefix is local-use by definition and guessing where its embedded IPv4 sits would be worse than refusing it. That is the better call. My version had a test asserting the permissive behaviour, which would have encoded the weaker posture into the suite.

So the production commits were dropped rather than rebased — merging them would have regressed `main`. Only unmerged work of my own was discarded; no merged history was touched. What survives is the part `main` genuinely lacks, rewritten against `main`'s actual behaviour.

I also filed the finding on #1486 ([comment](https://github.com/groupthinking/EventRelay/pull/1486#issuecomment-5222114672)) correcting my own earlier framing of it as "a regression in #1486" — it was reachable on `main` via DNS answers before #1486 existed.

## Production evidence

Not applicable — test-only, no runtime behaviour changes and no `apps/web` UI surface. Vercel preview builds green.

## Agent handoff

- [x] One canonical issue is linked — #1520
- [x] No competing PR implements the same issue — #1486 is merged; this covers the gap its own tests leave.
- [x] Acceptance criteria are satisfied — all five on #1520, including the mutation requirement.
- [x] Required checks pass on the current head — 26 green, zero failures on `75a901d`.
- [x] Human decision is requested only for: merge approval.

One outstanding item is **not** something I can satisfy myself: CodeRabbit's `Enforce Copilot Verification` pre-merge check wants an explicit GitHub Copilot approval plus the `copilot-rabbit` label. I requested a Copilot review rather than adding the label, since adding it myself would assert that a review happened when it has not. If the repo wants that gate satisfied, it needs the Copilot review to actually land.

## Agent provenance

Produced by a scheduled, unattended PR-remediation routine running under the repo owner's account. It halts at the human gate — no auto-merge to protected `main` is requested or performed. The branch was force-pushed once, replacing two unmerged commits of my own with the rescoped `2d65d6d`; `75a901d` then applied the review fixes on top.