### PR TITLE
fix(web): run WDK start() on the same undici fetch as its Agent

### DIFF
--- a/apps/web/src/app/api/workflows/video-to-actions/route.ts
+++ b/apps/web/src/app/api/workflows/video-to-actions/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { start } from 'workflow/api';
 import { workflowStartErrorBody } from '@/lib/sentry-server-integrations';
+import { withWorldVercelFetch } from '@/lib/world-vercel-fetch';
 import { videoToActionsWorkflow } from '@/workflows/video-to-actions';
 
 export const runtime = 'nodejs';
@@ -54,7 +55,9 @@ export async function POST(request: Request): Promise<NextResponse> {
     typeof body.videoTitle === 'string' ? body.videoTitle.slice(0, 200) : undefined;
 
   try {
-    const run = await start(videoToActionsWorkflow, [{ url, videoTitle }]);
+    const run = await withWorldVercelFetch(() =>
+      start(videoToActionsWorkflow, [{ url, videoTitle }]),
+    );
     return NextResponse.json({
       ok: true,
       runId: run.runId,

--- a/apps/web/src/lib/__tests__/world-vercel-fetch.test.ts
+++ b/apps/web/src/lib/__tests__/world-vercel-fetch.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { withWorldVercelFetch } from '@/lib/world-vercel-fetch';
+
+describe('withWorldVercelFetch (issue #1538)', () => {
+  it('restores global fetch after success', async () => {
+    const original = globalThis.fetch;
+    await withWorldVercelFetch(async () => 'ok');
+    expect(globalThis.fetch).toBe(original);
+  });
+
+  it('restores global fetch after a throw', async () => {
+    const original = globalThis.fetch;
+    await expect(
+      withWorldVercelFetch(async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+    expect(globalThis.fetch).toBe(original);
+  });
+
+  it('runs the callback while fetch is rebound', async () => {
+    const original = globalThis.fetch;
+    const seen = await withWorldVercelFetch(async () => globalThis.fetch);
+    expect(seen).not.toBe(original);
+    expect(globalThis.fetch).toBe(original);
+  });
+});

--- a/apps/web/src/lib/world-vercel-fetch.ts
+++ b/apps/web/src/lib/world-vercel-fetch.ts
@@ -1,0 +1,21 @@
+/**
+ * `@workflow/world-vercel` builds an `undici.Agent` from the npm `undici`
+ * package (7.28.0 in its package.json) and passes it as `fetch(..., { dispatcher })`.
+ *
+ * On Vercel, `globalThis.fetch` is Node 22 / Next's fetch (undici 6). An Agent
+ * from undici 7 is a different class — `dispatch` then throws
+ * `Cannot read private member #P` (issue #1538). Sentry wrapping only puts
+ * `Proxy.dispatch` on the stack; #1541 proved skipOpenTelemetrySetup is not enough.
+ *
+ * Bind global fetch to the *same* `undici` module for the duration of `start()`.
+ */
+export async function withWorldVercelFetch<T>(fn: () => Promise<T>): Promise<T> {
+  const { fetch: undiciFetch } = await import('undici');
+  const previous = globalThis.fetch;
+  globalThis.fetch = undiciFetch as unknown as typeof fetch;
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = previous;
+  }
+}


### PR DESCRIPTION
## Canonical issue

Closes #1538

## Outcome

Studio Act on findings can start a durable run. start() no longer throws fetch failed / private member #P because the undici Agent and fetch now come from the same module.

## Scope

- Included: withWorldVercelFetch around start(); unit tests that fetch is rebound and restored; restore on throw.
- Explicitly excluded: Sentry off; undici version override in package-lock; WDK C.

## Risk

- Risk level: medium
- Failure mode: for the duration of start(), global fetch is undici's fetch. start() is short-lived. Restored in finally. Other concurrent requests on the same isolate could briefly see undici fetch — same isolate concurrency is possible on Node. That is accepted to fix production 500s.
- Rollback: revert the commit.

## Verification

- [x] Focused tests — 12 passed (world-vercel-fetch + prior 1538 suites).
- [ ] Required CI
- [x] Review threads resolved — none yet

## Production evidence

dpl_98B8Ppva3RceqGP2rJaoitsGvPjE (#1541, skipOpenTelemetrySetup) still returned HTTP 500 WORKFLOW_UNDICI_DISPATCH_CONFLICT. That rules out Sentry OTel as the only wrap. world-vercel declares undici 7.28.0; Node 22 fetch is undici 6. This PR aligns them for start().

## Agent handoff

- [x] One canonical issue is linked
- [x] No competing PR implements the same issue
- [x] Acceptance criteria are a production runId
- [ ] Required checks pass on the current head
- [x] Human decision is requested only for merge-when-CLEAN


