### PR TITLE
fix(web): skip Sentry OTel setup so WDK undici start() can dispatch

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,3 +1,8 @@
+// Must be set before Sentry/Next instrument fetch. @workflow/world-vercel
+// passes an undici Agent as fetch's dispatcher; any wrap of dispatch() reads
+// private field #P on the wrong class copy (#1538).
+process.env.NEXT_OTEL_FETCH_DISABLED = '1';
+
 import * as Sentry from '@sentry/nextjs';
 
 export async function register() {

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -1,10 +1,15 @@
 import * as Sentry from '@sentry/nextjs';
-import { sentryServerIntegrations } from '@/lib/sentry-server-integrations';
+import {
+  SENTRY_SERVER_SKIP_OTEL_SETUP,
+  sentryServerIntegrations,
+} from '@/lib/sentry-server-integrations';
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1,
   debug: false,
-  // Drop NodeFetch/undici wrapping — see sentry-server-integrations.ts / #1538.
+  // Drop NodeFetch *and* skip Sentry's OTel setup. #1539 filtered NodeFetch
+  // and still 500'd on production: initOpenTelemetry() re-wraps undici.
+  skipOpenTelemetrySetup: SENTRY_SERVER_SKIP_OTEL_SETUP,
   integrations: sentryServerIntegrations,
 });

--- a/apps/web/src/lib/__tests__/sentry-server-integrations.test.ts
+++ b/apps/web/src/lib/__tests__/sentry-server-integrations.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   SENTRY_INTEGRATIONS_UNSAFE_FOR_WDK,
+  SENTRY_SERVER_SKIP_OTEL_SETUP,
   WORKFLOW_UNDICI_DISPATCH_CODE,
   sentryServerIntegrations,
   withoutWorkflowBreakingIntegrations,
@@ -22,6 +23,11 @@ describe('withoutWorkflowBreakingIntegrations (issue #1538)', () => {
   it('is a no-op when NodeFetch is not present', () => {
     const input = [{ name: 'Http' }, { name: 'LinkedErrors' }];
     expect(withoutWorkflowBreakingIntegrations(input)).toEqual(input);
+  });
+
+  it('requires skipOpenTelemetrySetup — filtering NodeFetch alone is not enough', () => {
+    // #1539 deployed to uvai.io and still returned WORKFLOW_UNDICI_DISPATCH_CONFLICT.
+    expect(SENTRY_SERVER_SKIP_OTEL_SETUP).toBe(true);
   });
 
   it('is the Sentry.init integrations callback', () => {

--- a/apps/web/src/lib/sentry-server-integrations.ts
+++ b/apps/web/src/lib/sentry-server-integrations.ts
@@ -29,6 +29,12 @@ export function sentryServerIntegrations<T extends { name: string }>(
   return withoutWorkflowBreakingIntegrations(integrations);
 }
 
+/**
+ * Sentry Node still wraps undici inside `initOpenTelemetry()` even after
+ * NodeFetch is filtered (#1539 shipped, production still `#P`). Must stay true.
+ */
+export const SENTRY_SERVER_SKIP_OTEL_SETUP = true;
+
 export const WORKFLOW_UNDICI_DISPATCH_CODE = 'WORKFLOW_UNDICI_DISPATCH_CONFLICT';
 
 export function workflowStartErrorBody(err: unknown): {


### PR DESCRIPTION
## Canonical issue

Closes #1538

## Outcome

Studio Act on findings can call Workflow DevKit start() without undici throwing Cannot read private member #P at Proxy.dispatch.

## Scope

- Included: skipOpenTelemetrySetup on the Node Sentry client; NEXT_OTEL_FETCH_DISABLED=1 at the top of instrumentation.ts; keep the NodeFetch filter from #1539.
- Explicitly excluded: turning Sentry off; WDK C; changing the workflow package.

## Risk

- Risk level: medium
- Failure mode: Sentry will not auto-install its OpenTelemetry pipeline on the Node server. Incoming Next.js request traces can still exist. Outgoing fetch spans from Sentry OTel will not. That outgoing wrap is what 500s start().
- Rollback: revert the commit.

## Verification

- [x] Focused tests — 9 passed including SENTRY_SERVER_SKIP_OTEL_SETUP must stay true (regression of #1539).
- [ ] Required CI
- [x] Review threads resolved — none on this new PR

## Production evidence

After #1539, production dpl_21QEbdLZiiG8N6KPWtss76V3hoss still returned HTTP 500 with code WORKFLOW_UNDICI_DISPATCH_CONFLICT and error fetch failed. That proves NodeFetch filtering shipped and is insufficient. This PR addresses the remaining wrap (initOpenTelemetry / Next fetch instrumentation).

## Agent handoff

- [x] One canonical issue is linked
- [x] No competing PR implements the same issue
- [x] Acceptance criteria are the production 500 gone
- [ ] Required checks pass on the current head
- [x] Human decision is requested only for merge-when-CLEAN
