### PR TITLE
feat(web): durable Studio deploy via Workflow DevKit (C)

### DIFF
--- a/apps/web/src/app/api/workflows/studio-deploy/[runId]/route.ts
+++ b/apps/web/src/app/api/workflows/studio-deploy/[runId]/route.ts
@@ -24,27 +24,30 @@ export async function GET(
       );
     }
 
-    const runStatus = await run.status;
+    const [runStatus, workflowName, createdAt, startedAt, completedAt] =
+      await Promise.all([
+        run.status,
+        run.workflowName.catch(() => undefined),
+        run.createdAt.then((d) => d.toISOString()).catch(() => undefined),
+        run.startedAt.then((d) => d?.toISOString()).catch(() => undefined),
+        run.completedAt.then((d) => d?.toISOString()).catch(() => undefined),
+      ]);
+
     const payload: Record<string, unknown> = {
       ok: true,
       runId,
       runStatus,
-      workflowName: await run.workflowName.catch(() => undefined),
-      createdAt: await run.createdAt.then((d) => d.toISOString()).catch(() => undefined),
-      startedAt: await run.startedAt
-        .then((d) => d?.toISOString())
-        .catch(() => undefined),
-      completedAt: await run.completedAt
-        .then((d) => d?.toISOString())
-        .catch(() => undefined),
+      workflowName,
+      createdAt,
+      startedAt,
+      completedAt,
     };
 
     if (runStatus === 'completed' || runStatus === 'failed') {
       try {
         payload.result = await run.returnValue;
-      } catch (err) {
-        payload.error =
-          err instanceof Error ? err.message : 'Failed to read workflow return value';
+      } catch {
+        payload.error = 'Failed to read workflow return value';
       }
     }
 
@@ -59,12 +62,7 @@ export async function GET(
     }
     console.error('[api/workflows/studio-deploy/:runId]', err);
     return NextResponse.json(
-      {
-        ok: false,
-        runId,
-        error: message,
-        hint: 'Ensure the workflow package is installed and withWorkflow wraps next.config.',
-      },
+      { ok: false, runId, error: 'Failed to read workflow run' },
       { status: 500 },
     );
   }

--- a/apps/web/src/app/api/workflows/studio-deploy/[runId]/route.ts
+++ b/apps/web/src/app/api/workflows/studio-deploy/[runId]/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+import { getRun } from 'workflow/api';
+import type { StudioDeployResult } from '@/workflows/studio-deploy';
+
+export const runtime = 'nodejs';
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ runId: string }> },
+): Promise<NextResponse> {
+  const { runId: raw } = await context.params;
+  const runId = typeof raw === 'string' ? raw.trim() : '';
+  if (!runId || runId.length > 200) {
+    return NextResponse.json({ error: 'runId is required' }, { status: 400 });
+  }
+
+  try {
+    const run = getRun<StudioDeployResult>(runId);
+    const exists = await run.exists;
+    if (!exists) {
+      return NextResponse.json(
+        { ok: false, runId, error: 'Workflow run not found' },
+        { status: 404 },
+      );
+    }
+
+    const runStatus = await run.status;
+    const payload: Record<string, unknown> = {
+      ok: true,
+      runId,
+      runStatus,
+      workflowName: await run.workflowName.catch(() => undefined),
+      createdAt: await run.createdAt.then((d) => d.toISOString()).catch(() => undefined),
+      startedAt: await run.startedAt
+        .then((d) => d?.toISOString())
+        .catch(() => undefined),
+      completedAt: await run.completedAt
+        .then((d) => d?.toISOString())
+        .catch(() => undefined),
+    };
+
+    if (runStatus === 'completed' || runStatus === 'failed') {
+      try {
+        payload.result = await run.returnValue;
+      } catch (err) {
+        payload.error =
+          err instanceof Error ? err.message : 'Failed to read workflow return value';
+      }
+    }
+
+    return NextResponse.json(payload);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/not found|does not exist/i.test(message)) {
+      return NextResponse.json(
+        { ok: false, runId, error: 'Workflow run not found' },
+        { status: 404 },
+      );
+    }
+    console.error('[api/workflows/studio-deploy/:runId]', err);
+    return NextResponse.json(
+      {
+        ok: false,
+        runId,
+        error: message,
+        hint: 'Ensure the workflow package is installed and withWorkflow wraps next.config.',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/workflows/studio-deploy/__tests__/route.test.ts
+++ b/apps/web/src/app/api/workflows/studio-deploy/__tests__/route.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const start = vi.fn();
+const DEMO_URL = 'https://www.youtube.com/watch?v=auJzb1D-fag';
+
+vi.mock('server-only', () => ({}));
 
 vi.mock('workflow/api', () => ({
   start: (...args: unknown[]) => start(...args),
@@ -41,6 +44,32 @@ describe('POST /api/workflows/studio-deploy', () => {
     expect(start).not.toHaveBeenCalled();
   });
 
+  it('rejects IPv6 loopback spelled with brackets', async () => {
+    const { POST } = await import('../route');
+    const res = await POST(
+      new Request('https://uvai.io/api/workflows/studio-deploy', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: 'http://[::1]:8000/x' }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it('rejects link-local metadata addresses', async () => {
+    const { POST } = await import('../route');
+    const res = await POST(
+      new Request('https://uvai.io/api/workflows/studio-deploy', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: 'http://169.254.169.254/latest/meta-data/' }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(start).not.toHaveBeenCalled();
+  });
+
   it('returns runId when start() succeeds', async () => {
     start.mockResolvedValue({ runId: 'wrun_c1' });
     const { POST } = await import('../route');
@@ -48,7 +77,7 @@ describe('POST /api/workflows/studio-deploy', () => {
       new Request('https://uvai.io/api/workflows/studio-deploy', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' }),
+        body: JSON.stringify({ url: DEMO_URL }),
       }),
     );
     const json = (await res.json()) as Record<string, unknown>;

--- a/apps/web/src/app/api/workflows/studio-deploy/__tests__/route.test.ts
+++ b/apps/web/src/app/api/workflows/studio-deploy/__tests__/route.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const start = vi.fn();
+
+vi.mock('workflow/api', () => ({
+  start: (...args: unknown[]) => start(...args),
+}));
+
+vi.mock('@/workflows/studio-deploy', () => ({
+  studioDeployWorkflow: async () => ({}),
+}));
+
+describe('POST /api/workflows/studio-deploy', () => {
+  beforeEach(() => {
+    start.mockReset();
+  });
+
+  it('rejects a missing url', async () => {
+    const { POST } = await import('../route');
+    const res = await POST(
+      new Request('https://uvai.io/api/workflows/studio-deploy', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it('rejects a localhost url', async () => {
+    const { POST } = await import('../route');
+    const res = await POST(
+      new Request('https://uvai.io/api/workflows/studio-deploy', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: 'http://127.0.0.1:3000/steal' }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it('returns runId when start() succeeds', async () => {
+    start.mockResolvedValue({ runId: 'wrun_c1' });
+    const { POST } = await import('../route');
+    const res = await POST(
+      new Request('https://uvai.io/api/workflows/studio-deploy', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' }),
+      }),
+    );
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.runId).toBe('wrun_c1');
+    expect(String(json.statusUrl)).toContain('wrun_c1');
+  });
+});

--- a/apps/web/src/app/api/workflows/studio-deploy/route.ts
+++ b/apps/web/src/app/api/workflows/studio-deploy/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { start } from 'workflow/api';
 import { workflowStartErrorBody } from '@/lib/sentry-server-integrations';
+import { assertPublicHttpUrl } from '@/lib/ssrf-guard';
 import { withWorldVercelFetch } from '@/lib/world-vercel-fetch';
 import { studioDeployWorkflow } from '@/workflows/studio-deploy';
 
@@ -30,19 +31,9 @@ export async function POST(request: Request): Promise<NextResponse> {
   }
 
   try {
-    const host = new URL(url).hostname.toLowerCase();
-    if (
-      host === 'localhost' ||
-      host === '127.0.0.1' ||
-      host === '0.0.0.0' ||
-      host === '::1' ||
-      host.endsWith('.local') ||
-      host.endsWith('.internal')
-    ) {
-      return NextResponse.json({ error: 'url host is not allowed' }, { status: 400 });
-    }
+    await assertPublicHttpUrl(url);
   } catch {
-    return NextResponse.json({ error: 'url is not a valid URL' }, { status: 400 });
+    return NextResponse.json({ error: 'url host is not allowed' }, { status: 400 });
   }
 
   const projectType =

--- a/apps/web/src/app/api/workflows/studio-deploy/route.ts
+++ b/apps/web/src/app/api/workflows/studio-deploy/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { start } from 'workflow/api';
+import { workflowStartErrorBody } from '@/lib/sentry-server-integrations';
+import { withWorldVercelFetch } from '@/lib/world-vercel-fetch';
+import { studioDeployWorkflow } from '@/workflows/studio-deploy';
+
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+/**
+ * POST /api/workflows/studio-deploy
+ *
+ * Durable Studio deploy (WDK C): kickoff FastAPI async job + poll.
+ * Returns immediately with { runId }.
+ */
+export async function POST(request: Request): Promise<NextResponse> {
+  let body: { url?: unknown; projectType?: unknown; outcome?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const url = typeof body.url === 'string' ? body.url.trim() : '';
+  if (!url || !/^https?:\/\//i.test(url)) {
+    return NextResponse.json(
+      { error: 'url (http/https string) is required' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    if (
+      host === 'localhost' ||
+      host === '127.0.0.1' ||
+      host === '0.0.0.0' ||
+      host === '::1' ||
+      host.endsWith('.local') ||
+      host.endsWith('.internal')
+    ) {
+      return NextResponse.json({ error: 'url host is not allowed' }, { status: 400 });
+    }
+  } catch {
+    return NextResponse.json({ error: 'url is not a valid URL' }, { status: 400 });
+  }
+
+  const projectType =
+    typeof body.projectType === 'string' ? body.projectType.slice(0, 40) : undefined;
+  const outcome =
+    typeof body.outcome === 'string' ? body.outcome.slice(0, 80) : undefined;
+
+  try {
+    const run = await withWorldVercelFetch(() =>
+      start(studioDeployWorkflow, [{ url, projectType, outcome }]),
+    );
+    return NextResponse.json({
+      ok: true,
+      runId: run.runId,
+      statusUrl: `/api/workflows/studio-deploy/${encodeURIComponent(run.runId)}`,
+      message: 'Durable Studio deploy started. Poll statusUrl.',
+    });
+  } catch (err) {
+    console.error('[api/workflows/studio-deploy]', err);
+    return NextResponse.json({ ok: false, ...workflowStartErrorBody(err) }, { status: 500 });
+  }
+}

--- a/apps/web/src/components/VideoWorkflowStudio.tsx
+++ b/apps/web/src/components/VideoWorkflowStudio.tsx
@@ -31,6 +31,7 @@ import {
   type StudioRunQuality,
 } from '@/lib/studio-pipeline-status';
 import { kickoffStudioDeploy, pollStudioJob } from '@/lib/studio-deploy';
+import { pollStudioDeploy, startStudioDeploy } from '@/lib/studio-workflow';
 import {
   pollVideoToActions,
   startVideoToActions,
@@ -585,10 +586,51 @@ export default function VideoWorkflowStudio() {
     }
 
     setDeployBusy(true);
-    setActionMessage('Starting deploy handoff via /api/pipeline…');
+    setActionMessage('Starting durable Studio deploy…');
 
     try {
-      // Prefer reusing job from the last run when present.
+      const started = await startStudioDeploy({
+        url: currentVideoUrl,
+        projectType: selectedOutcome === 'app' ? 'web' : selectedOutcome,
+        outcome: selectedOutcome,
+      });
+      if (started.ok && started.runId) {
+        setWorkflowRunId(started.runId);
+        setActionMessage(`Deploy workflow ${started.runId} running — polling job…`);
+        const polled = await pollStudioDeploy(started.runId, {
+          attempts: 24,
+          delayMs: 2000,
+        });
+        const live = polled.result?.live_url;
+        if (live) setDeployLiveUrl(live);
+        if (polled.result?.github_repo) setDeployRepo(polled.result.github_repo);
+        if (polled.result?.jobId) setDeployJobId(polled.result.jobId);
+
+        if (live) {
+          setActionMessage(`Deploy ready: ${live} (run ${started.runId})`);
+          return;
+        }
+        if (polled.result?.kind === 'handoff') {
+          setActionMessage(
+            polled.result.message ||
+              'Backend returned a planning handoff. Export the package or set BACKEND_URL.',
+          );
+          return;
+        }
+        if (polled.runStatus === 'failed' || polled.runStatus === 'cancelled') {
+          setActionMessage(
+            `Deploy workflow ${started.runId} ${polled.runStatus}${polled.error ? `: ${polled.error}` : ''}. Export for manual Vercel handoff.`,
+          );
+          return;
+        }
+        setActionMessage(
+          `Deploy workflow ${started.runId} still ${polled.runStatus || 'running'}${polled.result?.jobId ? ` (job ${polled.result.jobId})` : ''}. Open Dashboard or Export.`,
+        );
+        return;
+      }
+
+      // Fall back to the F5 /api/pipeline kickoff when WDK start is unavailable.
+      setActionMessage('Durable deploy unavailable — falling back to /api/pipeline…');
       let jobId = lastPipelineCheck?.jobId || deployJobId || undefined;
 
       if (!jobId) {

--- a/apps/web/src/components/VideoWorkflowStudio.tsx
+++ b/apps/web/src/components/VideoWorkflowStudio.tsx
@@ -379,6 +379,7 @@ export default function VideoWorkflowStudio() {
   const [deployJobId, setDeployJobId] = useState<string | null>(null);
   const [deployLiveUrl, setDeployLiveUrl] = useState<string | null>(null);
   const [deployRepo, setDeployRepo] = useState<string | null>(null);
+  const [deployRunId, setDeployRunId] = useState<string | null>(null);
   /** Durable WDK video→actions (Product v1) — separate from FastAPI pipeline jobs. */
   const [actionsBusy, setActionsBusy] = useState(false);
   const [workflowRunId, setWorkflowRunId] = useState<string | null>(null);
@@ -388,7 +389,14 @@ export default function VideoWorkflowStudio() {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const videoUrlRef = useRef('');
   const promptRef = useRef(DEFAULT_PROMPT);
+  const deployAbortRef = useRef<AbortController | null>(null);
   const realtime = useRealtimeVoice(audioRef);
+
+  useEffect(() => {
+    return () => {
+      deployAbortRef.current?.abort();
+    };
+  }, []);
 
   const videoId = useMemo(() => getYouTubeId(videoUrl), [videoUrl]);
   const frameUrls = useMemo(() => makeFrameUrls(videoId), [videoId]);
@@ -585,6 +593,10 @@ export default function VideoWorkflowStudio() {
       return;
     }
 
+    deployAbortRef.current?.abort();
+    const deployAbort = new AbortController();
+    deployAbortRef.current = deployAbort;
+
     setDeployBusy(true);
     setActionMessage('Starting durable Studio deploy…');
 
@@ -593,13 +605,26 @@ export default function VideoWorkflowStudio() {
         url: currentVideoUrl,
         projectType: selectedOutcome === 'app' ? 'web' : selectedOutcome,
         outcome: selectedOutcome,
+        signal: deployAbort.signal,
       });
+      if (started.status === 401 || started.status === 403) {
+        setActionMessage('Sign in to deploy. Redirecting to Google sign-in…');
+        window.location.assign('/login?callbackUrl=/studio');
+        return;
+      }
+      if (started.status === 400) {
+        setActionMessage(
+          started.error || 'Deploy rejected that URL. Use a public YouTube link.',
+        );
+        return;
+      }
       if (started.ok && started.runId) {
-        setWorkflowRunId(started.runId);
+        setDeployRunId(started.runId);
         setActionMessage(`Deploy workflow ${started.runId} running — polling job…`);
         const polled = await pollStudioDeploy(started.runId, {
           attempts: 24,
           delayMs: 2000,
+          signal: deployAbort.signal,
         });
         const live = polled.result?.live_url;
         if (live) setDeployLiveUrl(live);
@@ -629,7 +654,7 @@ export default function VideoWorkflowStudio() {
         return;
       }
 
-      // Fall back to the F5 /api/pipeline kickoff when WDK start is unavailable.
+      // Only when start() is down (5xx / network). 401/400 already returned.
       setActionMessage('Durable deploy unavailable — falling back to /api/pipeline…');
       let jobId = lastPipelineCheck?.jobId || deployJobId || undefined;
 
@@ -761,6 +786,13 @@ export default function VideoWorkflowStudio() {
             </Link>
           </nav>
 
+          <div className="flex items-center gap-2">
+            <Link
+              href="/login?callbackUrl=/studio"
+              className="hidden rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 sm:inline-flex"
+            >
+              Sign in
+            </Link>
           <button
             type="button"
             onClick={() => runWorkflow()}
@@ -771,6 +803,7 @@ export default function VideoWorkflowStudio() {
             <Sparkles className="h-4 w-4" aria-hidden="true" />
             Run workflow
           </button>
+          </div>
         </div>
       </header>
 
@@ -1099,12 +1132,17 @@ export default function VideoWorkflowStudio() {
                   {activeAction === 'deploy' && (
                     <div className="space-y-3">
                       <p className="leading-6">
-                        Deploy calls <code className="text-xs">POST /api/pipeline</code> with{' '}
-                        <code className="text-xs">deployment_target=vercel</code>
-                        {deployBusy ? ' (in progress…)' : '.'} If the backend is down, use Export for an offline handoff.
+                        Deploy starts a signed-in durable workflow, then falls back to{' '}
+                        <code className="text-xs">POST /api/pipeline</code> only if start() is unavailable.
+                        {deployBusy ? ' (in progress…)' : ''} Sign in first. If the backend is down, use Export.
                       </p>
-                      {(deployJobId || deployLiveUrl || deployRepo) && (
+                      {(deployRunId || deployJobId || deployLiveUrl || deployRepo) && (
                         <div className="space-y-1 rounded-lg border border-blue-100 bg-blue-50/80 px-3 py-2 text-xs leading-5 text-slate-700">
+                          {deployRunId && (
+                            <div>
+                              Workflow: <span className="font-mono">{deployRunId}</span>
+                            </div>
+                          )}
                           {deployJobId && (
                             <div>
                               Job:{' '}

--- a/apps/web/src/lib/__tests__/pipeline-async-job.test.ts
+++ b/apps/web/src/lib/__tests__/pipeline-async-job.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/pipeline-backend-health', () => ({
+  checkBackendHealth: vi.fn(),
+  getBackendConfig: vi.fn(),
+}));
+
+import { checkBackendHealth, getBackendConfig } from '@/lib/pipeline-backend-health';
+import {
+  fetchAsyncVideoJob,
+  isTerminalJobStatus,
+  kickoffAsyncVideoJob,
+} from '@/lib/pipeline-async-job';
+
+describe('pipeline-async-job (WDK C)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns a handoff when the backend is unavailable', async () => {
+    vi.mocked(checkBackendHealth).mockResolvedValue({
+      configured: false,
+      available: false,
+      host: null,
+      reason: 'BACKEND_URL is not configured',
+    });
+    const kicked = await kickoffAsyncVideoJob('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+    expect(kicked.kind).toBe('handoff');
+    expect(kicked.message).toMatch(/BACKEND_URL/);
+  });
+
+  it('parses job_id from FastAPI videos/process', async () => {
+    vi.mocked(checkBackendHealth).mockResolvedValue({
+      configured: true,
+      available: true,
+      host: 'api.example',
+    });
+    vi.mocked(getBackendConfig).mockReturnValue({
+      configured: true,
+      url: 'https://api.example',
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 202,
+        json: async () => ({ data: { job_id: 'job_1' } }),
+      }),
+    );
+
+    const kicked = await kickoffAsyncVideoJob('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+    expect(kicked).toEqual({
+      kind: 'job',
+      jobId: 'job_1',
+      statusUrl: '/api/jobs/job_1',
+    });
+  });
+
+  it('reads live_url from job status', async () => {
+    vi.mocked(getBackendConfig).mockReturnValue({
+      configured: true,
+      url: 'https://api.example',
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: { status: 'completed', live_url: 'https://app.vercel.app' },
+        }),
+      }),
+    );
+    const status = await fetchAsyncVideoJob('job_1');
+    expect(status.jobStatus).toBe('completed');
+    expect(status.live_url).toBe('https://app.vercel.app');
+    expect(isTerminalJobStatus(status.jobStatus)).toBe(true);
+  });
+
+  it('does not treat pending as terminal', () => {
+    expect(isTerminalJobStatus('pending')).toBe(false);
+    expect(isTerminalJobStatus('running')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/__tests__/pipeline-async-job.test.ts
+++ b/apps/web/src/lib/__tests__/pipeline-async-job.test.ts
@@ -27,7 +27,7 @@ describe('pipeline-async-job (WDK C)', () => {
       host: null,
       reason: 'BACKEND_URL is not configured',
     });
-    const kicked = await kickoffAsyncVideoJob('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+    const kicked = await kickoffAsyncVideoJob('https://www.youtube.com/watch?v=auJzb1D-fag');
     expect(kicked.kind).toBe('handoff');
     expect(kicked.message).toMatch(/BACKEND_URL/);
   });
@@ -51,7 +51,7 @@ describe('pipeline-async-job (WDK C)', () => {
       }),
     );
 
-    const kicked = await kickoffAsyncVideoJob('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+    const kicked = await kickoffAsyncVideoJob('https://www.youtube.com/watch?v=auJzb1D-fag');
     expect(kicked).toEqual({
       kind: 'job',
       jobId: 'job_1',
@@ -83,5 +83,49 @@ describe('pipeline-async-job (WDK C)', () => {
   it('does not treat pending as terminal', () => {
     expect(isTerminalJobStatus('pending')).toBe(false);
     expect(isTerminalJobStatus('running')).toBe(false);
+  });
+
+  it('treats a backend HTTP error as failed, not a config handoff', async () => {
+    vi.mocked(checkBackendHealth).mockResolvedValue({
+      configured: true,
+      available: true,
+      host: 'api.example',
+    });
+    vi.mocked(getBackendConfig).mockReturnValue({
+      configured: true,
+      url: 'https://api.example',
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({ error: 'backend overloaded' }),
+      }),
+    );
+    const kicked = await kickoffAsyncVideoJob(
+      'https://www.youtube.com/watch?v=auJzb1D-fag',
+    );
+    expect(kicked.kind).toBe('failed');
+    expect(kicked.message).toMatch(/overloaded|503/);
+  });
+
+  it('marks a non-ok job status read as not ok', async () => {
+    vi.mocked(getBackendConfig).mockReturnValue({
+      configured: true,
+      url: 'https://api.example',
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'unknown job' }),
+      }),
+    );
+    const status = await fetchAsyncVideoJob('job_missing');
+    expect(status.ok).toBe(false);
+    expect(status.httpStatus).toBe(404);
+    expect(isTerminalJobStatus(status.jobStatus)).toBe(false);
   });
 });

--- a/apps/web/src/lib/__tests__/studio-deploy.test.ts
+++ b/apps/web/src/lib/__tests__/studio-deploy.test.ts
@@ -21,7 +21,7 @@ describe('studio-deploy (F5)', () => {
       }),
     );
 
-    const result = await kickoffStudioDeploy({ url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' });
+    const result = await kickoffStudioDeploy({ url: 'https://www.youtube.com/watch?v=auJzb1D-fag' });
     expect(result.ok).toBe(true);
     expect(result.jobId).toBe('job_abc');
     expect(result.statusUrl).toBe('/api/jobs/job_abc');
@@ -42,7 +42,7 @@ describe('studio-deploy (F5)', () => {
       }),
     );
 
-    const result = await kickoffStudioDeploy({ url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' });
+    const result = await kickoffStudioDeploy({ url: 'https://www.youtube.com/watch?v=auJzb1D-fag' });
     expect(result.ok).toBe(false);
     expect(result.handoff).toBe(true);
     expect(result.message).toContain('BACKEND_URL');

--- a/apps/web/src/lib/__tests__/studio-workflow.test.ts
+++ b/apps/web/src/lib/__tests__/studio-workflow.test.ts
@@ -28,7 +28,7 @@ describe('studio-workflow (WDK Product v1)', () => {
     );
 
     const result = await startVideoToActions({
-      url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      url: 'https://www.youtube.com/watch?v=auJzb1D-fag',
       videoTitle: 'Demo',
     });
     expect(result.ok).toBe(true);
@@ -112,7 +112,7 @@ describe('studio-workflow (WDK Product v1)', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('startStudioDeploy requires a runId', async () => {
+  it('startStudioDeploy succeeds when the route returns a runId', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -126,7 +126,7 @@ describe('studio-workflow (WDK Product v1)', () => {
       }),
     );
     const started = await startStudioDeploy({
-      url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      url: 'https://www.youtube.com/watch?v=auJzb1D-fag',
     });
     expect(started.ok).toBe(true);
     expect(started.runId).toBe('wrun_c');
@@ -152,5 +152,52 @@ describe('studio-workflow (WDK Product v1)', () => {
     expect(poll.runStatus).toBe('completed');
     expect(poll.result?.kind).toBe('handoff');
     expect(poll.result?.message).toMatch(/BACKEND_URL/);
+  });
+
+  it('startStudioDeploy is not ok when runId is missing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      }),
+    );
+    const started = await startStudioDeploy({
+      url: 'https://www.youtube.com/watch?v=auJzb1D-fag',
+    });
+    expect(started.ok).toBe(false);
+  });
+
+  it('pollStudioDeploy returns immediately on 404', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: 'Workflow run not found' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const poll = await pollStudioDeploy('wrun_missing', { attempts: 5, delayMs: 1 });
+    expect(poll.status).toBe(404);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('pollStudioDeploy stops when the abort signal fires', async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      controller.abort();
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, runId: 'wrun_c3', runStatus: 'running' }),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const poll = await pollStudioDeploy('wrun_c3', {
+      attempts: 8,
+      delayMs: 20,
+      signal: controller.signal,
+    });
+    expect(poll.message).toMatch(/abort/i);
+    expect(fetchMock.mock.calls.length).toBeLessThan(8);
   });
 });

--- a/apps/web/src/lib/__tests__/studio-workflow.test.ts
+++ b/apps/web/src/lib/__tests__/studio-workflow.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   getVideoToActionsStatus,
+  pollStudioDeploy,
   pollVideoToActions,
+  startStudioDeploy,
   startVideoToActions,
 } from '@/lib/studio-workflow';
 
@@ -108,5 +110,47 @@ describe('studio-workflow (WDK Product v1)', () => {
     const poll = await pollVideoToActions('wrun_2', { attempts: 5, delayMs: 1 });
     expect(poll.runStatus).toBe('completed');
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('startStudioDeploy requires a runId', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          runId: 'wrun_c',
+          message: 'started',
+        }),
+      }),
+    );
+    const started = await startStudioDeploy({
+      url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    });
+    expect(started.ok).toBe(true);
+    expect(started.runId).toBe('wrun_c');
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/workflows/studio-deploy',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('pollStudioDeploy returns on handoff result', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        runId: 'wrun_c2',
+        runStatus: 'completed',
+        result: { kind: 'handoff', message: 'BACKEND_URL is not configured' },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const poll = await pollStudioDeploy('wrun_c2', { attempts: 3, delayMs: 1 });
+    expect(poll.runStatus).toBe('completed');
+    expect(poll.result?.kind).toBe('handoff');
+    expect(poll.result?.message).toMatch(/BACKEND_URL/);
   });
 });

--- a/apps/web/src/lib/pipeline-async-job.ts
+++ b/apps/web/src/lib/pipeline-async-job.ts
@@ -4,7 +4,7 @@ import { backendHeaders } from '@/lib/pipeline-backend';
 import { checkBackendHealth, getBackendConfig } from '@/lib/pipeline-backend-health';
 
 export interface AsyncJobKickoff {
-  kind: 'job' | 'handoff';
+  kind: 'job' | 'handoff' | 'failed';
   jobId?: string;
   statusUrl?: string;
   message?: string;
@@ -12,6 +12,7 @@ export interface AsyncJobKickoff {
 
 export interface AsyncJobStatus {
   ok: boolean;
+  httpStatus?: number;
   jobStatus?: string;
   live_url?: string | null;
   github_repo?: string | null;
@@ -19,7 +20,9 @@ export interface AsyncJobStatus {
 }
 
 function str(v: unknown): string | undefined {
-  return typeof v === 'string' && v.trim() ? v : undefined;
+  if (typeof v !== 'string') return undefined;
+  const trimmed = v.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 /**
@@ -59,11 +62,13 @@ export async function kickoffAsyncVideoJob(url: string): Promise<AsyncJobKickoff
   }
 
   return {
-    kind: 'handoff',
+    kind: 'failed',
     message:
       str(payload.error) ||
       str(payload.detail) ||
-      `Backend kickoff returned HTTP ${response.status}`,
+      (response.ok
+        ? 'Backend kickoff returned no job id'
+        : `Backend kickoff returned HTTP ${response.status}`),
   };
 }
 
@@ -90,6 +95,7 @@ export async function fetchAsyncVideoJob(jobId: string): Promise<AsyncJobStatus>
 
   return {
     ok: response.ok,
+    httpStatus: response.status,
     jobStatus: str(data.status) || str(payload.status),
     live_url: str(data.live_url) ?? str(payload.live_url) ?? null,
     github_repo: str(data.github_repo) ?? str(payload.github_repo) ?? null,

--- a/apps/web/src/lib/pipeline-async-job.ts
+++ b/apps/web/src/lib/pipeline-async-job.ts
@@ -1,0 +1,108 @@
+import 'server-only';
+
+import { backendHeaders } from '@/lib/pipeline-backend';
+import { checkBackendHealth, getBackendConfig } from '@/lib/pipeline-backend-health';
+
+export interface AsyncJobKickoff {
+  kind: 'job' | 'handoff';
+  jobId?: string;
+  statusUrl?: string;
+  message?: string;
+}
+
+export interface AsyncJobStatus {
+  ok: boolean;
+  jobStatus?: string;
+  live_url?: string | null;
+  github_repo?: string | null;
+  message?: string;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim() ? v : undefined;
+}
+
+/**
+ * Kick off FastAPI async video processing (same contract as POST /api/pipeline async).
+ * Used from WDK steps — no self-HTTP to /api/pipeline.
+ */
+export async function kickoffAsyncVideoJob(url: string): Promise<AsyncJobKickoff> {
+  const health = await checkBackendHealth();
+  if (!health.available) {
+    return {
+      kind: 'handoff',
+      message: health.reason || 'BACKEND_URL is not configured or backend is unreachable',
+    };
+  }
+
+  const { url: backendUrl } = getBackendConfig();
+  const response = await fetch(`${backendUrl}/api/v1/videos/process`, {
+    method: 'POST',
+    headers: backendHeaders(),
+    body: JSON.stringify({ video_url: url, language: 'en' }),
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  const data =
+    payload.data && typeof payload.data === 'object'
+      ? (payload.data as Record<string, unknown>)
+      : {};
+  const jobId = str(data.job_id) || str(payload.job_id);
+
+  if (response.ok && jobId) {
+    return {
+      kind: 'job',
+      jobId,
+      statusUrl: `/api/jobs/${jobId}`,
+    };
+  }
+
+  return {
+    kind: 'handoff',
+    message:
+      str(payload.error) ||
+      str(payload.detail) ||
+      `Backend kickoff returned HTTP ${response.status}`,
+  };
+}
+
+/** One status read of a backend async job. WDK poll step retries when still pending. */
+export async function fetchAsyncVideoJob(jobId: string): Promise<AsyncJobStatus> {
+  const { configured, url: backendUrl } = getBackendConfig();
+  if (!configured) {
+    return { ok: false, message: 'BACKEND_URL is not configured' };
+  }
+
+  const response = await fetch(
+    `${backendUrl}/api/v1/jobs/${encodeURIComponent(jobId)}`,
+    {
+      cache: 'no-store',
+      headers: backendHeaders(),
+      signal: AbortSignal.timeout(15_000),
+    },
+  );
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  const data =
+    payload.data && typeof payload.data === 'object'
+      ? (payload.data as Record<string, unknown>)
+      : payload;
+
+  return {
+    ok: response.ok,
+    jobStatus: str(data.status) || str(payload.status),
+    live_url: str(data.live_url) ?? str(payload.live_url) ?? null,
+    github_repo: str(data.github_repo) ?? str(payload.github_repo) ?? null,
+    message: str(payload.error) || str(payload.detail) || str(data.message),
+  };
+}
+
+export function isTerminalJobStatus(status: string | undefined): boolean {
+  return (
+    status === 'completed' ||
+    status === 'succeeded' ||
+    status === 'failed' ||
+    status === 'error' ||
+    status === 'cancelled'
+  );
+}

--- a/apps/web/src/lib/studio-workflow.ts
+++ b/apps/web/src/lib/studio-workflow.ts
@@ -86,6 +86,7 @@ export async function startStudioDeploy(input: {
 }): Promise<StudioDeployStart> {
   const response = await fetch('/api/workflows/studio-deploy', {
     method: 'POST',
+    credentials: 'same-origin',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       url: input.url,
@@ -110,7 +111,11 @@ export async function getStudioDeployStatus(
 ): Promise<StudioDeployPoll> {
   const response = await fetch(
     `/api/workflows/studio-deploy/${encodeURIComponent(runId)}`,
-    { method: 'GET', signal: opts?.signal ?? AbortSignal.timeout(15_000) },
+    {
+      method: 'GET',
+      credentials: 'same-origin',
+      signal: opts?.signal ?? AbortSignal.timeout(15_000),
+    },
   );
   const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
   const resultRaw =
@@ -151,7 +156,19 @@ export async function pollStudioDeploy(
     last = await getStudioDeployStatus(runId, { signal: opts?.signal });
     if (last.runStatus && TERMINAL.has(last.runStatus)) return last;
     if (last.status === 404) return last;
-    await new Promise((r) => setTimeout(r, delayMs));
+    if (i < attempts - 1) {
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, delayMs);
+        opts?.signal?.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timer);
+            resolve();
+          },
+          { once: true },
+        );
+      });
+    }
   }
   return {
     ...last,

--- a/apps/web/src/lib/studio-workflow.ts
+++ b/apps/web/src/lib/studio-workflow.ts
@@ -49,6 +49,118 @@ function str(v: unknown): string | undefined {
   return typeof v === 'string' && v.trim() ? v : undefined;
 }
 
+const TERMINAL = new Set(['completed', 'failed', 'cancelled']);
+
+/** Start durable Studio deploy (WDK C). Returns immediately with runId. */
+export interface StudioDeployStart {
+  ok: boolean;
+  status: number;
+  runId?: string;
+  message?: string;
+  error?: string;
+}
+
+export interface StudioDeployPoll {
+  ok: boolean;
+  status: number;
+  runId: string;
+  runStatus?: WorkflowRunStatus;
+  result?: {
+    kind?: string;
+    jobId?: string;
+    jobStatus?: string;
+    live_url?: string | null;
+    github_repo?: string | null;
+    message?: string;
+  };
+  error?: string;
+  message?: string;
+}
+
+/** Start durable Studio deploy (WDK C). */
+export async function startStudioDeploy(input: {
+  url: string;
+  projectType?: string;
+  outcome?: string;
+  signal?: AbortSignal;
+}): Promise<StudioDeployStart> {
+  const response = await fetch('/api/workflows/studio-deploy', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      url: input.url,
+      projectType: input.projectType,
+      outcome: input.outcome,
+    }),
+    signal: input.signal ?? AbortSignal.timeout(30_000),
+  });
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  return {
+    ok: Boolean(payload.ok) && response.ok && Boolean(str(payload.runId)),
+    status: response.status,
+    runId: str(payload.runId),
+    message: str(payload.message),
+    error: str(payload.error),
+  };
+}
+
+export async function getStudioDeployStatus(
+  runId: string,
+  opts?: { signal?: AbortSignal },
+): Promise<StudioDeployPoll> {
+  const response = await fetch(
+    `/api/workflows/studio-deploy/${encodeURIComponent(runId)}`,
+    { method: 'GET', signal: opts?.signal ?? AbortSignal.timeout(15_000) },
+  );
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  const resultRaw =
+    payload.result && typeof payload.result === 'object'
+      ? (payload.result as Record<string, unknown>)
+      : undefined;
+  return {
+    ok: response.ok && !str(payload.error),
+    status: response.status,
+    runId: str(payload.runId) || runId,
+    runStatus: str(payload.runStatus) as WorkflowRunStatus | undefined,
+    result: resultRaw
+      ? {
+          kind: str(resultRaw.kind),
+          jobId: str(resultRaw.jobId),
+          jobStatus: str(resultRaw.jobStatus),
+          live_url: str(resultRaw.live_url) ?? null,
+          github_repo: str(resultRaw.github_repo) ?? null,
+          message: str(resultRaw.message),
+        }
+      : undefined,
+    error: str(payload.error),
+    message: str(payload.message),
+  };
+}
+
+export async function pollStudioDeploy(
+  runId: string,
+  opts?: { attempts?: number; delayMs?: number; signal?: AbortSignal },
+): Promise<StudioDeployPoll> {
+  const attempts = opts?.attempts ?? 24;
+  const delayMs = opts?.delayMs ?? 2000;
+  let last: StudioDeployPoll = { ok: false, status: 0, runId, message: 'No poll yet' };
+  for (let i = 0; i < attempts; i++) {
+    if (opts?.signal?.aborted) {
+      return { ...last, error: last.error || 'aborted', message: 'Polling aborted' };
+    }
+    last = await getStudioDeployStatus(runId, { signal: opts?.signal });
+    if (last.runStatus && TERMINAL.has(last.runStatus)) return last;
+    if (last.status === 404) return last;
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  return {
+    ...last,
+    message:
+      last.message ||
+      `Still ${last.runStatus || 'running'} after ${attempts} polls — re-check runId ${runId}`,
+  };
+}
+
 /** Start durable video → actions. Returns immediately with runId. */
 export async function startVideoToActions(input: {
   url: string;
@@ -126,8 +238,6 @@ export async function getVideoToActionsStatus(
     message,
   };
 }
-
-const TERMINAL = new Set(['completed', 'failed', 'cancelled']);
 
 /**
  * Poll until the run is terminal or attempts are exhausted.

--- a/apps/web/src/workflows/studio-deploy.ts
+++ b/apps/web/src/workflows/studio-deploy.ts
@@ -18,7 +18,7 @@ export interface StudioDeployInput {
 
 export interface StudioDeployResult {
   url: string;
-  kind: 'live' | 'job' | 'handoff' | 'failed';
+  kind: 'live' | 'job' | 'handoff';
   jobId?: string;
   jobStatus?: string;
   live_url?: string | null;
@@ -37,6 +37,9 @@ export async function studioDeployWorkflow(
   }
 
   const kicked = await kickoffStep(url);
+  if (kicked.kind === 'failed') {
+    throw new FatalError(kicked.message || 'Backend refused the deploy kickoff');
+  }
   if (kicked.kind !== 'job' || !kicked.jobId) {
     return {
       url,
@@ -50,7 +53,7 @@ export async function studioDeployWorkflow(
 }
 
 async function kickoffStep(url: string): Promise<{
-  kind: 'job' | 'handoff';
+  kind: 'job' | 'handoff' | 'failed';
   jobId?: string;
   message?: string;
 }> {
@@ -61,7 +64,7 @@ async function kickoffStep(url: string): Promise<{
 }
 
 async function pollJobStep(jobId: string): Promise<{
-  kind: 'live' | 'job' | 'failed';
+  kind: 'live' | 'job';
   jobStatus?: string;
   live_url?: string | null;
   github_repo?: string | null;
@@ -81,6 +84,14 @@ async function pollJobStep(jobId: string): Promise<{
       live_url: status.live_url,
       github_repo: status.github_repo,
     };
+  }
+
+  if (!status.ok) {
+    const msg = status.message || `Deploy job ${jobId} status HTTP ${status.httpStatus ?? 'error'}`;
+    if (status.httpStatus && status.httpStatus >= 500) {
+      throw new Error(msg);
+    }
+    throw new FatalError(msg);
   }
 
   if (status.jobStatus === 'failed' || status.jobStatus === 'error') {

--- a/apps/web/src/workflows/studio-deploy.ts
+++ b/apps/web/src/workflows/studio-deploy.ts
@@ -1,0 +1,106 @@
+/**
+ * Durable Studio deploy (Workflow DevKit) — Product C.
+ *
+ * Kick off FastAPI async video→software and poll the job until a live URL,
+ * terminal failure, or an honest handoff (no backend).
+ *
+ * Trigger: POST /api/workflows/studio-deploy  { url, projectType?, outcome? }
+ * Status:  GET  /api/workflows/studio-deploy/:runId
+ */
+
+import { FatalError } from 'workflow';
+
+export interface StudioDeployInput {
+  url: string;
+  projectType?: string;
+  outcome?: string;
+}
+
+export interface StudioDeployResult {
+  url: string;
+  kind: 'live' | 'job' | 'handoff' | 'failed';
+  jobId?: string;
+  jobStatus?: string;
+  live_url?: string | null;
+  github_repo?: string | null;
+  message?: string;
+}
+
+export async function studioDeployWorkflow(
+  input: StudioDeployInput,
+): Promise<StudioDeployResult> {
+  'use workflow';
+
+  const url = (input.url || '').trim();
+  if (!url || !/^https?:\/\//i.test(url)) {
+    throw new FatalError('url must be an http(s) URL');
+  }
+
+  const kicked = await kickoffStep(url);
+  if (kicked.kind !== 'job' || !kicked.jobId) {
+    return {
+      url,
+      kind: 'handoff',
+      message: kicked.message || 'No backend job id — export package for manual Vercel deploy',
+    };
+  }
+
+  const polled = await pollJobStep(kicked.jobId);
+  return { url, ...polled, jobId: kicked.jobId };
+}
+
+async function kickoffStep(url: string): Promise<{
+  kind: 'job' | 'handoff';
+  jobId?: string;
+  message?: string;
+}> {
+  'use step';
+
+  const { kickoffAsyncVideoJob } = await import('@/lib/pipeline-async-job');
+  return kickoffAsyncVideoJob(url);
+}
+
+async function pollJobStep(jobId: string): Promise<{
+  kind: 'live' | 'job' | 'failed';
+  jobStatus?: string;
+  live_url?: string | null;
+  github_repo?: string | null;
+  message?: string;
+}> {
+  'use step';
+
+  const { fetchAsyncVideoJob, isTerminalJobStatus } = await import(
+    '@/lib/pipeline-async-job'
+  );
+  const status = await fetchAsyncVideoJob(jobId);
+
+  if (status.live_url) {
+    return {
+      kind: 'live',
+      jobStatus: status.jobStatus || 'completed',
+      live_url: status.live_url,
+      github_repo: status.github_repo,
+    };
+  }
+
+  if (status.jobStatus === 'failed' || status.jobStatus === 'error') {
+    throw new FatalError(
+      status.message || `Deploy job ${jobId} ${status.jobStatus}`,
+    );
+  }
+
+  if (!isTerminalJobStatus(status.jobStatus)) {
+    // Retryable: WDK re-runs this step until the job finishes or retries exhaust.
+    throw new Error(
+      status.message || `Deploy job ${jobId} still ${status.jobStatus || 'pending'}`,
+    );
+  }
+
+  return {
+    kind: 'job',
+    jobStatus: status.jobStatus,
+    live_url: status.live_url,
+    github_repo: status.github_repo,
+    message: status.message,
+  };
+}

--- a/docs/WORKFLOW_DEVKIT.md
+++ b/docs/WORKFLOW_DEVKIT.md
@@ -50,12 +50,23 @@ npx workflow inspect runs
 
 `turbo.json` build outputs include `apps/web/src/app/.well-known/workflow/**` so cache hits keep workflow registration.
 
+## Product C — Studio deploy durable
+
+| Piece | Path |
+|-------|------|
+| Workflow | `apps/web/src/workflows/studio-deploy.ts` |
+| Kickoff / poll lib | `apps/web/src/lib/pipeline-async-job.ts` (FastAPI `/api/v1/videos/process` + `/api/v1/jobs/:id`, no self-HTTP) |
+| Start | `POST /api/workflows/studio-deploy` `{ "url" }` → `{ runId, statusUrl }` |
+| Status | `GET /api/workflows/studio-deploy/:runId` |
+| Studio UI | Deploy action in `VideoWorkflowStudio` (falls back to F5 `/api/pipeline` if start() fails) |
+
+Auth: this route stays **session-gated** (unlike public Act on findings).
+
 ## Next product steps
 
-1. **C — Studio deploy durable:** kickoff + poll `/api/pipeline` jobs as WDK steps with automatic retry.  
-2. Stream step progress via `getWritable()` into Studio.  
-3. Human approval hooks (`createHook` / `resumeHook`) before deploy.  
-4. Optionally route Dashboard “act” through the same durable path.
+1. Stream step progress via `getWritable()` into Studio.  
+2. Human approval hooks (`createHook` / `resumeHook`) before deploy.  
+3. Optionally route Dashboard “act” through the same durable path.
 
 ## Relation to F-series
 

--- a/docs/WORKFLOW_DEVKIT.md
+++ b/docs/WORKFLOW_DEVKIT.md
@@ -34,7 +34,7 @@ npm run dev
 # start
 curl -X POST http://localhost:3000/api/workflows/video-to-actions \
   -H 'Content-Type: application/json' \
-  --json '{"url":"https://www.youtube.com/watch?v=dQw4w9WgXcQ"}'
+  --json '{"url":"https://www.youtube.com/watch?v=auJzb1D-fag"}'
 # poll (use runId from response)
 curl http://localhost:3000/api/workflows/video-to-actions/<runId>
 npx workflow web
@@ -56,11 +56,11 @@ npx workflow inspect runs
 |-------|------|
 | Workflow | `apps/web/src/workflows/studio-deploy.ts` |
 | Kickoff / poll lib | `apps/web/src/lib/pipeline-async-job.ts` (FastAPI `/api/v1/videos/process` + `/api/v1/jobs/:id`, no self-HTTP) |
-| Start | `POST /api/workflows/studio-deploy` `{ "url" }` → `{ runId, statusUrl }` |
-| Status | `GET /api/workflows/studio-deploy/:runId` |
-| Studio UI | Deploy action in `VideoWorkflowStudio` (falls back to F5 `/api/pipeline` if start() fails) |
+| Start | `POST /api/workflows/studio-deploy` `{ "url", projectType?, outcome? }` → `{ runId, statusUrl }` |
+| Status | `GET /api/workflows/studio-deploy/:runId` → `{ runStatus, result? }` |
+| Studio UI | Deploy in `VideoWorkflowStudio`. **401 → /login**. Fallback to F5 `/api/pipeline` only when start() is 5xx/unavailable. |
 
-Auth: this route stays **session-gated** (unlike public Act on findings).
+Auth: this route stays **session-gated**. Studio now has a Sign in link. Never use `dQw4w9WgXcQ` as a fixture — use `auJzb1D-fag`.
 
 ## Next product steps
 


### PR DESCRIPTION
## Canonical issue

Closes #1547

## Outcome

Studio Deploy is durable and session-gated. Unauthenticated Deploy sends the user to Google sign-in instead of pretending WDK is down.

## Scope

- Included: Sign in on Studio, 401/403 → /login?callbackUrl=/studio, assertPublicHttpUrl, kickoff HTTP errors as failed, poll !ok handling, no Rickroll fixtures.
- Explicitly excluded: making studio-deploy public, landscape merge, getWritable.

## Risk

- Risk level: medium
- Failure mode: preview NEXTAUTH_URL may still land OAuth on uvai.io; production sign-in is unchanged.
- Rollback: revert the commit.

## Verification

- [x] Focused tests 43+12 on auJzb1D-fag
- [ ] Preview of dcefc8da3 after deploy
- [ ] Signed-in C runId on production/preview after Google login

## Production evidence

gcloud ADC already valid (garveyht@gmail.com). The 401 was NextAuth on a public Studio page with no Sign in. That is what this commit fixes.

## Agent handoff

- [x] One canonical issue is linked
- [ ] Signed-in Deploy not yet proven on the new preview