### PR TITLE
docs: correct stale issue #802 entry in SYSTEM_STATUS

### DIFF
--- a/shared/_core/SYSTEM_STATUS.md
+++ b/shared/_core/SYSTEM_STATUS.md
@@ -15,7 +15,7 @@
 | ----- | ------ |
 | Git status | ✅ Clean |
 | Open PRs | 33 |
-| Open issues | 3 (#808, #802, #153) |
+| Open issues | 3 (#808, #802, #153) — correction 2026-08-25: #802 was closed as a duplicate on 2026-07-17 (via PR #813), shortly after this snapshot; #808 and #153 have also since been closed |
 | Latest PR Checks run | ✅ Success |
 | Latest Security Scan run | ❌ Failure on `claude/determined-maxwell-ostftd` (run `29549151403`) |
 | Code/secret scanning alert API | ⚠️ Not accessible to integration (403) |


### PR DESCRIPTION
## Canonical issue

Closes #1560

## Outcome

The SYSTEM_STATUS snapshot no longer misleadingly lists issue #802 as open. A dated correction note on the "Open issues" row records that #802 was closed as a duplicate on 2026-07-17 (via PR #813), minutes after the snapshot was taken, and that #808 and #153 have also since been closed.

## Scope

- Included: one-line correction to `shared/_core/SYSTEM_STATUS.md`
- Explicitly excluded: rewriting the rest of the historical snapshot (kept as a dated record)

## Risk

- Risk level: low
- Failure mode: none (documentation only)
- Rollback: revert the commit

## Verification

- [x] Verified via the GitHub API that #802 is closed (duplicate, closed 2026-07-17T02:46Z), and that #808 and #153 are also closed
- [ ] Focused tests — n/a (docs only)
- [ ] Required CI

## Production evidence

Not applicable — documentation-only change.

## Agent handoff

- [x] One canonical issue is linked
- [x] No competing PR implements the same issue
- [x] Acceptance criteria are satisfied
- [ ] Required checks pass on the current head
- [x] Human decision is requested only for product, security, irreversible infrastructure, or production approval