### PR TITLE
fix(web): let public Studio Act on findings start without a session

### DIFF
--- a/apps/web/src/__tests__/proxy-auth-gate.test.ts
+++ b/apps/web/src/__tests__/proxy-auth-gate.test.ts
@@ -111,6 +111,36 @@ describe('login gate must fail closed (issue #1058)', () => {
     expect(response.status).not.toBe(503);
   });
 
+  it('lets public Studio Act on findings through when the secret IS configured', async () => {
+    const { proxy, NextRequest } = await loadProxy({
+      NEXTAUTH_SECRET: 'test-secret',
+      NODE_ENV: 'production',
+      AUTH_ALLOW_UNAUTHENTICATED: undefined,
+    });
+
+    const start = await proxy(
+      new NextRequest('https://app.example.com/api/workflows/video-to-actions', {
+        method: 'POST',
+      }),
+    );
+    expect(start.status).not.toBe(401);
+    expect(start.status).not.toBe(503);
+
+    const poll = await proxy(
+      new NextRequest('https://app.example.com/api/workflows/video-to-actions/run_1'),
+    );
+    expect(poll.status).not.toBe(401);
+    expect(poll.status).not.toBe(503);
+
+    // Sibling workflow surfaces stay gated — WDK C deploy must not inherit this.
+    const other = await proxy(
+      new NextRequest('https://app.example.com/api/workflows/studio-deploy', {
+        method: 'POST',
+      }),
+    );
+    expect(other.status).toBe(401);
+  });
+
   it('leaves local development unchanged (no secret, no 503)', async () => {
     const { proxy, NextRequest } = await loadProxy({
       NEXTAUTH_SECRET: undefined,

--- a/apps/web/src/lib/__tests__/auth-paths.test.ts
+++ b/apps/web/src/lib/__tests__/auth-paths.test.ts
@@ -37,6 +37,20 @@ describe('auth path policy', () => {
     expect(needsAuthentication('/api/pipeline/stream')).toBe(false);
   });
 
+  it('keeps Studio Act on findings (WDK video-to-actions) reachable without a session', () => {
+    // /studio is a public page. The durable start + poll endpoints must match
+    // that surface — otherwise Act on findings 401s with "Authentication
+    // required" and never returns a runId (2026-08-13 uvai.io smoke).
+    expect(isPublicApiPath('/api/workflows/video-to-actions')).toBe(true);
+    expect(isPublicApiPath('/api/workflows/video-to-actions/run_abc')).toBe(true);
+    expect(needsAuthentication('/api/workflows/video-to-actions')).toBe(false);
+    expect(needsAuthentication('/api/workflows/video-to-actions/run_abc')).toBe(false);
+    // Do not widen the whole /api/workflows tree or a prefix-sibling.
+    expect(isPublicApiPath('/api/workflows')).toBe(false);
+    expect(isPublicApiPath('/api/workflows/studio-deploy')).toBe(false);
+    expect(needsAuthentication('/api/workflows/studio-deploy')).toBe(true);
+  });
+
   it('still gates non-allowlisted billing routes', () => {
     // A sibling billing route with no explicit exemption stays protected —
     // guards against prefix-match over-exposure.

--- a/apps/web/src/lib/auth-paths.ts
+++ b/apps/web/src/lib/auth-paths.ts
@@ -7,6 +7,9 @@
 const PUBLIC_API_PREFIXES = [
   '/api/auth', // NextAuth sign-in / callback / csrf / session
   '/api/health', // ops probes (if present)
+  // Studio "Act on findings" (WDK B) — public page, durable start + poll.
+  // Sibling /api/workflows/* routes stay gated; this prefix is exact-segment.
+  '/api/workflows/video-to-actions',
 ] as const;
 
 /** Exact public API paths (prefix match would over-expose siblings). */


### PR DESCRIPTION
## Canonical issue

Closes #1535

## Outcome

Anonymous visitors on `/studio` can start and poll the durable **Act on findings** workflow. They no longer get `401 Authentication required` and a missing `runId`.

## Scope

- **Included:**
  - `auth-paths.ts` — add `/api/workflows/video-to-actions` to `PUBLIC_API_PREFIXES` (exact + `prefix/` children).
  - `auth-paths.test.ts` — public start/poll; sibling `/api/workflows/studio-deploy` and `/api/workflows` stay gated.
  - `proxy-auth-gate.test.ts` — with `NEXTAUTH_SECRET` set in production, start/poll are not 401/503; sibling POST is still 401.
- **Explicitly excluded:**
  - **`/api/pipeline` public.** Deploy still 401s for anonymous users. That is the FastAPI path / WDK C, not this smoke fail.
  - **Widening all of `/api/workflows`.** Future durable deploy routes stay session-gated until we choose otherwise.
  - **Production promote.** Live uvai.io is still SHA `f8767871c8`; this PR does not redeploy.

## Risk

- **Risk level:** low
- **Failure mode:** the durable Act path becomes callable without a session, which is what the public Studio page already advertises. Rate-limit (AI budget on POST) and SSRF checks on the URL remain. Status GET is a stored-run read.
- **Rollback:** revert the commit. No migration, env, or response-shape change.

## Verification

- [x] `npx vitest run src/lib/__tests__/auth-paths.test.ts src/__tests__/proxy-auth-gate.test.ts` — **30 passed**
- [ ] Required CI on this head
- [x] Review threads resolved — none open

## Production evidence

2026-08-13 smoke @ https://uvai.io/studio (`dpl_98YSSCZG4fxpLrgNBMjt1uKZ9vir`):

- TinyFish: `Could not start durable workflow: Authentication required` (no runId)
- Same-origin `fetch` from the Studio page: POST `/api/workflows/video-to-actions` → 401
- curl: same 401. Session `{}`. No cookies.

This PR is the B-path fix. Smoke must be re-run after it is on the *serving* production SHA.

## Agent handoff

- [x] One canonical issue is linked — #1535
- [x] No competing PR implements the same issue
- [x] Acceptance criteria are in the issue
- [ ] Required checks pass on the current head — first run pending
- [x] Human decision is requested only for: merge approval (standing rule: auto-merge when CLEAN)